### PR TITLE
Adds lazy create context to getContext() method

### DIFF
--- a/src/main/java/org/zeromq/ZContext.java
+++ b/src/main/java/org/zeromq/ZContext.java
@@ -215,6 +215,8 @@ public class ZContext implements Closeable
      * @return the context
      */
     public Context getContext() {
+        if (context == null)
+            context = ZMQ.context (ioThreads);
         return context;
     }
 


### PR DESCRIPTION
Need to work with the context object before a socket is opened e.g. to create poller object.
