### PR TITLE
IPv6 address parsing fix

### DIFF
--- a/src/main/java/zmq/TcpAddress.java
+++ b/src/main/java/zmq/TcpAddress.java
@@ -72,7 +72,7 @@ public class TcpAddress implements Address.IZAddress {
         //  Remove square brackets around the address, if any.
         if (addr_str.length () >= 2 && addr_str.charAt(0) == '[' &&
               addr_str.charAt(addr_str.length () - 1) == ']')
-            addr_str = addr_str.substring (1, addr_str.length () - 2);
+            addr_str = addr_str.substring (1, addr_str.length () - 1);
 
         int port;
         //  Allow 0 specifically, to detect invalid port error in atoi if not

--- a/src/test/java/zmq/TcpAddressTest.java
+++ b/src/test/java/zmq/TcpAddressTest.java
@@ -1,0 +1,40 @@
+/*
+    Copyright (c) 2009-2011 250bpm s.r.o.
+    Copyright (c) 2007-2009 iMatix Corporation
+    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+
+    This file is part of 0MQ.
+
+    0MQ is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    0MQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package zmq;
+
+import org.junit.*;
+
+import java.net.InetSocketAddress;
+
+import static org.junit.Assert.assertEquals;
+
+public class TcpAddressTest {
+    @Test
+    public void parsesIpv6Address() {
+        String addressString = "2000::a1";
+        int port = 9999;
+        TcpAddress address = new TcpAddress("[" + addressString + "]:" + port);
+
+        InetSocketAddress expected = new InetSocketAddress(addressString, port);
+        assertEquals(expected, address.address());
+    }
+}


### PR DESCRIPTION
This fixes an off-by-one error when parsing IPv6 addresses, where
the last character of the address string is chopped off.

This should address issue #74.
