### PR TITLE
subscriber should ignore HUGZ

### DIFF
--- a/src/test/java/guide/clonesrv6.java
+++ b/src/test/java/guide/clonesrv6.java
@@ -234,7 +234,7 @@ public class clonesrv6
             if (msg == null)
                 return 0;
 
-            if (msg.getKey().equals("HUGZ")) {
+            if (!msg.getKey().equals("HUGZ")) {
                 if (!srv.wasPending(msg)) {
                     //  If active update came before client update, flip it
                     //  around, store active update (with sequence) on pending


### PR DESCRIPTION
This fixes a bug in the subscriber handler where the passive clone processes only HUGZ, instead of the other way around.  Note the code from the original guide's c code correctly ignores HUGZ

``` c
if (strneq (kvmsg_key (kvmsg), "HUGZ")) {
...
```
