### PR TITLE
Slight refactorings.

### DIFF
--- a/src/main/java/org/zeromq/ZContext.java
+++ b/src/main/java/org/zeromq/ZContext.java
@@ -42,17 +42,17 @@ public class ZContext implements Closeable
     /**
      * Reference to underlying Context object
      */
-    private volatile Context context;
+    private volatile Context context;  //  Created lazily, use getContext() to access.
 
     /**
      * List of sockets managed by this ZContext
      */
-    private List<Socket> sockets;
+    private final List<Socket> sockets;
 
     /**
      * Number of io threads allocated to this context, default 1
      */
-    private int ioThreads;
+    private final int ioThreads;
 
     /**
      * Linger timeout, default 0
@@ -68,22 +68,28 @@ public class ZContext implements Closeable
      * Indicates if context object is owned by main thread
      * (useful for multi-threaded applications)
      */
-    private boolean main;
+    private final boolean main;
 
     /**
      * Class Constructor
      */
     public ZContext()
     {
-        this(1);
+        this(null, true, 1);
     }
 
     public ZContext(int ioThreads)
     {
+        this(null, true, ioThreads);
+    }
+
+    private ZContext(Context context, boolean main, int ioThreads)
+    {
         sockets = new CopyOnWriteArrayList<Socket>();
+        this.context = context;
         this.ioThreads = ioThreads;
+        this.main = main;
         linger = 0;
-        main = true;
     }
 
     /**
@@ -156,11 +162,7 @@ public class ZContext implements Closeable
      */
     public static ZContext shadow(ZContext ctx)
     {
-        ZContext shadow = new ZContext();
-        shadow.setContext(ctx.getContext());
-        shadow.setMain(false);
-
-        return shadow;
+        return new ZContext(ctx.getContext(), false, ctx.getIoThreads());
     }
 
     /**
@@ -169,14 +171,6 @@ public class ZContext implements Closeable
     public int getIoThreads()
     {
         return ioThreads;
-    }
-
-    /**
-     * @param ioThreads the ioThreads to set
-     */
-    public void setIoThreads(int ioThreads)
-    {
-        this.ioThreads = ioThreads;
     }
 
     /**
@@ -220,14 +214,6 @@ public class ZContext implements Closeable
     }
 
     /**
-     * @param main the main to set
-     */
-    public void setMain(boolean main)
-    {
-        this.main = main;
-    }
-
-    /**
      * @return the context
      */
     public Context getContext()
@@ -243,14 +229,6 @@ public class ZContext implements Closeable
             }
         }
         return result;
-    }
-
-    /**
-     * @param ctx   sets the underlying org.zeromq.Context associated with this ZContext wrapper object
-     */
-    public void setContext(Context ctx)
-    {
-        this.context = ctx;
     }
 
     /**

--- a/src/main/java/zmq/Ctx.java
+++ b/src/main/java/zmq/Ctx.java
@@ -38,6 +38,8 @@ import java.util.concurrent.locks.ReentrantLock;
 
 public class Ctx
 {
+    private static final int WAIT_FOREVER = -1;
+
     //  Information associated with inproc endpoint. Note that endpoint options
     //  are registered as well so that the peer can access them without a need
     //  for synchronisation, handshaking or similar.
@@ -194,7 +196,7 @@ public class Ctx
                 slotSync.unlock();
             }
             //  Wait till reaper thread closes all the sockets.
-            Command cmd = termMailbox.recv(-1);
+            Command cmd = termMailbox.recv(WAIT_FOREVER);
             if (cmd == null) {
                 throw new IllegalStateException();
             }
@@ -278,46 +280,7 @@ public class Ctx
         slotSync.lock();
         try {
             if (starting.compareAndSet(true, false)) {
-                //  Initialize the array of mailboxes. Additional three slots are for
-                //  zmq_term thread and reaper thread.
-                int mazmq;
-                int ios;
-                optSync.lock();
-                try {
-                    mazmq = maxSockets;
-                    ios = ioThreadCount;
-                }
-                finally {
-                    optSync.unlock();
-                }
-                slotCount = mazmq + ios + 2;
-                slots = new Mailbox[slotCount];
-                //alloc_assert (slots);
-
-                //  Initialize the infrastructure for zmq_term thread.
-                slots[TERM_TID] = termMailbox;
-
-                //  Create the reaper thread.
-                reaper = new Reaper(this, REAPER_TID);
-                //alloc_assert (reaper);
-                slots[REAPER_TID] = reaper.getMailbox();
-                reaper.start();
-
-                //  Create I/O thread objects and launch them.
-                for (int i = 2; i != ios + 2; i++) {
-                    IOThread ioThread = new IOThread(this, i);
-                    //alloc_assert (io_thread);
-                    ioThreads.add(ioThread);
-                    slots[i] = ioThread.getMailbox();
-                    ioThread.start();
-                }
-
-                //  In the unused part of the slot array, create a list of empty slots.
-                for (int i = (int) slotCount - 1;
-                      i >= (int) ios + 2; i--) {
-                    emptySlots.add(i);
-                    slots[i] = null;
-                }
+                initSlots();
             }
 
             //  Once zmq_term() was called, we can't create new sockets.
@@ -457,7 +420,6 @@ public class Ctx
         try {
             endpoint = endpoints.get(addr);
             if (endpoint == null) {
-                //ZError.errno(ZError.ECONNREFUSED);
                 return new Endpoint(null, new Options());
             }
 
@@ -471,5 +433,54 @@ public class Ctx
             endpointsSync.unlock();
         }
         return endpoint;
+    }
+
+    private void initSlots()
+    {
+        slotSync.lock();
+        try {
+            //  Initialize the array of mailboxes. Additional two slots are for
+            //  zmq_term thread and reaper thread.
+            int slotCount;
+            int ios;
+            optSync.lock();
+            try {
+                ios = ioThreadCount;
+                slotCount = maxSockets + ioThreadCount + 2;
+            }
+            finally {
+                optSync.unlock();
+            }
+            slots = new Mailbox[slotCount];
+            //alloc_assert (slots);
+
+            //  Initialize the infrastructure for zmq_term thread.
+            slots[TERM_TID] = termMailbox;
+
+            //  Create the reaper thread.
+            reaper = new Reaper(this, REAPER_TID);
+            //alloc_assert (reaper);
+            slots[REAPER_TID] = reaper.getMailbox();
+            reaper.start();
+
+            //  Create I/O thread objects and launch them.
+            for (int i = 2; i != ios + 2; i++) {
+                IOThread ioThread = new IOThread(this, i);
+                //alloc_assert (io_thread);
+                ioThreads.add(ioThread);
+                slots[i] = ioThread.getMailbox();
+                ioThread.start();
+            }
+
+            //  In the unused part of the slot array, create a list of empty slots.
+            for (int i = (int) slotCount - 1;
+                  i >= (int) ios + 2; i--) {
+                emptySlots.add(i);
+                slots[i] = null;
+            }
+        }
+        finally {
+            slotSync.unlock();
+        }
     }
 }

--- a/src/main/java/zmq/Reaper.java
+++ b/src/main/java/zmq/Reaper.java
@@ -134,10 +134,10 @@ public class Reaper extends ZObject implements IPollEvents, Closeable
     @Override
     protected void processReap(SocketBase socket)
     {
+        ++socketsReaping;
+
         //  Add the socket to the poller.
         socket.startReaping(poller);
-
-        ++socketsReaping;
     }
 
     @Override

--- a/src/main/java/zmq/Reaper.java
+++ b/src/main/java/zmq/Reaper.java
@@ -35,7 +35,7 @@ public class Reaper extends ZObject implements IPollEvents, Closeable
     private final Poller poller;
 
     //  Number of sockets being reaped at the moment.
-    private int sockets;
+    private int socketsReaping;
 
     //  If true, we were already asked to terminate.
     private volatile boolean terminating;
@@ -45,7 +45,7 @@ public class Reaper extends ZObject implements IPollEvents, Closeable
     public Reaper(Ctx ctx, int tid)
     {
         super(ctx, tid);
-        sockets = 0;
+        socketsReaping = 0;
         terminating = false;
         name = "reaper-" + tid;
         poller = new Poller(name);
@@ -126,10 +126,8 @@ public class Reaper extends ZObject implements IPollEvents, Closeable
         terminating = true;
 
         //  If there are no sockets being reaped finish immediately.
-        if (sockets == 0) {
-            sendDone();
-            poller.removeHandle(mailboxHandle);
-            poller.stop();
+        if (socketsReaping == 0) {
+            finishTerminating();
         }
     }
 
@@ -139,20 +137,25 @@ public class Reaper extends ZObject implements IPollEvents, Closeable
         //  Add the socket to the poller.
         socket.startReaping(poller);
 
-        ++sockets;
+        ++socketsReaping;
     }
 
     @Override
     protected void processReaped()
     {
-        --sockets;
+        --socketsReaping;
 
         //  If reaped was already asked to terminate and there are no more sockets,
         //  finish immediately.
-        if (sockets == 0 && terminating) {
-            sendDone();
-            poller.removeHandle(mailboxHandle);
-            poller.stop();
+        if (socketsReaping == 0 && terminating) {
+            finishTerminating();
         }
+    }
+
+    private void finishTerminating()
+    {
+        sendDone();
+        poller.removeHandle(mailboxHandle);
+        poller.stop();
     }
 }


### PR DESCRIPTION
These are some minor changes I made while I was browsing the code to understand it.  They should have no impact other than making the code clearer (hopefully).

ZContext: make the parameters set in the constructor final, and remove setters for those parameters.
Ctx:  move the code block for initialization of slots to a separate function, to reduce the size of createSocket().
Reaper:  move duplicated code block to a function.  Also, increment reap count before starting the reap instead of after.
