### PR TITLE
Fix issue #139 for inproc protocol (follow-up to pull request #142)

### DIFF
--- a/src/main/java/zmq/SocketBase.java
+++ b/src/main/java/zmq/SocketBase.java
@@ -339,6 +339,8 @@ public abstract class SocketBase extends Own
             if (rc) {
                 // Save last endpoint URI
                 options.lastEndpoint = addr;
+            }
+            else {
                 errno.set(ZError.EADDRINUSE);
             }
             return rc;

--- a/src/test/java/org/zeromq/TestZMQ.java
+++ b/src/test/java/org/zeromq/TestZMQ.java
@@ -187,6 +187,30 @@ public class TestZMQ
         }
     }
 
+    @Test(expected = ZMQException.class)
+    public void testBindInprocSameAddress()
+    {
+        ZMQ.Context context = ZMQ.context(1);
+
+        ZMQ.Socket socket1 = context.socket(ZMQ.REQ);
+        ZMQ.Socket socket2 = context.socket(ZMQ.REQ);
+        socket1.bind("inproc://address.already.in.use");
+        try {
+            socket2.bind("inproc://address.already.in.use");
+            fail("Exception not thrown");
+        }
+        catch (ZMQException e) {
+            assertEquals(e.getErrorCode(), ZMQ.Error.EADDRINUSE.getCode());
+            throw e;
+        }
+        finally {
+            socket1.close();
+            socket2.close();
+
+            context.term();
+        }
+    }
+
     @Test
     public void testEventConnected()
     {


### PR DESCRIPTION
Currently exception is not thrown in case bind fails for `inproc` protocol.
