### PR TITLE
clear zombies after they are removed from timer list

### DIFF
--- a/src/main/java/org/zeromq/ZLoop.java
+++ b/src/main/java/org/zeromq/ZLoop.java
@@ -341,6 +341,7 @@ public class ZLoop
                     }
                 }
             }
+            zombies.clear();
             //  Now handle any new timers added inside the loop
             timers.addAll(newTimers);
             newTimers.clear();


### PR DESCRIPTION
The loop.removeTimer is called, the arg is added to the ```zombies``` list (of timers to be removed).  The zombies are removed but the ```zombies``` list is never cleared.  So they are removed at each iteration.