### PR TITLE
Setter for uncaughtExceptionHandler in ZBeacon Threads

### DIFF
--- a/src/main/java/org/zeromq/ZBeacon.java
+++ b/src/main/java/org/zeromq/ZBeacon.java
@@ -71,8 +71,8 @@ public class ZBeacon
         broadcastClient.setDaemon(true);
     }
 
-    public setUncaughtExceptionHandlers(UncaughtExceptionHandler clientHandler,
-                UncaughtExceptionHandler serverHandler) {
+    public void setUncaughtExceptionHandlers(Thread.UncaughtExceptionHandler clientHandler, Thread.UncaughtExceptionHandler serverHandler)
+    {
         broadcastClient.setUncaughtExceptionHandler(clientHandler);
         broadcastServer.setUncaughtExceptionHandler(serverHandler);
     }

--- a/src/main/java/org/zeromq/ZBeacon.java
+++ b/src/main/java/org/zeromq/ZBeacon.java
@@ -71,6 +71,12 @@ public class ZBeacon
         broadcastClient.setDaemon(true);
     }
 
+    public setUncaughtExceptionHandlers(UncaughtExceptionHandler clientHandler,
+                UncaughtExceptionHandler serverHandler) {
+        broadcastClient.setUncaughtExceptionHandler(clientHandler);
+        broadcastServer.setUncaughtExceptionHandler(serverHandler);
+    }
+
     public void start()
     {
         if (listener != null) {


### PR DESCRIPTION
I'm making use of jeromq in a mobile application. The application uses `ZBeacon` for service discovery but being that its a mobile application a wifi connection cannot be gauranteed. If indeed the wifi connection drops jeromq's beacon threads will have an unhandled exception when they try to send/recv over the udp sockets.

One way I have found to resolve this is to allow the application using the `ZBeacon` to set the `Thread.UncaughtExceptionHandler`s on each of the threads. Doing so lets the application catch that state and reset the beacon when wifi comes back.

A working example here:

https://github.com/kevinkreiser/lapse_app/blob/master/app/src/main/java/kevinkreiser/lapse/ServiceNode.java#L150-L157