### PR TITLE
ZFrame.toString() – Break loop on finding the first non-printable character

### DIFF
--- a/src/main/java/org/zeromq/ZFrame.java
+++ b/src/main/java/org/zeromq/ZFrame.java
@@ -328,6 +328,7 @@ public class ZFrame
         for (byte aData : data) {
             if (aData < 32) {
                 isText = false;
+                break;
             }
         }
         if (isText) {


### PR DESCRIPTION
Whether a byte stream is printable or not can be determined on finding the first ASCII value that is not printable. Without `break`, a full iteration over the byte array will be performed.