### PR TITLE
Make java threads into daemons.

### DIFF
--- a/src/main/java/org/zeromq/ZBeacon.java
+++ b/src/main/java/org/zeromq/ZBeacon.java
@@ -65,7 +65,9 @@ public class ZBeacon
         }
 
         broadcastServer = new BroadcastServer(ignoreLocalAddress);
+        broadcastServer.setDaemon(true);
         broadcastClient = new BroadcastClient();
+        broadcastClient.setDaemon(true);
     }
 
     public void start()

--- a/src/main/java/org/zeromq/ZThread.java
+++ b/src/main/java/org/zeromq/ZThread.java
@@ -86,6 +86,7 @@ public class ZThread
     {
         //  Prepare child thread
         Thread shim = new ShimThread(runnable, args);
+        shim.setDaemon(true);
         shim.start();
     }
 

--- a/src/main/java/zmq/Poller.java
+++ b/src/main/java/zmq/Poller.java
@@ -167,6 +167,7 @@ public class Poller extends PollerBase implements Runnable
     public void start()
     {
         worker = new Thread(this, name);
+        worker.setDaemon(true);
         worker.start();
     }
 


### PR DESCRIPTION
I'm using jeromq in a situation where there is not always an opportunity to do a clean shutdown.  Because the threads are by default user threads, they cause the application to hang instead of terminating.  By setting the thread state to daemon before starting, this is no longer a problem.

Only the the thread in Poller was causing the issue in my use, but I did the same for all threads to be consistent.