### PR TITLE
support DirectByteBuffer on socket.sendByteBuffer()

### DIFF
--- a/src/main/java/zmq/Msg.java
+++ b/src/main/java/zmq/Msg.java
@@ -173,7 +173,13 @@ public class Msg {
     public final byte[] data ()
     {
         if (data == null && type == type_lmsg) {
-            if (buf.arrayOffset () == 0)
+            if (buf.isDirect ()) {
+                data = new byte [size];
+                int pos = buf.position();
+                buf.get(data);
+                buf.position(pos);
+            }
+            else if (buf.arrayOffset () == 0)
                 data = buf.array();
             else {
                 data = new byte [size];


### PR DESCRIPTION
In case a DirectByteBuffer is passed to socket.sendByteBuffer(), capture the bytes, which I assume is aligned with the current architecture as I see a similar System.arrayCopy() in case of array ByteBuffers when arrayoffset != 0 
