### PR TITLE
Set the compiler version to 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,15 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.0</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <profiles>


### PR DESCRIPTION
Without this, I encounter an error that annotations are not supported in 1.5 when I run "mvn test" or "mvn compile"
