### PR TITLE
Adding Osgi-manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,17 +86,33 @@
           <target>1.6</target>
         </configuration>
       </plugin>
-
-            <plugin>
+        <plugin>
+            <artifactId>maven-jar-plugin</artifactId>
+            <configuration>
+                <archive>
+                    <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                </archive>
+            </configuration>
+        </plugin>
+        <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.7</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
                         <Export-Package>*</Export-Package>
-                        <Import-Package>*</Import-Package>
                     </instructions>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
     </plugins>


### PR DESCRIPTION
Hi,

Currently jeromq does not have any manifest headers for osgi. It can be added easily by adding maven-bundle plugin.
