### PR TITLE
Fix issue when building with Ant and system default encoding is not UTF-8

### DIFF
--- a/maven-build.xml
+++ b/maven-build.xml
@@ -68,6 +68,7 @@
   <target name="compile" depends="get-deps" description="Compile the code">
     <mkdir dir="${maven.build.outputDir}"/>
     <javac destdir="${maven.build.outputDir}" 
+           encoding="UTF-8"
            nowarn="false" 
            debug="true" 
            optimize="false" 
@@ -93,6 +94,7 @@
           unless="maven.test.skip">
     <mkdir dir="${maven.build.testOutputDir}"/>
     <javac destdir="${maven.build.testOutputDir}" 
+           encoding="UTF-8"
            nowarn="false" 
            debug="true" 
            optimize="false" 


### PR DESCRIPTION
In my case, fixes the following issue:
    [javac] C:\test\jeromq-master\src\main\java\org\zeromq\ZMQ.java:1541: error: unmappable character for encoding Cp1251
    [javac]      \* Starts the built-in ├?MQ proxy in the current application thread.
    [javac]
    [javac] 1 error
