### PR TITLE
Change ZMQ.bind() method to return void.

### DIFF
--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -1158,9 +1158,9 @@ public class ZMQ
          * @param addr
          *            the endpoint to bind to.
          */
-        public final int bind(String addr)
+        public final void bind(String addr)
         {
-            return bind(addr, DYNFROM, DYNTO);
+            bind(addr, DYNFROM, DYNTO);
         }
 
         /**

--- a/src/test/java/org/zeromq/TestProxy.java
+++ b/src/test/java/org/zeromq/TestProxy.java
@@ -23,7 +23,6 @@ import org.zeromq.ZMQ.Context;
 import org.zeromq.ZMQ.Socket;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class TestProxy
@@ -116,22 +115,21 @@ public class TestProxy
         @Override
         public void run()
         {
-            int port;
             Socket frontend = ctx.socket(ZMQ.ROUTER);
 
             assertNotNull(frontend);
-            port = frontend.bind("tcp://127.0.0.1:6660");
-            assertEquals(port, 6660);
+            frontend.bind("tcp://127.0.0.1:6660");
 
             Socket backend = ctx.socket(ZMQ.DEALER);
             assertNotNull(backend);
-            port = backend.bind("tcp://127.0.0.1:6661");
-            assertEquals(port, 6661);
+            backend.bind("tcp://127.0.0.1:6661");
 
             ZMQ.proxy(frontend, backend, null);
 
             frontend.close();
             backend.close();
+
+            assert true;
         }
 
     }

--- a/src/test/java/org/zeromq/TestZProxy.java
+++ b/src/test/java/org/zeromq/TestZProxy.java
@@ -27,12 +27,11 @@ public class TestZProxy
 
             public void configure(Socket socket, ZProxy.Plug place, Object[] extrArgs)
             {
-                int port = -1;
                 if (place == ZProxy.Plug.FRONT) {
-                    port = socket.bind("tcp://127.0.0.1:6660");
+                    socket.bind("tcp://127.0.0.1:6660");
                 }
                 if (place == ZProxy.Plug.BACK) {
-                    port = socket.bind("tcp://127.0.0.1:6661");
+                    socket.bind("tcp://127.0.0.1:6661");
                 }
                 if (place == ZProxy.Plug.CAPTURE && socket != null) {
                     socket.bind("tcp://127.0.0.1:4263");
@@ -42,19 +41,17 @@ public class TestZProxy
             @Override
             public boolean restart(ZMsg cfg, Socket socket, ZProxy.Plug place, Object[] extraArgs)
             {
-                boolean rc = false;
-                int port = -1;
                 if (place == ZProxy.Plug.FRONT) {
-                    rc = socket.unbind("tcp://127.0.0.1:6660");
-                    port = socket.bind("tcp://127.0.0.1:6660");
+                    socket.unbind("tcp://127.0.0.1:6660");
+                    socket.bind("tcp://127.0.0.1:6660");
                 }
                 if (place == ZProxy.Plug.BACK) {
-                    rc = socket.unbind("tcp://127.0.0.1:6661");
-                    port = socket.bind("tcp://127.0.0.1:6661");
+                    socket.unbind("tcp://127.0.0.1:6661");
+                    socket.bind("tcp://127.0.0.1:6661");
                 }
                 if (place == ZProxy.Plug.CAPTURE && socket != null) {
-                    rc = socket.unbind("tcp://127.0.0.1:4263");
-                    port = socket.bind("tcp://127.0.0.1:5347");
+                    socket.unbind("tcp://127.0.0.1:4263");
+                    socket.bind("tcp://127.0.0.1:5347");
                 }
                 return false;
             }


### PR DESCRIPTION
ZMQ.bind method changed because is used when the port is known and  no sense return the port. Also, with this change, jeromq would have the same contract that JZMQ and ZeroMQ-Scala-Binding. Finally, most importantly, this change would use scala-zeromq library with jeromq, for now, this library only allows use with the two mentioned above libraries.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/zeromq/jeromq/239)
<!-- Reviewable:end -->
