### PR TITLE
Feature/add enotsock

### DIFF
--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -1879,7 +1879,8 @@ public class ZMQ
         EFSM(ZError.EFSM),
         ENOCOMPATPROTO(ZError.ENOCOMPATPROTO),
         ETERM(ZError.ETERM),
-        ENOTSOCK(ZError.ENOTSOCK);
+        ENOTSOCK(ZError.ENOTSOCK),
+        EAGAIN(ZError.EAGAIN);
 
         private final int code;
 

--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -1878,7 +1878,8 @@ public class ZMQ
         EMTHREAD(ZError.EMTHREAD),
         EFSM(ZError.EFSM),
         ENOCOMPATPROTO(ZError.ENOCOMPATPROTO),
-        ETERM(ZError.ETERM);
+        ETERM(ZError.ETERM),
+        ENOTSOCK(ZError.ENOTSOCK);
 
         private final int code;
 

--- a/src/main/java/zmq/ZError.java
+++ b/src/main/java/zmq/ZError.java
@@ -77,6 +77,7 @@ public class ZError
 
     private static final int ZMQ_HAUSNUMERO = 156384712;
 
+    public static final int ENOTSOCK = ZMQ_HAUSNUMERO + 5;
     public static final int EFSM = ZMQ_HAUSNUMERO + 51;
     public static final int ENOCOMPATPROTO = ZMQ_HAUSNUMERO + 52;
     public static final int ETERM = ZMQ_HAUSNUMERO + 53;


### PR DESCRIPTION
* Add additional error codes to jeromq that are present in jzmq (though they will be unused in jeromq for now)

This change is focused on fixing up a few small discrepancies that exist between jeromq and jzmq, so that a higher level library can switch between the two without compile issues.

I'm sure there are other synchronization changes between the two libraries that need to be done. These were just ones I ran into.