### PR TITLE
Throw an exception if the ByteBuffer provided to Msg is not flipped

### DIFF
--- a/src/main/java/zmq/Msg.java
+++ b/src/main/java/zmq/Msg.java
@@ -81,8 +81,12 @@ public class Msg {
     }
 
     public Msg(final ByteBuffer src) {
-        if (src == null)
+        if (src == null) {
             throw new IllegalArgumentException("ByteBuffer cannot be null");
+        }
+        if (src.position() > 0) {
+            throw new IllegalArgumentException("ByteBuffer position is not zero, did you forget to flip it?");
+        }
         this.type = TYPE_LMSG;
         this.flags = 0;
         this.buf = src.duplicate();

--- a/src/test/java/zmq/TestMsg.java
+++ b/src/test/java/zmq/TestMsg.java
@@ -1,0 +1,54 @@
+/*
+    Copyright (c) 2009-2011 250bpm s.r.o.
+    Copyright (c) 2007-2009 iMatix Corporation
+    Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
+
+    This file is part of 0MQ.
+
+    0MQ is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    0MQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package zmq;
+
+import org.junit.*;
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestMsg {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowForNullByteBuffer() {
+        new Msg((ByteBuffer)null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowForBufferWithWrongPosition() {
+        ByteBuffer buffer = ByteBuffer.allocate(10);
+        buffer.putChar('a');
+        buffer.putChar('b');
+        buffer.putChar('c');
+        new Msg(buffer);
+    }
+
+    @Test
+    public void shouldWorkForFlippedBuffers() {
+        ByteBuffer buffer = ByteBuffer.allocate(10);
+        buffer.putChar('a');
+        buffer.putChar('b');
+        buffer.putChar('c');
+        buffer.flip();
+        new Msg(buffer);
+    }
+}


### PR DESCRIPTION
`ByteBuffer`s passed to `sendByteBuffer` must be "flipped" previously (their position reset to zero). Not doing this doesn't throw but instead causes zmq to behave erratically.

This pull request verifies that the buffer is effectively flipped. Test cases added for extra safety.
