### PR TITLE
Problem: Building jeromq from source throws warning with maven 3.3.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,9 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>2.6</version>
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>


### PR DESCRIPTION
Maven 3.3.9 (bb52d8502b132ec0a5a3f4c09453c07478323dc5;
2015-11-10T17:41:47+01:00) says:

'build.plugins.plugin.version' for
org.apache.maven.plugins:maven-jar-plugin is missing. It is highly
recommended to fix these problems because they threaten the stability of
your build. For this reason, future Maven versions might no longer
support building such malformed projects.

Solution: Add groupId and version to maven-jar-plugin in pom.xml