### PR TITLE
#305

### DIFF
--- a/src/test/java/zmq/TestMsg.java
+++ b/src/test/java/zmq/TestMsg.java
@@ -30,16 +30,6 @@ public class TestMsg
         new Msg((ByteBuffer) null);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowForBufferWithWrongPosition()
-    {
-        ByteBuffer buffer = ByteBuffer.allocate(10);
-        buffer.putChar('a');
-        buffer.putChar('b');
-        buffer.putChar('c');
-        new Msg(buffer);
-    }
-
     @Test
     public void shouldWorkForFlippedBuffers()
     {


### PR DESCRIPTION
Allow ByteBuffers having arbitrary position/limit.
This also fixes the bug that trailing bytes of a HeapByteBuffer (backed
by an array) is sent (when its position=0 and limit < capacity). 
