### PR TITLE
Suppress platform dependent encoding warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,9 @@
   <developers>
     <developer />
   </developers>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>log4j</groupId>


### PR DESCRIPTION
e.g.) [WARNING] Using platform encoding (Cp1252 actually) to copy filtered resources, i.e. build is platform dependent!

http://maven.apache.org/general.html#encoding-warning
