### PR TITLE
Remove public method declaration in interfaces

### DIFF
--- a/src/main/java/zmq/IDecoder.java
+++ b/src/main/java/zmq/IDecoder.java
@@ -23,11 +23,11 @@ import java.nio.ByteBuffer;
 
 public interface IDecoder
 {
-    public void setMsgSink(IMsgSink msgSink);
+    void setMsgSink(IMsgSink msgSink);
 
-    public ByteBuffer getBuffer();
+    ByteBuffer getBuffer();
 
-    public int processBuffer(ByteBuffer buffer, int size);
+    int processBuffer(ByteBuffer buffer, int size);
 
-    public boolean stalled();
+    boolean stalled();
 }

--- a/src/main/java/zmq/IEncoder.java
+++ b/src/main/java/zmq/IEncoder.java
@@ -24,12 +24,12 @@ import java.nio.ByteBuffer;
 public interface IEncoder
 {
     //  Set message producer.
-    public void setMsgSource(IMsgSource msgSource);
+    void setMsgSource(IMsgSource msgSource);
 
     //  The function returns a batch of binary data. The data
     //  are filled to a supplied buffer. If no buffer is supplied (data_
     //  is null) encoder will provide buffer of its own.
-    public Transfer getData(ByteBuffer buffer);
+    Transfer getData(ByteBuffer buffer);
 
-    public boolean hasData();
+    boolean hasData();
 }

--- a/src/main/java/zmq/IMsgSink.java
+++ b/src/main/java/zmq/IMsgSink.java
@@ -23,5 +23,5 @@ public interface IMsgSink
 {
     //  Delivers a message. Returns true if successful; false otherwise.
     //  The function takes ownership of the passed message.
-    public int pushMsg(Msg msg);
+    int pushMsg(Msg msg);
 }

--- a/src/main/java/zmq/IMsgSource.java
+++ b/src/main/java/zmq/IMsgSource.java
@@ -22,5 +22,5 @@ package zmq;
 public interface IMsgSource
 {
     //  Fetch a message. Returns a Msg instance if successful; null otherwise.
-    public Msg pullMsg();
+    Msg pullMsg();
 }

--- a/src/main/java/zmq/Transfer.java
+++ b/src/main/java/zmq/Transfer.java
@@ -26,8 +26,8 @@ import java.nio.channels.WritableByteChannel;
 
 public interface Transfer
 {
-    public int transferTo(WritableByteChannel s) throws IOException;
-    public int remaining();
+    int transferTo(WritableByteChannel s) throws IOException;
+    int remaining();
 
     public static class ByteBufferTransfer implements Transfer
     {


### PR DESCRIPTION
All abstract, default, and static methods in an interface are implicitly public, so you can omit the public modifier.
