### PR TITLE
#307

### DIFF
--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -1404,7 +1404,7 @@ public class ZMQ
             zmq.Msg msg = base.recv(flags);
 
             if (msg != null) {
-                buffer.put(msg.data());
+                buffer.put(msg.buf());
                 return msg.size();
             }
 

--- a/src/main/java/zmq/Encoder.java
+++ b/src/main/java/zmq/Encoder.java
@@ -60,7 +60,7 @@ public class Encoder extends EncoderBase
     private boolean sizeReady()
     {
         //  Write message body into the buffer.
-        nextStep(inProgress.data(), inProgress.size(),
+        nextStep(inProgress.buf(),
                 MESSAGE_READY, !inProgress.hasMore());
         return true;
     }
@@ -101,10 +101,10 @@ public class Encoder extends EncoderBase
         }
         else {
             ByteBuffer b = ByteBuffer.wrap(tmpbuf);
-            b.put((byte) 0xff);
-            b.putLong(size);
-            b.put((byte) (inProgress.flags() & Msg.MORE));
-            nextStep(tmpbuf, 10, SIZE_READY, false);
+            b.put(0, (byte) 0xff);
+            b.putLong(1, size);
+            b.put(9, (byte) (inProgress.flags() & Msg.MORE));
+            nextStep(b, SIZE_READY, false);
         }
 
         return true;

--- a/src/main/java/zmq/Msg.java
+++ b/src/main/java/zmq/Msg.java
@@ -40,7 +40,7 @@ public class Msg
     private int size;
     private byte[] data;
     private final ByteBuffer buf;
-    // keep track of relative write position 
+    // keep track of relative write position
     private int writeIndex = 0;
     // keep track of relative read position
     private int readIndex = 0;

--- a/src/main/java/zmq/Msg.java
+++ b/src/main/java/zmq/Msg.java
@@ -40,6 +40,10 @@ public class Msg
     private int size;
     private byte[] data;
     private final ByteBuffer buf;
+    // keep track of relative write position 
+    private int writeIndex = 0;
+    // keep track of relative read position
+    private int readIndex = 0;
 
     public Msg()
     {
@@ -165,7 +169,7 @@ public class Msg
 
     public byte get()
     {
-        return buf.get();
+        return get(readIndex++);
     }
 
     public byte get(int index)
@@ -175,8 +179,7 @@ public class Msg
 
     public Msg put(byte b)
     {
-        buf.put(b);
-        return this;
+        return put(writeIndex++, b);
     }
 
     public Msg put(int index, byte b)
@@ -195,34 +198,44 @@ public class Msg
         if (src == null) {
             return this;
         }
-        buf.put(src, off, len);
+        ByteBuffer dup = buf.duplicate();
+        dup.position(writeIndex);
+        writeIndex += len;
+        dup.put(src, off, len);
         return this;
     }
 
     public Msg put(ByteBuffer src)
     {
-        buf.put(src);
+        ByteBuffer dup = buf.duplicate();
+        dup.position(writeIndex);
+        writeIndex += Math.min(dup.remaining(), src.remaining());
+        dup.put(src);
         return this;
     }
 
     public int getBytes(int index, byte[] dst, int off, int len)
     {
-        int count = Math.min(len, size);
-        if (buf.isDirect()) {
+        int count = Math.min(len, size - index);
+        if (data == null) {
             ByteBuffer dup = buf.duplicate();
             dup.position(index);
             dup.put(dst, off, count);
-            return count;
         }
-        System.arraycopy(data, index, dst, off, count);
+        else {
+           System.arraycopy(data, index, dst, off, count);
+        }
+
         return count;
     }
 
     public int getBytes(int index, ByteBuffer bb, int len)
     {
-        int count = Math.min(bb.remaining(), size - index);
+        ByteBuffer dup = buf.duplicate();
+        dup.position(index);
+        int count = Math.min(bb.remaining(), dup.remaining());
         count = Math.min(count, len);
-        bb.put(buf);
+        bb.put(dup);
         return count;
     }
 

--- a/src/main/java/zmq/V1Decoder.java
+++ b/src/main/java/zmq/V1Decoder.java
@@ -92,7 +92,7 @@ public class V1Decoder extends DecoderBase
         inProgress = new Msg(size);
 
         inProgress.setFlags(msgFlags);
-        nextStep(inProgress.data(), inProgress.size(),
+        nextStep(inProgress,
                 MESSAGE_READY);
 
         return true;
@@ -124,7 +124,7 @@ public class V1Decoder extends DecoderBase
         inProgress = new Msg((int) msgSize);
 
         inProgress.setFlags(msgFlags);
-        nextStep(inProgress.data(), inProgress.size(),
+        nextStep(inProgress,
                 MESSAGE_READY);
 
         return true;

--- a/src/main/java/zmq/V1Encoder.java
+++ b/src/main/java/zmq/V1Encoder.java
@@ -64,8 +64,7 @@ public class V1Encoder extends EncoderBase
     private boolean sizeReady()
     {
         //  Write message body into the buffer.
-        nextStep(inProgress.data(), inProgress.size(),
-                MESSAGE_READY, !inProgress.hasMore());
+        nextStep(inProgress.buf(), MESSAGE_READY, !inProgress.hasMore());
         return true;
     }
 
@@ -100,9 +99,8 @@ public class V1Encoder extends EncoderBase
         final int size = inProgress.size();
         if (size > 255) {
             ByteBuffer b = ByteBuffer.wrap(tmpbuf);
-            b.position(1);
-            b.putLong(size);
-            nextStep(tmpbuf, 9, SIZE_READY, false);
+            b.putLong(1, size);
+            nextStep(b, SIZE_READY, false);
         }
         else {
             tmpbuf[1] = (byte) (size);

--- a/src/test/java/org/zeromq/TestZMQ.java
+++ b/src/test/java/org/zeromq/TestZMQ.java
@@ -166,6 +166,102 @@ public class TestZMQ
 
     }
 
+    @Test
+    public void testByteBufferLarge() throws InterruptedException, CharacterCodingException
+    {
+        ZMQ.Context context = ZMQ.context(1);
+        int[] array = new int[2048 * 2000];
+        for (int i = 0; i < array.length; ++i) {
+           array[i] = i;
+        }
+        ByteBuffer bSend = ByteBuffer.allocate(Integer.SIZE / 8 * array.length).order(ByteOrder.nativeOrder());
+        bSend.asIntBuffer().put(array);
+        ByteBuffer bRec = ByteBuffer.allocate(bSend.capacity()).order(ByteOrder.nativeOrder());
+        int[] recArray = new int[array.length];
+
+        ZMQ.Socket push = null;
+        ZMQ.Socket pull = null;
+        try {
+            push = context.socket(ZMQ.PUSH);
+            pull = context.socket(ZMQ.PULL);
+            pull.bind("tcp://*:12345");
+            push.connect("tcp://localhost:12345");
+            push.sendByteBuffer(bSend, 0);
+            pull.recvByteBuffer(bRec, 0);
+            bRec.flip();
+            bRec.asIntBuffer().get(recArray);
+            assertArrayEquals(array, recArray);
+        }
+        finally {
+            try {
+                push.close();
+            }
+            catch (Exception ignore) {
+                ignore.printStackTrace();
+            }
+            try {
+                pull.close();
+            }
+            catch (Exception ignore) {
+                ignore.printStackTrace();
+            }
+            try {
+                context.term();
+            }
+            catch (Exception ignore) {
+                ignore.printStackTrace();
+            }
+        }
+    }
+
+    @Test
+    public void testByteBufferLargeDirect() throws InterruptedException, CharacterCodingException
+    {
+        ZMQ.Context context = ZMQ.context(1);
+        int[] array = new int[2048 * 2000];
+        for (int i = 0; i < array.length; ++i) {
+           array[i] = i;
+        }
+        ByteBuffer bSend = ByteBuffer.allocateDirect(Integer.SIZE / 8 * array.length).order(ByteOrder.nativeOrder());
+        bSend.asIntBuffer().put(array);
+        ByteBuffer bRec = ByteBuffer.allocateDirect(bSend.capacity()).order(ByteOrder.nativeOrder());
+        int[] recArray = new int[array.length];
+
+        ZMQ.Socket push = null;
+        ZMQ.Socket pull = null;
+        try {
+            push = context.socket(ZMQ.PUSH);
+            pull = context.socket(ZMQ.PULL);
+            pull.bind("tcp://*:12345");
+            push.connect("tcp://localhost:12345");
+            push.sendByteBuffer(bSend, 0);
+            pull.recvByteBuffer(bRec, 0);
+            bRec.flip();
+            bRec.asIntBuffer().get(recArray);
+            assertArrayEquals(array, recArray);
+        }
+        finally {
+            try {
+                push.close();
+            }
+            catch (Exception ignore) {
+                ignore.printStackTrace();
+            }
+            try {
+                pull.close();
+            }
+            catch (Exception ignore) {
+                ignore.printStackTrace();
+            }
+            try {
+                context.term();
+            }
+            catch (Exception ignore) {
+                ignore.printStackTrace();
+            }
+        }
+    }
+
     @Test(expected = ZMQException.class)
     public void testBindSameAddress()
     {

--- a/src/test/java/zmq/TestEncoder.java
+++ b/src/test/java/zmq/TestEncoder.java
@@ -137,7 +137,7 @@ public class TestEncoder
         public CustomEncoder(int bufsize)
         {
             super(bufsize);
-            nextStep(null, read_body, true);
+            nextStep((Msg) null, read_body, true);
         }
 
         @Override

--- a/src/test/java/zmq/TestProxyTcp.java
+++ b/src/test/java/zmq/TestProxyTcp.java
@@ -22,7 +22,6 @@ package zmq;
 import java.io.IOException;
 import java.net.Socket;
 import java.nio.ByteBuffer;
-import java.nio.channels.Selector;
 
 import org.junit.Test;
 import static org.junit.Assert.assertThat;
@@ -196,7 +195,7 @@ public class TestProxyTcp
         public ProxyEncoder(int bufsize)
         {
             super(bufsize);
-            nextStep(null, WRITE_HEADER, true);
+            nextStep((Msg) null, WRITE_HEADER, true);
             messageReady = false;
             identityRecieved = false;
         }
@@ -266,7 +265,6 @@ public class TestProxyTcp
     static class Main extends Thread
     {
         private Ctx ctx;
-        private Selector selector;
         Main(Ctx ctx)
         {
             this.ctx = ctx;


### PR DESCRIPTION
Pull request for #307.
Aim is to avoid extra copy when Msg contains a DirectByteBuffers or HeapByteBuffers with position>0 or limit!=capacity. To make this possible, EncoderBase and DecoderBase also use ByteBuffers and ByteBuffer in Msg needs to keep track of its initial positions (the problem was that it allows relative operations on its ByteBuffer but removing these methods would break compatibility with existing code therefore I decided to use write-/readIndex).
