### PR TITLE
ADD: Ability to send an optional UncaughtExceptionHandler to the context

### DIFF
--- a/src/main/java/org/zeromq/ZContext.java
+++ b/src/main/java/org/zeromq/ZContext.java
@@ -69,6 +69,9 @@ public class ZContext implements Closeable
      * (useful for multi-threaded applications)
      */
     private boolean main;
+    
+    // UncaughtExceptionHandler for handling uncaught exceptions outside of JeroMQ
+    private Thread.UncaughtExceptionHandler eh;
 
     /**
      * Class Constructor
@@ -76,6 +79,17 @@ public class ZContext implements Closeable
     public ZContext()
     {
         this(1);
+    }
+    
+    public ZContext(Thread.UncaughtExceptionHandler eh)
+    {
+        this(1, eh);
+    }
+    
+    public ZContext(int ioThreads, Thread.UncaughtExceptionHandler eh)
+    {
+        this(ioThreads);
+        this.eh = eh;
     }
 
     public ZContext(int ioThreads)
@@ -85,7 +99,7 @@ public class ZContext implements Closeable
         linger = 0;
         main = true;
     }
-
+    
     /**
      * Destructor.  Call this to gracefully terminate context and close any managed 0MQ sockets
      */
@@ -238,7 +252,13 @@ public class ZContext implements Closeable
             synchronized (this) {
                 result = context;
                 if (result == null) {
-                    result = ZMQ.context(ioThreads);
+                    if(this.eh == null)
+                    {
+                        result = ZMQ.context(ioThreads);
+                    }else
+                    {
+                        result = ZMQ.context(ioThreads, this.eh);
+                    }
                     context = result;
                 }
             }

--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -253,6 +253,20 @@ public class ZMQ
     {
         return new Context(ioThreads);
     }
+    
+    /**
+     * Create a new Context with UncaughtExceptionHandler.
+     *
+     * @param ioThreads
+     *            Number of threads to use, usually 1 is sufficient for most use cases.
+     * @param eh
+     *            UncaughtExceptionHandler for the worker threads
+     * @return the Context
+     */
+    public static Context context(int ioThreads, Thread.UncaughtExceptionHandler eh)
+    {
+        return new Context(ioThreads, eh);
+    }
 
     public static class Context implements Closeable
     {
@@ -267,6 +281,19 @@ public class ZMQ
         protected Context(int ioThreads)
         {
             ctx = zmq.ZMQ.zmqInit(ioThreads);
+        }
+        
+        /**
+         * Class constructor with UncaughtExceptionHandler.
+         *
+         * @param ioThreads
+         *            size of the threads pool to handle I/O operations.
+         * @param eh
+         *            UncaughtExceptionHandler for the worker threads
+         */
+        protected Context(int ioThreads, Thread.UncaughtExceptionHandler eh)
+        {
+            ctx = zmq.ZMQ.zmqInit(ioThreads, eh);
         }
 
         /**

--- a/src/main/java/zmq/Ctx.java
+++ b/src/main/java/zmq/Ctx.java
@@ -110,6 +110,15 @@ public class Ctx
 
     public static final int TERM_TID = 0;
     public static final int REAPER_TID = 1;
+    
+    // UncaughtExceptionHandler, optionally sent when creating context
+    private Thread.UncaughtExceptionHandler eh;
+    
+    public Ctx(Thread.UncaughtExceptionHandler eh)
+    {
+        this();
+        this.eh = eh;
+    }
 
     public Ctx()
     {
@@ -283,7 +292,14 @@ public class Ctx
 
                 //  Create I/O thread objects and launch them.
                 for (int i = 2; i != ios + 2; i++) {
-                    IOThread ioThread = new IOThread(this, i);
+                    IOThread ioThread;
+                    if(this.eh == null)
+                    {
+                        ioThread = new IOThread(this, i);
+                    }else
+                    {
+                        ioThread = new IOThread(this, i, this.eh);
+                    }
                     //alloc_assert (io_thread);
                     ioThreads.add(ioThread);
                     slots[i] = ioThread.getMailbox();

--- a/src/main/java/zmq/IOThread.java
+++ b/src/main/java/zmq/IOThread.java
@@ -33,6 +33,19 @@ public class IOThread extends ZObject implements IPollEvents
     private final Poller poller;
 
     final String name;
+    
+    // Constructor with UncaughtExceptionHandler
+    public IOThread(Ctx ctx, int tid, Thread.UncaughtExceptionHandler eh)
+    {
+        super(ctx, tid);
+        name = "iothread-" + tid;
+        poller = new Poller(name, eh);
+
+        mailbox = new Mailbox(name);
+        mailboxHandle = mailbox.getFd();
+        poller.addHandle(mailboxHandle, this);
+        poller.setPollIn(mailboxHandle);
+    }
 
     public IOThread(Ctx ctx, int tid)
     {

--- a/src/main/java/zmq/Poller.java
+++ b/src/main/java/zmq/Poller.java
@@ -59,10 +59,24 @@ public class Poller extends PollerBase implements Runnable
     private Thread worker;
     private Selector selector;
     private final String name;
+    
+    // UncaughtExceptionHandler, optionally sent when creating context
+    private Thread.UncaughtExceptionHandler eh;
 
     public Poller()
     {
         this("poller");
+    }
+    
+    public Poller(Thread.UncaughtExceptionHandler eh)
+    {
+        this("poller", eh);
+    }
+    
+    public Poller(String name, Thread.UncaughtExceptionHandler eh)
+    {
+        this(name);
+        this.eh = eh;
     }
 
     public Poller(String name)
@@ -167,6 +181,9 @@ public class Poller extends PollerBase implements Runnable
     public void start()
     {
         worker = new Thread(this, name);
+        if(this.eh != null){
+            worker.setUncaughtExceptionHandler(this.eh);
+        }
         worker.start();
     }
 

--- a/src/main/java/zmq/ZMQ.java
+++ b/src/main/java/zmq/ZMQ.java
@@ -244,6 +244,14 @@ public class ZMQ
         Ctx ctx = new Ctx();
         return ctx;
     }
+    
+    //  New context API with UncaughtExceptionHandler
+    public static Ctx zmq_ctx_new(Thread.UncaughtExceptionHandler eh)
+    {
+        //  Create 0MQ context.
+        Ctx ctx = new Ctx(eh);
+        return ctx;
+    }
 
     private static void zmq_ctx_destroy(Ctx ctx)
     {
@@ -275,6 +283,17 @@ public class ZMQ
     {
         if (ioThreads >= 0) {
             Ctx ctx = zmq_ctx_new();
+            zmq_ctx_set(ctx, ZMQ_IO_THREADS, ioThreads);
+            return ctx;
+        }
+        throw new IllegalArgumentException("io_threds must not be negative");
+    }
+    
+    //  Stable/legacy context API with UncaughtExceptionHandler
+    public static Ctx zmqInit(int ioThreads, Thread.UncaughtExceptionHandler eh)
+    {
+        if (ioThreads >= 0) {
+            Ctx ctx = zmq_ctx_new(eh);
             zmq_ctx_set(ctx, ZMQ_IO_THREADS, ioThreads);
             return ctx;
         }


### PR DESCRIPTION
I've added a couple of constructors, and I'm testing for null values where necessary, so one can choose whether or not to use the context with an UncaughtExceptionHandler.
As previously mentioned, I'm not sure if this is best practice, but it makes it easy to close and re-open socket connections when the thread terminates. Hope it's of some use to you.