### PR TITLE
use configurable Charset in every String.getBytes() and new String()

### DIFF
--- a/src/main/java/org/jeromq/ZFrame.java
+++ b/src/main/java/org/jeromq/ZFrame.java
@@ -82,7 +82,7 @@ public class ZFrame {
      */
     public ZFrame(String data) {
         if (data != null) {
-            this.data = data.getBytes();
+            this.data = data.getBytes(ZMQ.CHARSET);
         }
     }
     
@@ -250,7 +250,7 @@ public class ZFrame {
      *          New byte array contents for frame
      */
     public void reset(String data) {
-        this.data = data.getBytes();
+        this.data = data.getBytes(ZMQ.CHARSET);
     }
     
     /**
@@ -288,7 +288,7 @@ public class ZFrame {
      */
     public boolean streq(String str) {
         if (!hasData()) return false;
-        return new String(this.data).compareTo(str) == 0;
+        return new String(this.data, ZMQ.CHARSET).compareTo(str) == 0;
     }
 
     @Override
@@ -322,7 +322,7 @@ public class ZFrame {
                 isText = false;
         }
         if (isText) 
-            return new String(data);
+            return new String(data, ZMQ.CHARSET);
         else
             return strhex();
     }

--- a/src/main/java/org/jeromq/ZMQ.java
+++ b/src/main/java/org/jeromq/ZMQ.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.Selector;
+import java.nio.charset.Charset;
 
 import zmq.Ctx;
 import zmq.DecoderBase;
@@ -166,6 +167,12 @@ public class ZMQ {
     public static final int EVENT_DISCONNECTED = zmq.ZMQ.ZMQ_EVENT_DISCONNECTED;
     
     public static final int EVENT_ALL = zmq.ZMQ.ZMQ_EVENT_ALL;
+
+    public static final byte[] MESSAGE_SEPARATOR = new byte[0];
+
+    public static final byte[] SUBSCRIPTION_ALL = new byte[0];
+
+    public static Charset CHARSET = Charset.defaultCharset();
 
     /**
      * Create a new Context.
@@ -569,7 +576,7 @@ public class ZMQ {
         }
         
         public final void setIdentity(String identity) {
-            setIdentity(identity.getBytes());
+            setIdentity(identity.getBytes(CHARSET));
         }
         /**
          * @see #setRate(long)
@@ -821,7 +828,7 @@ public class ZMQ {
         }
         
         public final void subscribe(String topic) {
-            subscribe(topic.getBytes());
+            subscribe(topic.getBytes(CHARSET));
         }
         
 
@@ -840,7 +847,7 @@ public class ZMQ {
         }
         
         public final void unsubscribe(String topic) {
-            unsubscribe(topic.getBytes());
+            unsubscribe(topic.getBytes(CHARSET));
         }
 
         
@@ -1138,7 +1145,7 @@ public class ZMQ {
             zmq.Msg msg = base.recv(flags);
             
             if (msg != null) {
-                return new String (msg.data());
+                return new String (msg.data(), CHARSET);
             }
             
             return null;
@@ -1154,7 +1161,7 @@ public class ZMQ {
             while(true) {
                 Msg msg = recvMsg(0);
                 System.out.println(String.format("[%03d] %s", msg.size(), 
-                        msg.size() > 0 ? new String(msg.data()) : ""));
+                        msg.size() > 0 ? new String(msg.data(), CHARSET) : ""));
                 if (!hasReceiveMore()) {
                     break;
                 }

--- a/src/main/java/org/zeromq/ZFrame.java
+++ b/src/main/java/org/zeromq/ZFrame.java
@@ -77,7 +77,7 @@ public class ZFrame {
      */
     public ZFrame(String data) {
         if (data != null) {
-            this.data = data.getBytes();
+            this.data = data.getBytes(ZMQ.CHARSET);
         }
     }
     
@@ -235,7 +235,7 @@ public class ZFrame {
      *          New byte array contents for frame
      */
     public void reset(String data) {
-        this.data = data.getBytes();
+        this.data = data.getBytes(ZMQ.CHARSET);
     }
     
     /**
@@ -273,7 +273,7 @@ public class ZFrame {
      */
     public boolean streq(String str) {
         if (!hasData()) return false;
-        return new String(this.data).compareTo(str) == 0;
+        return new String(this.data, ZMQ.CHARSET).compareTo(str) == 0;
     }
 
     @Override
@@ -307,7 +307,7 @@ public class ZFrame {
                 isText = false;
         }
         if (isText) 
-            return new String(data);
+            return new String(data, ZMQ.CHARSET);
         else
             return strhex();
     }

--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -23,6 +23,8 @@ package org.zeromq;
 
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectableChannel;
+import java.nio.charset.Charset;
+
 import zmq.Ctx;
 import zmq.DecoderBase;
 import zmq.EncoderBase;
@@ -157,6 +159,12 @@ public class ZMQ {
     public static final int EVENT_DISCONNECTED = zmq.ZMQ.ZMQ_EVENT_DISCONNECTED;
 
     public static final int EVENT_ALL = zmq.ZMQ.ZMQ_EVENT_ALL;
+
+    public static final byte[] MESSAGE_SEPARATOR = new byte[0];
+
+    public static final byte[] SUBSCRIPTION_ALL = new byte[0];
+    
+    public static Charset CHARSET = Charset.defaultCharset();
 
     /**
      * Create a new Context.
@@ -953,15 +961,15 @@ public class ZMQ {
         }
 
         public final boolean send (String data) {
-            return send (data.getBytes (), 0);
+            return send (data.getBytes (CHARSET), 0);
         }
         
         public final boolean sendMore (String data) {
-            return send(data.getBytes (), zmq.ZMQ.ZMQ_SNDMORE);
+            return send(data.getBytes (CHARSET), zmq.ZMQ.ZMQ_SNDMORE);
         }
         
         public final boolean send (String data, int flags) {
-            return send(data.getBytes (), flags);
+            return send(data.getBytes (CHARSET), flags);
         }
         
         public final boolean send (byte[] data) {
@@ -1090,7 +1098,7 @@ public class ZMQ {
             byte [] msg = recv(flags);
             
             if (msg != null) {
-                return new String (msg);
+                return new String (msg, CHARSET);
             }
 
             return null;

--- a/src/main/java/zmq/Msg.java
+++ b/src/main/java/zmq/Msg.java
@@ -80,7 +80,7 @@ public class Msg {
     }
     
     public Msg(String src) {
-        this(src.getBytes(), false);
+        this(src.getBytes(ZMQ.CHARSET), false);
     }
     
     public Msg(byte[] src, boolean copy) {
@@ -254,7 +254,7 @@ public class Msg {
     }
 
     public final void put(String str, int i) {
-        put(str.getBytes(), i);
+        put(str.getBytes(ZMQ.CHARSET), i);
     }
 
     public final void put(Msg data, int i) {

--- a/src/main/java/zmq/Options.java
+++ b/src/main/java/zmq/Options.java
@@ -179,7 +179,7 @@ public class Options {
             byte[] val;
             
             if (optval_ instanceof String)
-                val = ((String) optval_).getBytes();
+                val = ((String) optval_).getBytes(ZMQ.CHARSET);
             else if (optval_ instanceof byte[])
                 val = (byte[]) optval_;
             else {

--- a/src/main/java/zmq/Sub.java
+++ b/src/main/java/zmq/Sub.java
@@ -52,7 +52,7 @@ public class Sub extends XSub {
         byte[] val;
         
         if (optval_ instanceof String)
-            val = ((String)optval_).getBytes();
+            val = ((String)optval_).getBytes(ZMQ.CHARSET);
         else if (optval_ instanceof byte[])
             val = (byte[]) optval_;
         else

--- a/src/main/java/zmq/ZMQ.java
+++ b/src/main/java/zmq/ZMQ.java
@@ -26,6 +26,7 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 
 
@@ -157,6 +158,12 @@ public class ZMQ {
     public static final int ZMQ_STREAMER = 1;
     public static final int ZMQ_FORWARDER = 2;
     public static final int ZMQ_QUEUE = 3;
+    
+    public static final byte[] MESSAGE_SEPARATOR = new byte[0];
+
+    public static final byte[] SUBSCRIPTION_ALL = new byte[0];
+
+    public static Charset CHARSET = Charset.defaultCharset();
 
     public static class Event
     {
@@ -190,7 +197,7 @@ public class ZMQ {
             ByteBuffer buffer = ByteBuffer.allocate (size);
             buffer.putInt (event);
             buffer.put ((byte) addr.length());
-            buffer.put (addr.getBytes());
+            buffer.put (addr.getBytes(CHARSET));
             buffer.put ((byte) flag);
             if (flag == VALUE_INTEGER)
                 buffer.putInt ((Integer)arg);
@@ -217,7 +224,7 @@ public class ZMQ {
             if (flag == VALUE_INTEGER)
                 arg = buffer.getInt ();
             
-            return new Event (event, new String (addr), arg);
+            return new Event (event, new String (addr, CHARSET), arg);
         }
     }
     //  New context API
@@ -353,7 +360,7 @@ public class ZMQ {
     // Sending functions.
     public static int zmq_send(SocketBase s_, String str, 
             int flags_) {
-        byte [] data = str.getBytes();
+        byte [] data = str.getBytes(CHARSET);
         return zmq_send(s_, data, data.length, flags_);
     }
 

--- a/src/test/java/guide/MDP.java
+++ b/src/test/java/guide/MDP.java
@@ -18,6 +18,7 @@ package guide;
  */
 import java.util.Arrays;
 
+import org.zeromq.ZMQ;
 import org.zeromq.ZFrame;
 
 /**
@@ -45,7 +46,7 @@ public enum MDP {
     private final byte[] data;
 
     MDP(String value) {
-        this.data = value.getBytes();
+        this.data = value.getBytes(ZMQ.CHARSET);
     }
     MDP(int value) { //watch for ints>255, will be truncated
         byte b = (byte) (value & 0xFF);

--- a/src/test/java/guide/ZHelper.java
+++ b/src/test/java/guide/ZHelper.java
@@ -29,7 +29,7 @@ public class ZHelper
                 data += String.format ("%02X", msg[i]);
             }
             if (isText)
-                data = new String (msg);
+                data = new String (msg, ZMQ.CHARSET);
 
             System.out.println (String.format ("[%03d] %s", msg.length, data));
             if (!sock.hasReceiveMore ())
@@ -41,7 +41,7 @@ public class ZHelper
     {
         String identity = String.format ("%04X-%04X", rand.nextInt (), rand.nextInt ());
 
-        sock.setIdentity (identity.getBytes ());
+        sock.setIdentity (identity.getBytes (ZMQ.CHARSET));
     }
 
     public static List<Socket> buildZPipe(Context ctx) {

--- a/src/test/java/guide/asyncsrv.java
+++ b/src/test/java/guide/asyncsrv.java
@@ -36,7 +36,7 @@ public class asyncsrv
 
             //  Set random identity to make tracing easier
             String identity = String.format("%04X-%04X", rand.nextInt(), rand.nextInt());
-            client.setIdentity(identity.getBytes());
+            client.setIdentity(identity.getBytes(ZMQ.CHARSET));
             client.connect("tcp://localhost:5570");
 
             PollItem[] items = new PollItem[] { new PollItem(client, Poller.POLLIN) };

--- a/src/test/java/guide/bstar.java
+++ b/src/test/java/guide/bstar.java
@@ -254,7 +254,7 @@ public class bstar
 
         //  Create subscriber for state coming from peer
         statesub = ctx.createSocket(ZMQ.SUB);
-        statesub.subscribe("".getBytes());
+        statesub.subscribe(ZMQ.SUBSCRIPTION_ALL);
         statesub.connect(remote);
 
         //  Set-up basic reactor events

--- a/src/test/java/guide/bstarsrv.java
+++ b/src/test/java/guide/bstarsrv.java
@@ -132,7 +132,7 @@ public class bstarsrv
         ZContext ctx = new ZContext();
         Socket statepub = ctx.createSocket(ZMQ.PUB);
         Socket statesub = ctx.createSocket(ZMQ.SUB);
-        statesub.subscribe("".getBytes());
+        statesub.subscribe(ZMQ.SUBSCRIPTION_ALL);
         Socket frontend = ctx.createSocket(ZMQ.ROUTER);
         bstarsrv fsm = new bstarsrv();
 

--- a/src/test/java/guide/clone.java
+++ b/src/test/java/guide/clone.java
@@ -111,7 +111,7 @@ public class clone
             snapshot.connect(String.format("%s:%d", address, port));
             subscriber = ctx.createSocket(ZMQ.SUB);
             subscriber.connect(String.format("%s:%d", address, port + 1));
-            subscriber.subscribe(subtree.getBytes());
+            subscriber.subscribe(subtree.getBytes(ZMQ.CHARSET));
         }
 
         protected void destroy()

--- a/src/test/java/guide/clonecli1.java
+++ b/src/test/java/guide/clonecli1.java
@@ -21,7 +21,7 @@ public class clonecli1 {
 		ZContext ctx = new ZContext();
 		Socket subscriber = ctx.createSocket(ZMQ.SUB);
 		subscriber.connect("tcp://localhost:5556");
-		subscriber.subscribe("".getBytes());
+		subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
 
 		while (true) {
 			kvsimple kvMsg = kvsimple.recv(subscriber);

--- a/src/test/java/guide/clonecli2.java
+++ b/src/test/java/guide/clonecli2.java
@@ -24,10 +24,10 @@ public class clonecli2 {
 
 		Socket subscriber = ctx.socket(ZMQ.SUB);
 		subscriber.connect("tcp://localhost:5557");
-		subscriber.subscribe("".getBytes());
+		subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
 
 		// get state snapshot
-		snapshot.send("ICANHAZ?".getBytes(), 0);
+		snapshot.send("ICANHAZ?".getBytes(ZMQ.CHARSET), 0);
         long sequence = 0;
 		while (true) {
             kvsimple kvMsg = kvsimple.recv(snapshot);

--- a/src/test/java/guide/clonecli3.java
+++ b/src/test/java/guide/clonecli3.java
@@ -25,14 +25,14 @@ public class clonecli3 {
 
 		Socket subscriber = ctx.createSocket(ZMQ.SUB);
 		subscriber.connect("tcp://localhost:5557");
-		subscriber.subscribe("".getBytes());
+		subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
 
 		Socket push = ctx.createSocket(ZMQ.PUSH);
 		push.connect("tcp://localhost:5558");
 
 		// get state snapshot
         long sequence = 0;
-        snapshot.send("ICANHAZ?".getBytes(), 0);
+        snapshot.send("ICANHAZ?".getBytes(ZMQ.CHARSET), 0);
 		while (true) {
             kvsimple kvMsg = kvsimple.recv(snapshot);
             if (kvMsg == null)

--- a/src/test/java/guide/clonecli4.java
+++ b/src/test/java/guide/clonecli4.java
@@ -30,7 +30,7 @@ public class clonecli4
 
 		Socket subscriber = ctx.createSocket(ZMQ.SUB);
         subscriber.connect("tcp://localhost:5557");
-        subscriber.subscribe(SUBTREE.getBytes());
+        subscriber.subscribe(SUBTREE.getBytes(ZMQ.CHARSET));
 
 		Socket push = ctx.createSocket(ZMQ.PUSH);
 		push.connect("tcp://localhost:5558");

--- a/src/test/java/guide/clonecli5.java
+++ b/src/test/java/guide/clonecli5.java
@@ -28,7 +28,7 @@ public class clonecli5
 
 		Socket subscriber = ctx.createSocket(ZMQ.SUB);
         subscriber.connect("tcp://localhost:5557");
-        subscriber.subscribe(SUBTREE.getBytes());
+        subscriber.subscribe(SUBTREE.getBytes(ZMQ.CHARSET));
 
 		Socket publisher = ctx.createSocket(ZMQ.PUSH);
 		publisher.connect("tcp://localhost:5558");

--- a/src/test/java/guide/clonesrv2.java
+++ b/src/test/java/guide/clonesrv2.java
@@ -88,7 +88,7 @@ public class clonesrv2 {
 					byte[] identity = snapshot.recv(0);
                     if (identity == null)
                         break;
-					String request = new String(snapshot.recv(0));
+					String request = new String(snapshot.recv(0), ZMQ.CHARSET);
 
                     if (!request.equals("ICANHAZ?")) {
                         System.out.println("E: bad request, aborting");
@@ -106,7 +106,7 @@ public class clonesrv2 {
                     // now send end message with getSequence number
                     System.out.println("Sending state snapshot = " + stateSequence);
                     snapshot.send(identity, ZMQ.SNDMORE);
-                    kvsimple message = new kvsimple("KTHXBAI", stateSequence, "".getBytes());
+                    kvsimple message = new kvsimple("KTHXBAI", stateSequence, ZMQ.MESSAGE_SEPARATOR);
                     message.send(snapshot);
 				}
 			}

--- a/src/test/java/guide/clonesrv3.java
+++ b/src/test/java/guide/clonesrv3.java
@@ -74,7 +74,7 @@ public class clonesrv3 {
                 // now send end message with getSequence number
                 System.out.println("Sending state snapshot = " + sequence);
                 snapshot.send(identity, ZMQ.SNDMORE);
-                kvsimple message = new kvsimple("KTHXBAI", sequence, "".getBytes());
+                kvsimple message = new kvsimple("KTHXBAI", sequence, ZMQ.SUBSCRIPTION_ALL);
                 message.send(snapshot);
             }
         }

--- a/src/test/java/guide/clonesrv4.java
+++ b/src/test/java/guide/clonesrv4.java
@@ -79,7 +79,7 @@ public class clonesrv4
                 // now send end message with getSequence number
                 System.out.println("Sending state snapshot = " + sequence);
                 snapshot.send(identity, ZMQ.SNDMORE);
-                kvsimple message = new kvsimple("KTHXBAI", sequence, "".getBytes());
+                kvsimple message = new kvsimple("KTHXBAI", sequence, ZMQ.SUBSCRIPTION_ALL);
                 message.send(snapshot);
             }
         }

--- a/src/test/java/guide/clonesrv5.java
+++ b/src/test/java/guide/clonesrv5.java
@@ -58,7 +58,7 @@ public class clonesrv5
                     socket.send(identity, ZMQ.SNDMORE);
                     kvmsg kvmsg = new kvmsg(srv.sequence);
                     kvmsg.setKey("KTHXBAI");
-                    kvmsg.setBody(subtree.getBytes());
+                    kvmsg.setBody(subtree.getBytes(ZMQ.CHARSET));
                     kvmsg.send(socket);
                     kvmsg.destroy();
                 }
@@ -161,7 +161,7 @@ public class clonesrv5
         long ttl = Long.parseLong(msg.getProp("ttl"));
         if (ttl > 0 && System.currentTimeMillis() >= ttl) {
             msg.setSequence(++sequence);
-            msg.setBody("".getBytes());
+            msg.setBody(ZMQ.MESSAGE_SEPARATOR);
             msg.send(publisher);
             msg.store(kvmap);
             System.out.printf("I: publishing delete=%d\n", sequence);

--- a/src/test/java/guide/clonesrv6.java
+++ b/src/test/java/guide/clonesrv6.java
@@ -61,7 +61,7 @@ public class clonesrv6
                     socket.send(identity, ZMQ.SNDMORE);
                     kvmsg kvmsg = new kvmsg(srv.sequence);
                     kvmsg.setKey("KTHXBAI");
-                    kvmsg.setBody(subtree.getBytes());
+                    kvmsg.setBody(subtree.getBytes(ZMQ.CHARSET));
                     kvmsg.send(socket);
                     kvmsg.destroy();
                 }
@@ -117,7 +117,7 @@ public class clonesrv6
 
             kvmsg msg = new kvmsg(srv.sequence);
             msg.setKey("HUGZ");
-            msg.setBody("".getBytes());
+            msg.setBody(ZMQ.MESSAGE_SEPARATOR);
             msg.send(srv.publisher);
             msg.destroy();
 
@@ -287,13 +287,13 @@ public class clonesrv6
         //  Set up our clone server sockets
         publisher = ctx.createSocket(ZMQ.PUB);
         collector = ctx.createSocket(ZMQ.SUB);
-        collector.subscribe("".getBytes());
+        collector.subscribe(ZMQ.SUBSCRIPTION_ALL);
         publisher.bind(String.format("tcp://*:%d", port + 1));
         collector.bind(String.format("tcp://*:%d", port+2));
 
         //  Set up our own clone client interface to peer
         subscriber = ctx.createSocket(ZMQ.SUB);
-        subscriber.subscribe("".getBytes());
+        subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
         subscriber.connect(String.format("tcp://localhost:%d", peer + 1));
     }
 
@@ -371,7 +371,7 @@ public class clonesrv6
         long ttl = Long.parseLong(msg.getProp("ttl"));
         if (ttl > 0 && System.currentTimeMillis() >= ttl) {
             msg.setSequence(++sequence);
-            msg.setBody("".getBytes());
+            msg.setBody(ZMQ.MESSAGE_SEPARATOR);
             msg.send(publisher);
             msg.store(kvmap);
             System.out.printf("I: publishing delete=%d\n", sequence);

--- a/src/test/java/guide/espresso.java
+++ b/src/test/java/guide/espresso.java
@@ -24,8 +24,8 @@ public class espresso
             //  Subscribe to "A" and "B"
             Socket subscriber = ctx.createSocket(ZMQ.SUB);
             subscriber.connect("tcp://localhost:6001");
-            subscriber.subscribe("A".getBytes());
-            subscriber.subscribe("B".getBytes());
+            subscriber.subscribe("A".getBytes(ZMQ.CHARSET));
+            subscriber.subscribe("B".getBytes(ZMQ.CHARSET));
 
             int count = 0;
             while (count < 5) {

--- a/src/test/java/guide/flserver3.java
+++ b/src/test/java/guide/flserver3.java
@@ -19,7 +19,7 @@ public class flserver3
         String bindEndpoint = "tcp://*:5555";
         String connectEndpoint = "tcp://localhost:5555";
         Socket server = ctx.createSocket(ZMQ.ROUTER);
-        server.setIdentity(connectEndpoint.getBytes());
+        server.setIdentity(connectEndpoint.getBytes(ZMQ.CHARSET));
         server.bind(bindEndpoint);
         System.out.printf ("I: service is ready at %s\n", bindEndpoint);
 

--- a/src/test/java/guide/hwclient.java
+++ b/src/test/java/guide/hwclient.java
@@ -22,10 +22,10 @@ public class hwclient{
         for(int requestNbr = 0; requestNbr != 10; requestNbr++) {
             String request = "Hello" ;
             System.out.println("Sending Hello " + requestNbr );
-            socket.send(request.getBytes (), 0);
+            socket.send(request.getBytes (ZMQ.CHARSET), 0);
 
             byte[] reply = socket.recv(0);
-            System.out.println("Received " + new String (reply) + " " + requestNbr);
+            System.out.println("Received " + new String (reply, ZMQ.CHARSET) + " " + requestNbr);
         }
         
         socket.close();

--- a/src/test/java/guide/hwserver.java
+++ b/src/test/java/guide/hwserver.java
@@ -21,12 +21,12 @@ public class hwserver{
         while (!Thread.currentThread ().isInterrupted ()) {
 
             byte[] reply = socket.recv(0);
-            System.out.println("Received " + ": [" + new String(reply) + "]");
+            System.out.println("Received " + ": [" + new String(reply, ZMQ.CHARSET) + "]");
 
             //  Create a "Hello" message.
             String request = "world" ;
             // Send the message
-            socket.send(request.getBytes (), 0);
+            socket.send(request.getBytes (ZMQ.CHARSET), 0);
 
             Thread.sleep(1000); //  Do some 'work'
         }

--- a/src/test/java/guide/identity.java
+++ b/src/test/java/guide/identity.java
@@ -24,7 +24,7 @@ public class identity {
 
         //  Then set the identity ourself
         Socket identified = context.socket(ZMQ.REQ);
-        identified.setIdentity("Hello".getBytes ());
+        identified.setIdentity("Hello".getBytes (ZMQ.CHARSET));
         identified.connect ("inproc://example");
         identified.send("ROUTER socket uses REQ's socket identity", 0);
         ZHelper.dump (sink);

--- a/src/test/java/guide/kvmsg.java
+++ b/src/test/java/guide/kvmsg.java
@@ -48,7 +48,7 @@ public class kvmsg
         ByteBuffer msg = ByteBuffer.allocate(props_size);
         for (Entry<Object, Object> o: props.entrySet()) {
             String prop = o.getKey().toString() + "=" + o.getValue().toString() + "\n";
-            msg.put(prop.getBytes());
+            msg.put(prop.getBytes(ZMQ.CHARSET));
         }
         present[FRAME_PROPS] = true;
         frame[FRAME_PROPS] = msg.array();
@@ -63,8 +63,8 @@ public class kvmsg
         if (msg.length == 0)
             return;
 
-        System.out.println("" + msg.length + " :" + new String(msg));
-        for (String prop: new String(msg).split("\n")) {
+        System.out.println("" + msg.length + " :" + new String(msg, ZMQ.CHARSET));
+        for (String prop: new String(msg, ZMQ.CHARSET).split("\n")) {
             String[] split = prop.split("=");
             props.setProperty(split[0], split[1]);
         }
@@ -125,7 +125,7 @@ public class kvmsg
         //  .skip
         int frameNbr;
         for (frameNbr = 0; frameNbr < KVMSG_FRAMES; frameNbr++) {
-            byte[] copy = new byte[0];
+            byte[] copy = ZMQ.MESSAGE_SEPARATOR;
             if (present[frameNbr])
                 copy = frame[frameNbr];
             socket.send(copy, (frameNbr < KVMSG_FRAMES - 1)? ZMQ.SNDMORE: 0);
@@ -165,7 +165,7 @@ public class kvmsg
                     size = KVMSG_KEY_MAX;
                 byte[] buf = new byte[size];
                 System.arraycopy(frame[FRAME_KEY], 0, buf, 0, size);
-                key = new String(buf);
+                key = new String(buf, ZMQ.CHARSET);
             }
             return key;
         }
@@ -177,7 +177,7 @@ public class kvmsg
     public void setKey(String key)
     {
         byte[] msg = new byte[key.length()];
-        System.arraycopy(key.getBytes(), 0, msg, 0, key.length());
+        System.arraycopy(key.getBytes(ZMQ.CHARSET), 0, msg, 0, key.length());
         frame[FRAME_KEY] = msg;
         present[FRAME_KEY] = true;
     }
@@ -232,7 +232,7 @@ public class kvmsg
     //  Set message body using printf format
     public void fmtBody(String fmt, Object... args)
     {
-        setBody(String.format(fmt, args).getBytes());
+        setBody(String.format(fmt, args).getBytes(ZMQ.CHARSET));
     }
 
     //  Return body size from last read message, if any, else zero
@@ -258,7 +258,7 @@ public class kvmsg
     //  Sets the UUID to a randomly generated value
     public void setUUID()
     {
-        byte[] msg = UUID.randomUUID().toString().getBytes();
+        byte[] msg = UUID.randomUUID().toString().getBytes(ZMQ.CHARSET);
         present[FRAME_UUID] = true;
         frame[FRAME_UUID] = msg;
     }
@@ -347,7 +347,7 @@ public class kvmsg
         kvmsg kvmsg = new kvmsg(1);
         kvmsg.setKey("getKey");
         kvmsg.setUUID();
-        kvmsg.setBody("body".getBytes());
+        kvmsg.setBody("body".getBytes(ZMQ.CHARSET));
         if (verbose)
             kvmsg.dump();
         kvmsg.send(output);
@@ -366,7 +366,7 @@ public class kvmsg
         kvmsg.setProp("prop2", "value2");
         kvmsg.setKey("getKey");
         kvmsg.setUUID();
-        kvmsg.setBody("body".getBytes());
+        kvmsg.setBody("body".getBytes(ZMQ.CHARSET));
         assert (kvmsg.getProp("prop2").equals("value2"));
         if (verbose)
             kvmsg.dump();

--- a/src/test/java/guide/kvsimple.java
+++ b/src/test/java/guide/kvsimple.java
@@ -41,7 +41,7 @@ public class kvsimple {
 
 	public void send(Socket publisher) {
 
-		publisher.send(key.getBytes(), ZMQ.SNDMORE);
+		publisher.send(key.getBytes(ZMQ.CHARSET), ZMQ.SNDMORE);
 
 		ByteBuffer bb = ByteBuffer.allocate(8);
 		bb.asLongBuffer().put(sequence);
@@ -54,7 +54,7 @@ public class kvsimple {
         byte [] data = updates.recv(0);
         if (data == null || !updates.hasReceiveMore())
             return null;
-		String key = new String(data);
+		String key = new String(data, ZMQ.CHARSET);
         data = updates.recv(0);
         if (data == null || !updates.hasReceiveMore())
             return null;

--- a/src/test/java/guide/lruqueue3.java
+++ b/src/test/java/guide/lruqueue3.java
@@ -25,12 +25,12 @@ class ClientThread3 extends Thread
 
         //  Send request, get reply
         while (true) {
-            client.send("HELLO".getBytes(), 0);
+            client.send("HELLO".getBytes(ZMQ.CHARSET), 0);
             byte[] data = client.recv(0);
 
             if (data == null)
                 break;
-            String reply = new String(data);
+            String reply = new String(data, ZMQ.CHARSET);
             try {
                 Thread.sleep(1000);
             } catch (InterruptedException e) {
@@ -63,7 +63,7 @@ class WorkerThread3 extends Thread
             if (msg == null)
                 break;
 
-            msg.getLast().reset("OK".getBytes());
+            msg.getLast().reset("OK".getBytes(ZMQ.CHARSET));
 
             msg.send(worker);
             System.out.println(Thread.currentThread().getName() + " Worker Sent OK");
@@ -132,7 +132,7 @@ class BackendHandler implements ZLoop.IZLoopHandler
 
             //  Forward message to client if it's not a READY
             ZFrame frame = msg.getFirst();
-            if (new String(frame.getData()).equals(lruqueue3.LRU_READY))
+            if (new String(frame.getData(), ZMQ.CHARSET).equals(lruqueue3.LRU_READY))
                 msg.destroy();
             else
                 msg.send(arg.frontend);

--- a/src/test/java/guide/lvcache.java
+++ b/src/test/java/guide/lvcache.java
@@ -22,7 +22,7 @@ public class lvcache
         backend.bind("tcp://*:5558");
 
         //  Subscribe to every single topic from publisher
-        frontend.subscribe("".getBytes());
+        frontend.subscribe(ZMQ.SUBSCRIPTION_ALL);
 
         //  Store last instance of each topic in a cache
         Map<String, String> cache = new HashMap<String, String>();
@@ -59,7 +59,7 @@ public class lvcache
                 //  Event is one byte 0=unsub or 1=sub, followed by topic
                 byte[] event = frame.getData();
                 if (event [0] == 1) {
-                    String topic = new String(event, 1, event.length -1);
+                    String topic = new String(event, 1, event.length -1, ZMQ.CHARSET);
                     System.out.printf ("Sending cached topic %s\n", topic);
                     String previous = cache.get(topic);
                     if (previous != null) {

--- a/src/test/java/guide/mdbroker.java
+++ b/src/test/java/guide/mdbroker.java
@@ -300,7 +300,7 @@ public class mdbroker {
             String name = msg.peekLast().toString();
             returnCode = services.containsKey(name) ? "200" : "400";
         }
-        msg.peekLast().reset(returnCode.getBytes());
+        msg.peekLast().reset(returnCode.getBytes(ZMQ.CHARSET));
         // Remove & save client return envelope and insert the
         // protocol header and service name, then rewrap envelope.
         ZFrame client = msg.unwrap();

--- a/src/test/java/guide/mdwrkapi.java
+++ b/src/test/java/guide/mdwrkapi.java
@@ -77,7 +77,7 @@ public class mdwrkapi {
 
         msg.addFirst(command.newFrame());
         msg.addFirst(MDP.W_WORKER.newFrame());
-        msg.addFirst(new ZFrame(new byte[0]));
+        msg.addFirst(new ZFrame(ZMQ.MESSAGE_SEPARATOR));
 
         if (verbose) {
             log.format("I: sending %s to broker\n", command);

--- a/src/test/java/guide/mspoller.java
+++ b/src/test/java/guide/mspoller.java
@@ -18,7 +18,7 @@ public class mspoller {
         //  Connect to weather server
         ZMQ.Socket subscriber = context.socket(ZMQ.SUB);
         subscriber.connect("tcp://localhost:5556");
-        subscriber.subscribe("10001 ".getBytes());
+        subscriber.subscribe("10001 ".getBytes(ZMQ.CHARSET));
 
         //  Initialize poll set
         ZMQ.Poller items = new ZMQ.Poller (2);

--- a/src/test/java/guide/msreader.java
+++ b/src/test/java/guide/msreader.java
@@ -19,7 +19,7 @@ public class msreader {
         //  Connect to weather server
         ZMQ.Socket subscriber = context.socket(ZMQ.SUB);
         subscriber.connect("tcp://localhost:5556");
-        subscriber.subscribe("10001 ".getBytes());
+        subscriber.subscribe("10001 ".getBytes(ZMQ.CHARSET));
 
         //  Process messages from both sockets
         //  We prioritize traffic from the task ventilator

--- a/src/test/java/guide/pathosub.java
+++ b/src/test/java/guide/pathosub.java
@@ -21,7 +21,7 @@ public class pathosub
 
         Random rand = new Random(System.currentTimeMillis());
         String subscription = String.format("%03d", rand.nextInt(1000));
-        subscriber.subscribe(subscription.getBytes());
+        subscriber.subscribe(subscription.getBytes(ZMQ.CHARSET));
 
         while (true) {
             String topic = subscriber.recvStr();

--- a/src/test/java/guide/peering1.java
+++ b/src/test/java/guide/peering1.java
@@ -35,7 +35,7 @@ public class peering1
 
         //  Connect statefe to all peers
         Socket statefe = ctx.createSocket(ZMQ.SUB);
-        statefe.subscribe("".getBytes());
+        statefe.subscribe(ZMQ.SUBSCRIPTION_ALL);
         int argn;
         for (argn = 1; argn < argv.length; argn++) {
             String peer = argv[argn];
@@ -55,8 +55,8 @@ public class peering1
 
             //  Handle incoming status messages
             if (items[0].isReadable()) {
-                String peer_name = new String(statefe.recv(0));
-                String available = new String(statefe.recv(0));
+                String peer_name = new String(statefe.recv(0), ZMQ.CHARSET);
+                String available = new String(statefe.recv(0), ZMQ.CHARSET);
                 System.out.printf("%s - %s workers free\n", peer_name, available);
             } else {
                 //  Send random values for worker availability

--- a/src/test/java/guide/peering2.java
+++ b/src/test/java/guide/peering2.java
@@ -101,12 +101,12 @@ public class peering2
 
         //  Bind cloud frontend to endpoint
         Socket cloudfe = ctx.createSocket(ZMQ.ROUTER);
-        cloudfe.setIdentity(self.getBytes());
+        cloudfe.setIdentity(self.getBytes(ZMQ.CHARSET));
         cloudfe.bind(String.format("ipc://%s-cloud.ipc", self));
 
         //  Connect cloud backend to all peers
         Socket cloudbe = ctx.createSocket(ZMQ.ROUTER);
-        cloudbe.setIdentity(self.getBytes());
+        cloudbe.setIdentity(self.getBytes(ZMQ.CHARSET));
         int argn;
         for (argn = 1; argn < argv.length; argn++) {
             String peer = argv[argn];
@@ -169,7 +169,7 @@ public class peering2
 
                 //  If it's READY, don't route the message any further
                 ZFrame frame = msg.getFirst();
-                if (new String(frame.getData()).equals(WORKER_READY)) {
+                if (new String(frame.getData(), ZMQ.CHARSET).equals(WORKER_READY)) {
                     msg.destroy();
                     msg = null;
                 }
@@ -186,7 +186,7 @@ public class peering2
             //  Route reply to cloud if it's addressed to a broker
             for (argn = 1; msg != null && argn < argv.length; argn++) {
                 byte[] data = msg.getFirst().getData();
-                if (argv[argn].equals(new String(data))) {
+                if (argv[argn].equals(new String(data, ZMQ.CHARSET))) {
                     msg.send(cloudfe);
                     msg = null;
                 }

--- a/src/test/java/guide/peering3.java
+++ b/src/test/java/guide/peering3.java
@@ -146,12 +146,12 @@ public class peering3
 
         //  Bind cloud frontend to endpoint
         Socket cloudfe = ctx.createSocket(ZMQ.ROUTER);
-        cloudfe.setIdentity(self.getBytes());
+        cloudfe.setIdentity(self.getBytes(ZMQ.CHARSET));
         cloudfe.bind(String.format("ipc://%s-cloud.ipc", self));
 
         //  Connect cloud backend to all peers
         Socket cloudbe = ctx.createSocket(ZMQ.ROUTER);
-        cloudbe.setIdentity(self.getBytes());
+        cloudbe.setIdentity(self.getBytes(ZMQ.CHARSET));
         int argn;
         for (argn = 1; argn < argv.length; argn++) {
             String peer = argv[argn];
@@ -165,7 +165,7 @@ public class peering3
 
         //  Connect statefe to all peers
         Socket statefe = ctx.createSocket(ZMQ.SUB);
-        statefe.subscribe("".getBytes());
+        statefe.subscribe(ZMQ.SUBSCRIPTION_ALL);
         for (argn = 1; argn < argv.length; argn++) {
             String peer = argv[argn];
             System.out.printf("I: connecting to state backend at '%s'\n", peer);
@@ -226,7 +226,7 @@ public class peering3
 
                 //  If it's READY, don't route the message any further
                 ZFrame frame = msg.getFirst();
-                if (new String(frame.getData()).equals(WORKER_READY)) {
+                if (new String(frame.getData(), ZMQ.CHARSET).equals(WORKER_READY)) {
                     msg.destroy();
                     msg = null;
                 }
@@ -243,7 +243,7 @@ public class peering3
             //  Route reply to cloud if it's addressed to a broker
             for (argn = 1; msg != null && argn < argv.length; argn++) {
                 byte[] data = msg.getFirst().getData();
-                if (argv[argn].equals(new String(data))) {
+                if (argv[argn].equals(new String(data, ZMQ.CHARSET))) {
                     msg.send(cloudfe);
                     msg = null;
                 }

--- a/src/test/java/guide/ppqueue.java
+++ b/src/test/java/guide/ppqueue.java
@@ -33,7 +33,7 @@ public class ppqueue {
         
         protected Worker(ZFrame address) {
             this.address = address;
-            identity = new String(address.getData());
+            identity = new String(address.getData(), ZMQ.CHARSET);
             expiry = System.currentTimeMillis() + HEARTBEAT_INTERVAL * HEARTBEAT_LIVENESS;
         }
 
@@ -113,7 +113,7 @@ public class ppqueue {
                 //  Validate control message, or return reply to client
                 if (msg.size() == 1) {
                     ZFrame frame = msg.getFirst();
-                    String data = new String(frame.getData());
+                    String data = new String(frame.getData(), ZMQ.CHARSET);
                     if (!data.equals(PPP_READY)
                     &&  !data.equals( PPP_HEARTBEAT)) {
                         System.out.println ("E: invalid message from worker");

--- a/src/test/java/guide/ppworker.java
+++ b/src/test/java/guide/ppworker.java
@@ -106,7 +106,7 @@ public class ppworker
                     //  queue was (recently) alive, so reset our liveness indicator:
                     if (msg.size() == 1) {
                         ZFrame frame = msg.getFirst();
-                        if (PPP_HEARTBEAT.equals(new String(frame.getData())))
+                        if (PPP_HEARTBEAT.equals(new String(frame.getData(), ZMQ.CHARSET)))
                             liveness = HEARTBEAT_LIVENESS;
                         else {
                             System.out.println("E: invalid message\n");

--- a/src/test/java/guide/psenvsub.java
+++ b/src/test/java/guide/psenvsub.java
@@ -17,7 +17,7 @@ public class psenvsub {
         Socket subscriber = context.socket(ZMQ.SUB);
 
         subscriber.connect("tcp://localhost:5563");
-        subscriber.subscribe("B".getBytes());
+        subscriber.subscribe("B".getBytes(ZMQ.CHARSET));
         while (!Thread.currentThread ().isInterrupted ()) {
             // Read envelope with address
             String address = subscriber.recvStr ();

--- a/src/test/java/guide/rtmama.java
+++ b/src/test/java/guide/rtmama.java
@@ -10,7 +10,7 @@ public class rtmama {
     private static final int NBR_WORKERS  =10;
     
     public static class Worker implements Runnable {
-        private final byte[] END = "END".getBytes();
+        private final byte[] END = "END".getBytes(ZMQ.CHARSET);
 
         public void run() {
             ZMQ.Context context = ZMQ.context(1);
@@ -22,7 +22,7 @@ public class rtmama {
             while (true) {
                 worker.send("ready", 0);
                 byte[] workerload = worker.recv(0);
-                if (new String(workerload).equals("END")) {
+                if (new String(workerload, ZMQ.CHARSET).equals("END")) {
                     System.out.println(
                         String.format(
                             "Processs %d tasks.", total

--- a/src/test/java/guide/rtpapa.java
+++ b/src/test/java/guide/rtpapa.java
@@ -21,7 +21,7 @@ public class rtpapa
         client.bind("ipc://routing.ipc");
 
         Socket worker = context.socket(ZMQ.REP);
-        worker.setIdentity("A".getBytes());
+        worker.setIdentity("A".getBytes(ZMQ.CHARSET));
         worker.connect("ipc://routing.ipc");
 
         //  Wait for the worker to connect so that when we send a message

--- a/src/test/java/guide/spqueue.java
+++ b/src/test/java/guide/spqueue.java
@@ -54,7 +54,7 @@ public class spqueue
 
                 //  Forward message to client if it's not a READY
                 ZFrame frame = msg.getFirst();
-                if (new String(frame.getData()).equals(WORKER_READY))
+                if (new String(frame.getData(), ZMQ.CHARSET).equals(WORKER_READY))
                     msg.destroy();
                 else
                     msg.send(frontend);

--- a/src/test/java/guide/spworker.java
+++ b/src/test/java/guide/spworker.java
@@ -26,7 +26,7 @@ public class spworker
         //  Set random identity to make tracing easier
         Random rand = new Random(System.nanoTime());
         String identity = String.format("%04X-%04X", rand.nextInt(0x10000), rand.nextInt(0x10000));
-        worker.setIdentity(identity.getBytes());
+        worker.setIdentity(identity.getBytes(ZMQ.CHARSET));
         worker.connect("tcp://localhost:5556");
 
         //  Tell broker we're ready for work

--- a/src/test/java/guide/suisnail.java
+++ b/src/test/java/guide/suisnail.java
@@ -26,7 +26,7 @@ public class suisnail
         {
             //  Subscribe to everything
             Socket subscriber = ctx.createSocket(ZMQ.SUB);
-            subscriber.subscribe("".getBytes());
+            subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
             subscriber.connect("tcp://localhost:5556");
 
             //  Get and process messages

--- a/src/test/java/guide/syncsub.java
+++ b/src/test/java/guide/syncsub.java
@@ -15,14 +15,14 @@ public class syncsub{
         //  First, connect our subscriber socket
         Socket subscriber = context.socket(ZMQ.SUB);
         subscriber.connect("tcp://localhost:5561");
-        subscriber.subscribe("".getBytes());
+        subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
 
         //  Second, synchronize with publisher
         Socket syncclient = context.socket(ZMQ.REQ);
         syncclient.connect("tcp://localhost:5562");
 
         //  - send a synchronization request
-        syncclient.send("".getBytes(), 0);
+        syncclient.send(ZMQ.MESSAGE_SEPARATOR, 0);
 
         //  - wait for synchronization reply
         syncclient.recv(0);

--- a/src/test/java/guide/tasksink.java
+++ b/src/test/java/guide/tasksink.java
@@ -17,7 +17,7 @@ public class tasksink {
         receiver.bind("tcp://*:5558");
 
         //  Wait for start of batch
-        String string = new String(receiver.recv(0));
+        String string = new String(receiver.recv(0), ZMQ.CHARSET);
 
         //  Start our clock now
         long tstart = System.currentTimeMillis();
@@ -26,7 +26,7 @@ public class tasksink {
         int task_nbr;
         int total_msec = 0;     //  Total calculated cost in msecs
         for (task_nbr = 0; task_nbr < 100; task_nbr++) {
-            string = new String(receiver.recv(0)).trim();
+            string = new String(receiver.recv(0), ZMQ.CHARSET).trim();
             if ((task_nbr / 10) * 10 == task_nbr) {
                 System.out.print(":");
             } else {

--- a/src/test/java/guide/taskwork.java
+++ b/src/test/java/guide/taskwork.java
@@ -24,7 +24,7 @@ public class taskwork {
 
         //  Process tasks forever
         while (!Thread.currentThread ().isInterrupted ()) {
-            String string = new String(receiver.recv(0)).trim();
+            String string = new String(receiver.recv(0), ZMQ.CHARSET).trim();
             long msec = Long.parseLong(string);
             //  Simple progress indicator for the viewer
             System.out.flush();
@@ -34,7 +34,7 @@ public class taskwork {
             Thread.sleep(msec);
 
             //  Send results to sink
-            sender.send("".getBytes(), 0);
+            sender.send(ZMQ.MESSAGE_SEPARATOR, 0);
         }
         sender.close();
         receiver.close();

--- a/src/test/java/guide/taskwork2.java
+++ b/src/test/java/guide/taskwork2.java
@@ -19,7 +19,7 @@ public class taskwork2 {
 
         ZMQ.Socket controller = context.socket(ZMQ.SUB);
         controller.connect("tcp://localhost:5559");
-        controller.subscribe("".getBytes());
+        controller.subscribe(ZMQ.SUBSCRIPTION_ALL);
 
         ZMQ.Poller items = new ZMQ.Poller (2);
         items.register(receiver, ZMQ.Poller.POLLIN);

--- a/src/test/java/guide/titanic.java
+++ b/src/test/java/guide/titanic.java
@@ -249,8 +249,8 @@ public class titanic
                     //  UUID is prefixed with '-' if still waiting
                     if (entry[0] == '-') {
                         if (verbose)
-                            System.out.printf("I: processing request %s\n", new String(entry, 1, entry.length -1));
-                        if (serviceSuccess(new String(entry, 1, entry.length -1))) {
+                            System.out.printf("I: processing request %s\n", new String(entry, 1, entry.length -1, ZMQ.CHARSET));
+                        if (serviceSuccess(new String(entry, 1, entry.length -1, ZMQ.CHARSET))) {
                             //  Mark queue entry as processed
                             file.seek(file.getFilePointer() - 37);
                             file.writeBytes("+");

--- a/src/test/java/guide/tripping.java
+++ b/src/test/java/guide/tripping.java
@@ -62,7 +62,7 @@ public class tripping {
             ZContext ctx = new ZContext();
             Socket worker = ctx.createSocket(ZMQ.DEALER);
             worker.setHWM (0);
-            worker.setIdentity("W".getBytes());
+            worker.setIdentity("W".getBytes(ZMQ.CHARSET));
             worker.connect("tcp://localhost:5556");
             while (!Thread.currentThread().isInterrupted()) {
                 ZMsg msg = ZMsg.recvMsg(worker);
@@ -83,7 +83,7 @@ public class tripping {
             ZContext ctx = new ZContext();
             Socket client = ctx.createSocket(ZMQ.DEALER);
             client.setHWM (0);
-            client.setIdentity("C".getBytes());
+            client.setIdentity("C".getBytes(ZMQ.CHARSET));
             client.connect("tcp://localhost:5555");
             System.out.println("Setting up test");
             try {

--- a/src/test/java/guide/wuclient.java
+++ b/src/test/java/guide/wuclient.java
@@ -20,7 +20,7 @@ public class wuclient {
 
         //  Subscribe to zipcode, default is NYC, 10001
         String filter = (args.length > 0) ? args[0] : "10001 ";
-        subscriber.subscribe(filter.getBytes());
+        subscriber.subscribe(filter.getBytes(ZMQ.CHARSET));
 
         //  Process 100 updates
         int update_nbr;

--- a/src/test/java/guide/wuproxy.java
+++ b/src/test/java/guide/wuproxy.java
@@ -22,7 +22,7 @@ public class wuproxy{
         backend.bind("tcp://10.1.1.0:8100");
 
         //  Subscribe on everything
-        frontend.subscribe("".getBytes());
+        frontend.subscribe(ZMQ.SUBSCRIPTION_ALL);
 
         //  Run the proxy until the user interrupts us
         ZMQ.proxy (frontend, backend, null);

--- a/src/test/java/org/jeromq/TestZDevice.java
+++ b/src/test/java/org/jeromq/TestZDevice.java
@@ -47,10 +47,10 @@ public class TestZDevice {
             s.connect( "tcp://127.0.0.1:6660");
             s.send("hellow", 0);
             Msg msg = s.recvMsg(0);
-            System.out.println(name + " got response1 " + new String(msg.data()));
+            System.out.println(name + " got response1 " + new String(msg.data(), ZMQ.CHARSET));
             s.send("world cup", 0);
             msg = s.recvMsg(0);
-            System.out.println(name + " got response2 " + new String(msg.data()));
+            System.out.println(name + " got response2 " + new String(msg.data(), ZMQ.CHARSET));
 
             s.close();
             System.out.println("Stop client thread " + name);
@@ -80,7 +80,7 @@ public class TestZDevice {
                 if (msg == null) {
                     throw new RuntimeException();
                 }
-                String identity = new String(msg.data(), 0 , msg.size());
+                String identity = new String(msg.data(), 0 , msg.size(), ZMQ.CHARSET);
                 System.out.println(name + " recieved cleint identity " + identity);
                 msg = s.recvMsg(0);
                 if (msg == null) {
@@ -92,7 +92,7 @@ public class TestZDevice {
                 if (msg == null) {
                     throw new RuntimeException();
                 }
-                String data = new String(msg.data(), 0 , msg.size());
+                String data = new String(msg.data(), 0 , msg.size(), ZMQ.CHARSET);
 
                 System.out.println(name + " recieved data " + msg + " " + data);
                 s.send(identity, ZMQ.SNDMORE);

--- a/src/test/java/org/zeromq/TestProxy.java
+++ b/src/test/java/org/zeromq/TestProxy.java
@@ -17,7 +17,7 @@ public class TestProxy
             s = ctx.socket(ZMQ.REQ);
             name = name_;
 
-            s.setIdentity(name.getBytes ());
+            s.setIdentity(name.getBytes (ZMQ.CHARSET));
         }
 
         @Override
@@ -40,7 +40,7 @@ public class TestProxy
             s = ctx.socket(ZMQ.DEALER);
             name = name_;
 
-            s.setIdentity(name.getBytes ());
+            s.setIdentity(name.getBytes (ZMQ.CHARSET));
         }
 
         @Override

--- a/src/test/java/org/zeromq/TestZMQ.java
+++ b/src/test/java/org/zeromq/TestZMQ.java
@@ -73,10 +73,10 @@ public class TestZMQ extends TestCase
             pull = context.socket(ZMQ.PULL);
             pull.bind("tcp://*:12344");
             push.connect("tcp://localhost:12344");
-            bb.put("PING".getBytes());
+            bb.put("PING".getBytes(ZMQ.CHARSET));
             bb.flip();
             push.sendByteBuffer(bb, 0);
-            String actual = new String(pull.recv());
+            String actual = new String(pull.recv(), ZMQ.CHARSET);
             assertEquals("PING", actual);
         } finally {
             try {
@@ -106,12 +106,12 @@ public class TestZMQ extends TestCase
             pull = context.socket(ZMQ.PULL);
             pull.bind("tcp://*:12345");
             push.connect("tcp://localhost:12345");
-            push.send("PING".getBytes(), 0);
+            push.send("PING".getBytes(ZMQ.CHARSET), 0);
             pull.recvByteBuffer(bb, 0);
             bb.flip();
             byte[] b = new byte[bb.remaining()];
             bb.duplicate().get(b);
-            assertEquals("PING", new String(b));
+            assertEquals("PING", new String(b, ZMQ.CHARSET));
         } finally {
             try {
                 push.close();

--- a/src/test/java/zmq/Helper.java
+++ b/src/test/java/zmq/Helper.java
@@ -142,7 +142,7 @@ public class Helper {
     
     public static void bounce (SocketBase sb, SocketBase sc)
     {
-        byte[] content = "12345678ABCDEFGH12345678abcdefgh".getBytes();
+        byte[] content = "12345678ABCDEFGH12345678abcdefgh".getBytes(ZMQ.CHARSET);
 
         //  Send the message.
         int rc = ZMQ.zmq_send (sc, content, 32, ZMQ.ZMQ_SNDMORE);
@@ -180,9 +180,9 @@ public class Helper {
     
     public static void send (Socket sa, String data) throws IOException
     {
-        byte[] content = data.getBytes();
+        byte[] content = data.getBytes(ZMQ.CHARSET);
 
-        byte[] length = String.format("%04d", content.length).getBytes();
+        byte[] length = String.format("%04d", content.length).getBytes(ZMQ.CHARSET);
 
         byte[] buf = new byte[1024];
         int reslen ;
@@ -209,10 +209,10 @@ public class Helper {
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
-        reslen = Integer.valueOf(new String(buf, 0, 4));
+        reslen = Integer.valueOf(new String(buf, 0, 4, ZMQ.CHARSET));
 
         in.read(buf, 0, reslen);
-        System.out.println("recv " + reslen + " " + new String(buf,0, reslen));
+        System.out.println("recv " + reslen + " " + new String(buf, 0, reslen, ZMQ.CHARSET));
         
     }
 

--- a/src/test/java/zmq/TestBlob.java
+++ b/src/test/java/zmq/TestBlob.java
@@ -33,7 +33,7 @@ public class TestBlob {
     public void testBlobMap() {
         HashMap<Blob, String> map = new HashMap<Blob, String>();
         
-        Blob b = new Blob("a".getBytes());
+        Blob b = new Blob("a".getBytes(ZMQ.CHARSET));
         map.put(b, "aa");
         
         assertThat(map.remove(b), notNullValue());

--- a/src/test/java/zmq/TestDecoder.java
+++ b/src/test/java/zmq/TestDecoder.java
@@ -45,7 +45,7 @@ public class TestDecoder {
     private int read_short_message (ByteBuffer buf) {
         buf.put((byte)6);
         buf.put((byte)0); // flag
-        buf.put("hello".getBytes());
+        buf.put("hello".getBytes(ZMQ.CHARSET));
         
         return buf.position();
     }
@@ -56,15 +56,15 @@ public class TestDecoder {
         buf.put((byte)201);
         buf.put((byte)0); // flag
         for (int i=0; i < 6; i++)
-            buf.put("0123456789".getBytes());
-        buf.put("01".getBytes());
+            buf.put("0123456789".getBytes(ZMQ.CHARSET));
+        buf.put("01".getBytes(ZMQ.CHARSET));
         return buf.position();
     }
 
     private int read_long_message2 (ByteBuffer buf) {
-        buf.put("23456789".getBytes());        
+        buf.put("23456789".getBytes(ZMQ.CHARSET));        
         for (int i=0; i < 13; i++)
-            buf.put("0123456789".getBytes());
+            buf.put("0123456789".getBytes(ZMQ.CHARSET));
         return buf.position();
     }
 
@@ -150,7 +150,7 @@ public class TestDecoder {
 
         private boolean read_header () {
             
-            assertThat (new String (header, 0, 6), is ("HEADER"));
+            assertThat (new String (header, 0, 6, ZMQ.CHARSET), is ("HEADER"));
             ByteBuffer b = ByteBuffer.wrap (header, 6, 4);
             size = b.getInt();
             
@@ -197,11 +197,11 @@ public class TestDecoder {
         assertThat(session.out.size(), is(1));
     }
     private void read_body(ByteBuffer in) {
-        in.put("1234567890".getBytes());
-        in.put("1234567890".getBytes());
+        in.put("1234567890".getBytes(ZMQ.CHARSET));
+        in.put("1234567890".getBytes(ZMQ.CHARSET));
     }
     private int read_header(ByteBuffer in) {
-        in.put("HEADER".getBytes());
+        in.put("HEADER".getBytes(ZMQ.CHARSET));
         in.putInt(20);
         return in.position();
     }

--- a/src/test/java/zmq/TestEncoder.java
+++ b/src/test/java/zmq/TestEncoder.java
@@ -47,7 +47,7 @@ public class TestEncoder {
     // as if it read data from socket
     private Msg read_short_message () {
         Msg msg = new Msg(5);
-        msg.put("hello".getBytes(),0);
+        msg.put("hello".getBytes(ZMQ.CHARSET),0);
         
         return msg;
     }
@@ -57,7 +57,7 @@ public class TestEncoder {
         
         Msg msg = new Msg(200);
         for (int i=0; i < 20; i++)
-            msg.put("0123456789".getBytes(), i*10);
+            msg.put("0123456789".getBytes(ZMQ.CHARSET), i*10);
         return msg;
     }
 
@@ -164,7 +164,7 @@ public class TestEncoder {
                 return false;
             }
             header.clear();
-            header.put("HEADER".getBytes());
+            header.put("HEADER".getBytes(ZMQ.CHARSET));
             header.putInt(msg.size());
             header.flip();
             next_step(header.array (), 10, read_header, !msg.has_more());
@@ -191,9 +191,9 @@ public class TestEncoder {
         write(out);
         byte[] data = sock.data();
 
-        assertThat(new String(data,0, 6), is("HEADER"));
+        assertThat(new String(data, 0, 6, ZMQ.CHARSET), is("HEADER"));
         assertThat((int)data[9], is(20));
-        assertThat(new String(data,10, 20), is("12345678901234567890"));
+        assertThat(new String(data, 10, 20, ZMQ.CHARSET), is("12345678901234567890"));
         
     }
 }

--- a/src/test/java/zmq/TestProxyTcp.java
+++ b/src/test/java/zmq/TestProxyTcp.java
@@ -74,7 +74,7 @@ public class TestProxyTcp {
                     throw new RuntimeException("hello");
                 }
                 System.out.println("REP recieved " + msg);
-                String data = new String(msg.data(), 0 , msg.size());
+                String data = new String(msg.data(), 0 , msg.size(), ZMQ.CHARSET);
 
                 Msg response = null;
                 if (i%3 == 2) {
@@ -131,7 +131,7 @@ public class TestProxyTcp {
         }
 
         private boolean read_header() {
-            size = Integer.parseInt(new String(header));
+            size = Integer.parseInt(new String(header, ZMQ.CHARSET));
             System.out.println("Received " + size);
             msg = new Msg(size);
             next_step(msg, read_body);
@@ -144,7 +144,7 @@ public class TestProxyTcp {
             if (msg_sink == null)
                 return false;
             
-            System.out.println("Received body " + new String(msg.data()));
+            System.out.println("Received body " + new String(msg.data(), ZMQ.CHARSET));
             
             if (!identity_sent) {
                 Msg identity = new Msg();
@@ -238,7 +238,7 @@ public class TestProxyTcp {
             System.out.println ("write header " + msg.size());
 
             header.clear ();
-            header.put (String.format("%04d", msg.size()).getBytes());
+            header.put (String.format("%04d", msg.size()).getBytes(ZMQ.CHARSET));
             header.flip ();
             next_step (header.array (), 4, write_body, false);
             return true;

--- a/src/test/java/zmq/TestReqrepDevice.java
+++ b/src/test/java/zmq/TestReqrepDevice.java
@@ -84,13 +84,13 @@ public class TestReqrepDevice {
         //  Receive the request.
         msg = ZMQ.zmq_recv (rep, 0);
         assertThat (msg.size() , is(3));
-        buff = new String(msg.data());
+        buff = new String(msg.data(), ZMQ.CHARSET);
         assertThat (buff , is("ABC"));
         rcvmore = ZMQ.zmq_getsockopt (rep, ZMQ.ZMQ_RCVMORE);
         assertThat (rcvmore>0, is(true));
         msg = ZMQ.zmq_recv (rep, 0);
         assertThat (msg.size(), is( 4));
-        buff = new String(msg.data());
+        buff = new String(msg.data(), ZMQ.CHARSET);
         assertThat (buff, is("DEFG") );
         rcvmore = ZMQ.zmq_getsockopt (rep, ZMQ.ZMQ_RCVMORE);
         assertThat (rcvmore, is(0L));
@@ -115,13 +115,13 @@ public class TestReqrepDevice {
         //  Receive the reply.
         msg = ZMQ.zmq_recv (req, 0);
         assertThat (msg.size() , is(6));
-        buff = new String(msg.data());
+        buff = new String(msg.data(), ZMQ.CHARSET);
         assertThat (buff , is("GHIJKL"));
         rcvmore = ZMQ.zmq_getsockopt (req, ZMQ.ZMQ_RCVMORE);
         assertThat (rcvmore>0, is(true));
         msg = ZMQ.zmq_recv (req, 0);
         assertThat (msg.size(), is( 2));
-        buff = new String(msg.data());
+        buff = new String(msg.data(), ZMQ.CHARSET);
         assertThat (buff, is("MN") );
         rcvmore = ZMQ.zmq_getsockopt (req, ZMQ.ZMQ_RCVMORE);
         assertThat (rcvmore, is(0L));

--- a/src/test/java/zmq/TestYQueue.java
+++ b/src/test/java/zmq/TestYQueue.java
@@ -38,7 +38,7 @@ public class TestYQueue {
         Msg m5 = new Msg(5);
         Msg m6 = new Msg(6);
         Msg m7 = new Msg(7);
-        m7.put("1234567".getBytes(),0);
+        m7.put("1234567".getBytes(ZMQ.CHARSET),0);
 
         p.push(m1); 
         assertThat(p.back_pos(), is(1));


### PR DESCRIPTION
Don't know your opinion, but personally I avoid to the maximum any call to .getBytes() or new String or equivalent calls that assumes a default charset from the environment.
