### PR TITLE
Added ZThread class from czmq

### DIFF
--- a/src/main/java/org/jeromq/ZContext.java
+++ b/src/main/java/org/jeromq/ZContext.java
@@ -59,6 +59,11 @@ public class ZContext {
     private int linger;
     
     /**
+     * HWM timeout, default 1
+     */
+    private int hwm;
+    
+    /**
      * Indicates if context object is owned by main thread
      * (useful for multi-threaded applications)
      */
@@ -172,6 +177,22 @@ public class ZContext {
     }
 
     /**
+     * @return the HWM
+     */
+    public int getHWM ()
+    {
+        return hwm;
+    }
+
+    /**
+     * @param hwm the HWM to set
+     */
+    public void setHWM (int hwm) {
+        this.hwm = hwm;
+    }
+
+
+    /**
      * @return the main
      */
     public boolean isMain() {
@@ -195,8 +216,9 @@ public class ZContext {
     /**
      * @param ctx   sets the underlying org.zeromq.Context associated with this ZContext wrapper object
      */
-    public void setContext(Context ctx) {
+    public void setContext (Context ctx) {
         this.context = ctx;
+        setMain (false);
     }
     
     /**
@@ -205,5 +227,6 @@ public class ZContext {
     public List<Socket> getSockets() {
         return sockets;
     }
+
     
 }

--- a/src/main/java/org/jeromq/ZMQ.java
+++ b/src/main/java/org/jeromq/ZMQ.java
@@ -439,9 +439,9 @@ public class ZMQ {
          * @param hwm
          *            the number of messages to queue.
          */
-        @Deprecated
         public final void setHWM(long hwm) {
-            // not support at zeromq 3
+            setSndHWM (hwm);
+            setRcvHWM (hwm);
         }
         
         /**

--- a/src/main/java/org/jeromq/ZThread.java
+++ b/src/main/java/org/jeromq/ZThread.java
@@ -1,0 +1,97 @@
+package org.jeromq;
+
+import org.jeromq.ZMQ.Socket;
+
+public class ZThread
+{
+    public static interface IAttachedRunnable
+    {
+        public void run (Object [] args, ZContext ctx, Socket pipe);
+    }
+
+    public static interface IDetachedRunnable
+    {
+        public void run (Object [] args);
+    }
+
+    private static class ShimThread extends Thread 
+    {
+        private ZContext ctx;
+        private IAttachedRunnable attachedRunnable;
+        private IDetachedRunnable detachedRunnable;
+        private Object[] args;
+        private Socket pipe;
+
+        protected ShimThread (ZContext ctx, IAttachedRunnable runnable, Object [] args, Socket pipe) 
+        {
+            assert (ctx != null);
+            assert (pipe != null);
+            assert (runnable != null);
+            
+            this.ctx = ctx;
+            this.attachedRunnable = runnable;
+            this.args = args;
+            this.pipe = pipe;
+        }
+        
+        public ShimThread (IDetachedRunnable runnable, Object[] args)
+        {
+            assert (runnable != null);
+            this.detachedRunnable = runnable;
+            this.args = args;
+        }
+
+        @Override
+        public void run () 
+        {
+            if (attachedRunnable != null) {
+                attachedRunnable.run (args, ctx, pipe);
+                ctx.destroy ();
+            } else
+                detachedRunnable.run (args);
+        }
+    }
+    
+    //  --------------------------------------------------------------------------
+    //  Create a detached thread. A detached thread operates autonomously
+    //  and is used to simulate a separate process. It gets no ctx, and no
+    //  pipe.
+    
+    public static void start (IDetachedRunnable runnable, Object ... args)
+    {
+        //  Prepare child thread
+        Thread shim = new ShimThread (runnable, args);
+        shim.start ();
+    }
+    
+    //  --------------------------------------------------------------------------
+    //  Create an attached thread. An attached thread gets a ctx and a PAIR
+    //  pipe back to its parent. It must monitor its pipe, and exit if the
+    //  pipe becomes unreadable. Returns pipe, or null if there was an error.
+    
+    public static Socket fork (ZContext ctx, IAttachedRunnable runnable, Object ... args) 
+    {
+        Socket pipe = ctx.createSocket (ZMQ.PAIR);
+        
+        if (pipe != null) {
+            pipe.setHWM (ctx.getHWM ());
+            pipe.bind (String.format ("inproc://zctx-pipe-%d", pipe.hashCode ()));
+        } else {
+            return null;
+        }
+        
+        //  Connect child pipe to our pipe
+        ZContext ccontext = ZContext.shadow (ctx);
+        Socket cpipe = ccontext.createSocket (ZMQ.PAIR);
+        if (cpipe == null)
+            return null;
+        cpipe.setHWM (1);
+        cpipe.connect (String.format ("inproc://zctx-pipe-%d", pipe.hashCode ()));
+
+        //  Prepare child thread
+        Thread shim = new ShimThread (ccontext, runnable, args, cpipe);
+        shim.start ();
+        
+        return pipe;
+    }
+}

--- a/src/test/java/org/jeromq/TestZThread.java
+++ b/src/test/java/org/jeromq/TestZThread.java
@@ -1,0 +1,58 @@
+package org.jeromq;
+
+import org.jeromq.ZMQ.Socket;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestZThread
+{
+
+    @Test
+    public void testDetached () 
+    {
+        ZThread.IDetachedRunnable detached = new ZThread.IDetachedRunnable() {
+            
+            @Override
+            public void run (Object[] args)
+            {
+                ZContext ctx = new ZContext ();
+                assert (ctx != null);
+
+                Socket push = ctx.createSocket (ZMQ.PUSH);
+                assert (push != null);
+                ctx.destroy ();
+            }
+        };
+        
+        ZThread.start (detached);
+    }
+    
+    @Test
+    public void testFork ()
+    {
+        ZContext ctx = new ZContext ();
+        
+        ZThread.IAttachedRunnable attached = new ZThread.IAttachedRunnable() {
+            
+            @Override
+            public void run (Object[] args, ZContext ctx, Socket pipe)
+            {
+                //  Create a socket to check it'll be automatically deleted
+                ctx.createSocket (ZMQ.PUSH);
+                pipe.recvStr ();
+                pipe.send ("pong");
+            }
+        };
+        
+        Socket pipe = ZThread.fork (ctx, attached);
+        assert (pipe != null);
+        
+        pipe.send ("ping");
+        String pong = pipe.recvStr ();
+        
+        Assert.assertEquals (pong, "pong");
+        
+        //  Everything should be cleanly closed now
+        ctx.destroy ();
+    }
+}


### PR DESCRIPTION
Now we support
- ZThread.fork
- ZThread.start (cannot use ZThread.new as the 'new' is keyword)
