### PR TITLE
ZContext.close doesn't have to throw an exception

### DIFF
--- a/src/main/java/org/zeromq/ZContext.java
+++ b/src/main/java/org/zeromq/ZContext.java
@@ -232,7 +232,7 @@ public class ZContext implements Closeable
 
 
     @Override
-    public void close() throws IOException
+    public void close()
     {
         destroy();
     }


### PR DESCRIPTION
According to java specification, an overriding instance method doesn't have to throw exceptions specified by its superclass.

With this pull request, there is one less exception to worry about.
