### PR TITLE
Fix: recvFrame() method of ZFrame does not return null if no data available

### DIFF
--- a/src/main/java/org/zeromq/ZFrame.java
+++ b/src/main/java/org/zeromq/ZFrame.java
@@ -356,7 +356,8 @@ public class ZFrame {
      */ 
     public static ZFrame recvFrame(Socket socket, int flags) {
         ZFrame f = new ZFrame ();
-        f.recv(socket, flags);
+        byte [] data = f.recv(socket, flags);
+        if (data == null) return null;
         return f;
     }
 

--- a/src/main/java/org/zeromq/ZMsg.java
+++ b/src/main/java/org/zeromq/ZMsg.java
@@ -646,4 +646,23 @@ public class ZMsg implements Iterable<ZFrame>, Deque<ZFrame> {
     public int size() {
         return frames.size();
     }
+
+    /**
+     * Returns pretty string representation of multipart message:
+     * [ frame0, frame1, ..., frameN ]
+     *
+     * @return toString version of ZMsg object
+     */
+    @Override
+    public String toString() {
+        StringBuilder out = new StringBuilder("[ ");
+        Iterator<ZFrame> frameIterator = frames.iterator();
+        while (frameIterator.hasNext()) {
+            out.append(frameIterator.next());
+            if (frameIterator.hasNext()) out.append(", "); // skip last iteration
+        }
+        out.append(" ]");
+        return out.toString();
+    }
+
 }

--- a/src/test/java/org/zeromq/ZMsgTest.java
+++ b/src/test/java/org/zeromq/ZMsgTest.java
@@ -1,0 +1,45 @@
+package org.zeromq;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Created by hartmann on 3/21/14.
+ */
+public class ZMsgTest {
+
+    @Test
+    public void testRecvFrame() throws Exception {
+        ZMQ.Context ctx = ZMQ.context(0);
+        ZMQ.Socket  socket   = ctx.socket(ZMQ.PULL);
+
+        ZFrame f = ZFrame.recvFrame(socket, ZMQ.NOBLOCK);
+        Assert.assertNull(f);
+    }
+
+    @Test
+    public void testRecvMsg() throws Exception {
+        ZMQ.Context ctx = ZMQ.context(0);
+        ZMQ.Socket  socket   = ctx.socket(ZMQ.PULL);
+
+        ZMsg msg = ZMsg.recvMsg(socket, ZMQ.NOBLOCK);
+        Assert.assertNull(msg);
+    }
+
+    @Test
+    public void testRecvNullByteMsg() throws Exception {
+        ZMQ.Context ctx = ZMQ.context(0);
+        ZMQ.Socket sender = ctx.socket(ZMQ.PUSH);
+        ZMQ.Socket receiver = ctx.socket(ZMQ.PULL);
+
+        receiver.bind("inproc://" + this.hashCode());
+        sender.connect("inproc://" +this.hashCode());
+
+        sender.send(new byte[0]);
+        ZMsg msg = ZMsg.recvMsg(receiver, ZMQ.NOBLOCK);
+        Assert.assertNotNull(msg);
+    }
+
+
+
+}


### PR DESCRIPTION
Fixes issue #148
