### PR TITLE
Improved handling of ephemeral ports

### DIFF
--- a/src/main/java/zmq/SocketBase.java
+++ b/src/main/java/zmq/SocketBase.java
@@ -356,7 +356,7 @@ public abstract class SocketBase extends Own
             // Save last endpoint URI
             options.last_endpoint = listener.get_address ();
 
-            add_endpoint(addr_, listener);
+            add_endpoint(options.last_endpoint, listener);
             return true;
         }
 

--- a/src/main/java/zmq/TcpAddress.java
+++ b/src/main/java/zmq/TcpAddress.java
@@ -56,6 +56,16 @@ public class TcpAddress implements Address.IZAddress {
         
     }
     
+    public int getPort(){
+        if (address != null)
+            return address.getPort();
+        return -1;
+    }
+
+    //Used after binding to ephemeral port to update ephemeral port (0) to actual port
+    protected void updatePort(int port){
+        address = new InetSocketAddress(address.getAddress(), port);
+    }
 
     @Override
     public void resolve(String name_, boolean ipv4only_) {

--- a/src/main/java/zmq/TcpListener.java
+++ b/src/main/java/zmq/TcpListener.java
@@ -135,18 +135,19 @@ public class TcpListener extends Own implements IPollEvents {
     public int set_address(final String addr_)  {
         address.resolve(addr_, options.ipv4only > 0 ? true : false);
         
-        endpoint = address.toString();
         try {
             handle = ServerSocketChannel.open();
             handle.configureBlocking(false);
             handle.socket().setReuseAddress(true);
             handle.socket().bind(address.address(), options.backlog);
+            if (address.getPort()==0)
+                address.updatePort(handle.socket().getLocalPort());
         } catch (IOException e) {
             close ();
             return ZError.EADDRINUSE;
         }
-        
-        socket.event_listening(endpoint, handle);
+         
+        socket.event_listening(address.toString(), handle);
         return 0;
     }
 


### PR DESCRIPTION
When using ephemeral port the actual port being used was not returned.
The socket.bind(String addr) method now returns correct port also for
ephermal ports.
