### PR TITLE
MsgAllocator allows users to define how Msg are created

### DIFF
--- a/src/main/java/zmq/Decoder.java
+++ b/src/main/java/zmq/Decoder.java
@@ -108,7 +108,7 @@ public class Decoder extends DecoderBase
 
             }
             else {
-                inProgress = new Msg(size - 1);
+                inProgress = getMsgAllocator().allocate(size - 1);
             }
 
             nextStep(tmpbuf, 1, FLAGS_READY);
@@ -145,7 +145,7 @@ public class Decoder extends DecoderBase
         //  inProgress is initialized at this point so in theory we should
         //  close it before calling init_size, however, it's a 0-byte
         //  message and thus we can treat it as uninitialized...
-        inProgress = new Msg(msgSize);
+        inProgress = getMsgAllocator().allocate(msgSize);
 
         nextStep(tmpbuf, 1, FLAGS_READY);
 

--- a/src/main/java/zmq/DecoderBase.java
+++ b/src/main/java/zmq/DecoderBase.java
@@ -36,6 +36,7 @@ public abstract class DecoderBase implements IDecoder
 {
     //  Where to store the read data.
     private ByteBuffer readBuf;
+    private MsgAllocator msgAllocator = new MsgAllocatorHeap();
 
     //  The buffer for data to decode.
     private int bufsize;
@@ -186,6 +187,16 @@ public abstract class DecoderBase implements IDecoder
             }
         }
         return false;
+    }
+
+    public MsgAllocator getMsgAllocator()
+    {
+       return msgAllocator;
+    }
+
+    public void setMsgAllocator(MsgAllocator msgAllocator)
+    {
+       this.msgAllocator = msgAllocator;
     }
 
     protected abstract boolean next();

--- a/src/main/java/zmq/MsgAllocator.java
+++ b/src/main/java/zmq/MsgAllocator.java
@@ -1,0 +1,13 @@
+package zmq;
+
+public interface MsgAllocator
+{
+   /**
+    * Allocate a Msg based on users needs (e.g., using DirectByteBuffer with additional space in
+    * front for header information).
+    *
+    * @param size The size of the Msg.
+    * @return Msg The ByteBuffer Msg to meet space requirements
+    */
+   Msg allocate(int size);
+}

--- a/src/main/java/zmq/MsgAllocatorHeap.java
+++ b/src/main/java/zmq/MsgAllocatorHeap.java
@@ -1,0 +1,10 @@
+package zmq;
+
+public class MsgAllocatorHeap implements MsgAllocator
+{
+   @Override
+   public Msg allocate(int size)
+   {
+      return new Msg(size);
+   }
+}

--- a/src/main/java/zmq/MsgAllocatorOffHeap.java
+++ b/src/main/java/zmq/MsgAllocatorOffHeap.java
@@ -1,0 +1,12 @@
+package zmq;
+
+import java.nio.ByteBuffer;
+
+public class MsgAllocatorOffHeap implements MsgAllocator
+{
+   @Override
+   public Msg allocate(int size)
+   {
+      return new Msg(ByteBuffer.allocateDirect(size));
+   }
+}

--- a/src/main/java/zmq/Options.java
+++ b/src/main/java/zmq/Options.java
@@ -115,6 +115,7 @@ public class Options
     int socketId;
     Class<? extends DecoderBase> decoder;
     Class<? extends EncoderBase> encoder;
+    MsgAllocator msgAllocator;
 
     public Options()
     {
@@ -151,6 +152,7 @@ public class Options
         tcpAcceptFilters = new ArrayList<TcpAddress.TcpAddressMask>();
         decoder = null;
         encoder = null;
+        msgAllocator = null;
     }
 
     @SuppressWarnings("unchecked")
@@ -331,6 +333,41 @@ public class Options
                 throw new IllegalArgumentException("decoder " + optval);
             }
             return;
+        case ZMQ.ZMQ_MSG_ALLOCATOR:
+           if (optval instanceof String) {
+               try {
+                   Class<? extends MsgAllocator> msgAllocatorClass = Class.forName((String) optval).asSubclass(MsgAllocator.class);
+                   msgAllocator = msgAllocatorClass.newInstance();
+               }
+               catch (ClassNotFoundException e) {
+                   throw new IllegalArgumentException(e);
+               }
+               catch (InstantiationException e) {
+                  throw new IllegalArgumentException(e);
+               }
+               catch (IllegalAccessException e) {
+                  throw new IllegalArgumentException(e);
+               }
+           }
+           else if (optval instanceof Class) {
+              try {
+                 Class<? extends MsgAllocator> msgAllocatorClass = (Class<? extends MsgAllocator>) optval;
+                 msgAllocator = msgAllocatorClass.newInstance();
+              }
+              catch (InstantiationException e) {
+                 throw new IllegalArgumentException(e);
+              }
+              catch (IllegalAccessException e) {
+                 throw new IllegalArgumentException(e);
+              }
+           }
+           else if (optval instanceof MsgAllocator) {
+              msgAllocator = (MsgAllocator) optval;
+           }
+           else {
+               throw new IllegalArgumentException("msgAllocator " + optval);
+           }
+           return;
 
         default:
             throw new IllegalArgumentException("Unknown Option " + option);

--- a/src/main/java/zmq/V1Decoder.java
+++ b/src/main/java/zmq/V1Decoder.java
@@ -89,7 +89,7 @@ public class V1Decoder extends DecoderBase
         //  inProgress is initialised at this point so in theory we should
         //  close it before calling msgInitWithSize, however, it's a 0-byte
         //  message and thus we can treat it as uninitialised...
-        inProgress = new Msg(size);
+        inProgress = getMsgAllocator().allocate(size);
 
         inProgress.setFlags(msgFlags);
         nextStep(inProgress,
@@ -121,7 +121,7 @@ public class V1Decoder extends DecoderBase
         //  inProgress is initialised at this point so in theory we should
         //  close it before calling init_size, however, it's a 0-byte
         //  message and thus we can treat it as uninitialised.
-        inProgress = new Msg((int) msgSize);
+        inProgress = getMsgAllocator().allocate((int) msgSize);
 
         inProgress.setFlags(msgFlags);
         nextStep(inProgress,

--- a/src/main/java/zmq/ZMQ.java
+++ b/src/main/java/zmq/ZMQ.java
@@ -113,6 +113,7 @@ public class ZMQ
     /* Custom options */
     public static final int ZMQ_ENCODER = 1001;
     public static final int ZMQ_DECODER = 1002;
+    public static final int ZMQ_MSG_ALLOCATOR = 1003;
 
     /*  Message options                                                           */
     public static final int ZMQ_MORE = 1;


### PR DESCRIPTION
MsgAllocator allows users to define how Msg are created (respectively Msg's ByteBuffer). This allows for more flexibility (e.g., this allows us to directly use DirectByteBuffers and initialize them with some extra space at their start where header information will be stored in a later step – saving us some extra copying work). 
We should probably first discuss #308 as this pull request builds on it.