### PR TITLE
Fix Spinning in Reaper Thread

### DIFF
--- a/src/main/java/org/zeromq/ZBeacon.java
+++ b/src/main/java/org/zeromq/ZBeacon.java
@@ -26,6 +26,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
 import java.nio.channels.DatagramChannel;
 import java.util.Arrays;
 
@@ -215,6 +216,9 @@ public class ZBeacon
 
                     size = read - buffer.remaining();
                     handleMessage(buffer, size, senderAddress);
+                }
+                catch (ClosedChannelException ioException) {
+                    break;
                 }
                 catch (IOException ioException) {
                     throw new RuntimeException(ioException);

--- a/src/main/java/zmq/Signaler.java
+++ b/src/main/java/zmq/Signaler.java
@@ -105,6 +105,7 @@ public class Signaler
 
         while (true) {
             try {
+                Thread.interrupted();
                 nbytes = w.write(dummy);
             }
             catch (IOException e) {


### PR DESCRIPTION
To address Issue #172, signaler clear interrupted thread state right before the pipe write. Even though this, `Pipe` could still be `ClosedByInterruptException` at write and very hard to handle it.