### PR TITLE
re-resolve tcp addresses on reconnections

### DIFF
--- a/src/main/java/zmq/Address.java
+++ b/src/main/java/zmq/Address.java
@@ -20,58 +20,57 @@
 package zmq;
 
 import java.net.InetSocketAddress;
+import java.net.Inet6Address;
 import java.net.SocketAddress;
 
 public class Address {
 
     public static interface IZAddress {
-
         String toString();
         void resolve(String name_, boolean ip4only_);
         SocketAddress address();
     };
-    
-    final private String protocol;
-    final private String address;
-    
+
+    private final String protocol;
+    private final String address;
+    private final boolean ipv4only;
+
     private IZAddress resolved;
-    
-    public Address(final String protocol_, final String address_) {
+
+    public Address(final String protocol_, final String address_, final boolean ipv4only_) {
         protocol = protocol_;
         address = address_;
+        ipv4only = ipv4only_;
         resolved = null;
     }
-    
+
     public Address(SocketAddress sockaddr_) {
-        protocol = "tcp";
         InetSocketAddress sockaddr = (InetSocketAddress)sockaddr_;
         address = sockaddr.getAddress().getHostAddress() + ":" + sockaddr.getPort();
+        protocol = "tcp";
+        resolved = null;
+        ipv4only = !(sockaddr.getAddress() instanceof Inet6Address);
     }
 
     @Override
     public String toString() {
-        if (protocol.equals("tcp")) {
-            if (resolved != null) {
-                return resolved.toString();
-            }
-        }   
-        else if (protocol.equals("ipc")) {
-            if (resolved != null) {
-                return resolved.toString();
-            }
-        }   
-
-        if (!protocol.isEmpty() && !address.isEmpty ()) {
-            return protocol + "://" + address;
+        if (protocol.equals("tcp") && isResolved()) {
+            return resolved.toString();
         }
-        
-        return "";
+        else if (protocol.equals("ipc") && isResolved()) {
+            return resolved.toString();
+        }
+        else if (!protocol.isEmpty() && !address.isEmpty ()) {
+            return protocol + "://" + address;
+        } else {
+            return "";
+        }
     }
 
     public String protocol() {
         return protocol;
     }
-    
+
     public String address() {
         return address;
     }
@@ -80,9 +79,23 @@ public class Address {
         return resolved;
     }
 
-    public IZAddress resolved(IZAddress value) {
-        resolved = value;
-        return resolved;
+    public boolean isResolved() {
+        return resolved != null;
     }
 
+    public boolean resolve() {
+       if (protocol.equals("tcp")) {
+            resolved = new TcpAddress();
+            resolved.resolve(address, ipv4only);
+            return true;
+        }
+        else if (protocol.equals("ipc")) {
+            resolved = new IpcAddress();
+            resolved.resolve(address, true);
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
 }

--- a/src/test/java/zmq/Helper.java
+++ b/src/test/java/zmq/Helper.java
@@ -2,19 +2,19 @@
     Copyright (c) 2007-2012 iMatix Corporation
     Copyright (c) 2011 250bpm s.r.o.
     Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
-                
+
     This file is part of 0MQ.
 
     0MQ is free software; you can redistribute it and/or modify it under
     the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation; either version 3 of the License, or
     (at your option) any later version.
-            
+
     0MQ is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU Lesser General Public License for more details.
-        
+
     You should have received a copy of the GNU Lesser General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -35,16 +35,16 @@ import static org.hamcrest.CoreMatchers.*;
 public class Helper {
 
     public static AtomicInteger counter = new AtomicInteger(2);
-    
+
     public static class DummyCtx extends Ctx {
-        
+
     }
-    
+
     public static class DummySocketChannel implements WritableByteChannel {
 
         private int bufsize;
         private byte[] buf;
-        
+
         public DummySocketChannel() {
             this(64);
         }
@@ -52,19 +52,19 @@ public class Helper {
             this.bufsize = bufsize;
             buf = new byte[bufsize];
         }
-        
+
         public byte[] data () {
             return buf;
         }
         @Override
         public void close() throws IOException {
-            
+
         }
         @Override
         public boolean isOpen() {
             return true;
         }
-        
+
         @Override
         public int write(ByteBuffer src) throws IOException {
             int remaining = src.remaining();
@@ -78,16 +78,16 @@ public class Helper {
         }
 
     }
-    
+
     public static DummyCtx CTX = new DummyCtx();
-    
+
     public static class DummyIOThread extends IOThread {
 
         public DummyIOThread() {
             super(CTX, 2);
         }
     }
-    
+
     public static class DummySocket extends SocketBase {
 
         public DummySocket() {
@@ -102,22 +102,22 @@ public class Helper {
         @Override
         protected void xterminated(Pipe pipe_) {
         }
-        
+
     }
-    
+
     public static class DummySession extends SessionBase {
 
         public List<Msg> out = new ArrayList<Msg>();
-        
+
         public DummySession () {
-            this(new DummyIOThread(),  false, new DummySocket(), new Options(), new Address("tcp", "localhost:9090"));
+            this(new DummyIOThread(),  false, new DummySocket(), new Options(), new Address("tcp", "localhost:9090", false));
         }
-        
+
         public DummySession(IOThread io_thread_, boolean connect_,
                 SocketBase socket_, Options options_, Address addr_) {
             super(io_thread_, connect_, socket_, options_, addr_);
         }
-        
+
         @Override
         public int push_msg (Msg msg)
         {
@@ -125,21 +125,21 @@ public class Helper {
             out.add(msg);
             return 0;
         }
-        
+
         @Override
-        public Msg pull_msg () 
+        public Msg pull_msg ()
         {
             System.out.println("session.read " + out);
             if (out.size() == 0) {
                 return null;
             }
             Msg msg = out.remove(0);
-            
+
             return msg;
         }
-        
+
     }
-    
+
     public static void bounce (SocketBase sb, SocketBase sc)
     {
         byte[] content = "12345678ABCDEFGH12345678abcdefgh".getBytes(ZMQ.CHARSET);
@@ -177,7 +177,7 @@ public class Helper {
         //  Check whether the message is still the same.
         //assert (memcmp (buf2, content, 32) == 0);
     }
-    
+
     public static void send (Socket sa, String data) throws IOException
     {
         byte[] content = data.getBytes(ZMQ.CHARSET);
@@ -193,7 +193,7 @@ public class Helper {
 
         out.write(length);
         out.write(content);
-        
+
         System.out.println("sent " + data.length() + " " + data);
         int to_read = 4; // 4 + greeting_size
         int read = 0;
@@ -201,7 +201,7 @@ public class Helper {
             rc = in.read(buf, read, to_read);
             read += rc;
             to_read -= rc;
-            System.out.println("read " + rc + " total_read " + read + " to_read " + to_read); 
+            System.out.println("read " + rc + " total_read " + read + " to_read " + to_read);
         }
         System.out.println(String.format("%02x %02x %02x %02x", buf[0], buf[1], buf[2], buf[3]));
         try {
@@ -213,7 +213,7 @@ public class Helper {
 
         in.read(buf, 0, reslen);
         System.out.println("recv " + reslen + " " + new String(buf, 0, reslen, ZMQ.CHARSET));
-        
+
     }
 
 }

--- a/src/test/java/zmq/TestAddress.java
+++ b/src/test/java/zmq/TestAddress.java
@@ -2,26 +2,24 @@
     Copyright (c) 2007-2012 iMatix Corporation
     Copyright (c) 2011 250bpm s.r.o.
     Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
-                
+
     This file is part of 0MQ.
 
     0MQ is free software; you can redistribute it and/or modify it under
     the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation; either version 3 of the License, or
     (at your option) any later version.
-            
+
     0MQ is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU Lesser General Public License for more details.
-        
+
     You should have received a copy of the GNU Lesser General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 package zmq;
 
-
-import org.junit.Ignore;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.*;
@@ -30,33 +28,21 @@ public class TestAddress {
 
     @Test
     public void ToNotResolvedToString() {
-        Address addr = new Address("tcp", "localhost:90");
-        
+        Address addr = new Address("tcp", "google.com:90", false);
         String saddr = addr.toString();
-        assertThat(saddr, is("tcp://localhost:90"));
-    }
-    
-    @Test
-    public void testResolvedToString() {
-        Address addr = new Address("tcp", "google.com:90");
-        addr.resolved(new TcpAddress());
-        addr.resolved().resolve("google.com:90", false);
-        
-        String saddr = addr.toString();
-        //assertThat(saddr, is("tcp://tf-1in-f101.le100.net:90"));
-        System.out.println(saddr);
-
-        addr.resolved(null);
-        saddr = addr.toString();
         assertThat(saddr, is("tcp://google.com:90"));
     }
 
+    @Test
+    public void testResolvedToString() {
+        Address addr = new Address("tcp", "google.com:90", false);
+        addr.resolve();
+        String resolved = addr.toString();
+        assertTrue(resolved.matches("tcp://\\d+\\.\\d+\\.\\d+\\.\\d+:90"));
+    }
+
     @Test(expected=IllegalArgumentException.class)
-    @Ignore
     public void testInvaid() {
-        
-        Address addr = new Address("tcp", "ggglocalhostxxx:90");
-        addr.resolved(new TcpAddress());
-        addr.resolved().resolve("ggglocalhostxxx:90", false);
+        new Address("tcp", "ggglocalhostxxx:90", false).resolve();
     }
 }


### PR DESCRIPTION
Resolve the address on `add_reconnect_timer`, to tolerate DNS changes.

This might look expensive but in reality, the code eventually calls `InetAddress.getByName` which is cached internally in the jdk and also configurable, (see http://stackoverflow.com/questions/12099526/setting-java-dns-cache-ttl) so not only you get tolerance to DNS changes but also respect what the user chose as it's DNS ttl timeout.

Note: the patch removes some extra whitespace, to focus on the important part of the patch add ?w=1 to the url:

https://github.com/zeromq/jeromq/pull/129/files?w=1
