### PR TITLE
Avoid extra byte copies in Pub/Sub 

### DIFF
--- a/src/main/java/zmq/Mtrie.java
+++ b/src/main/java/zmq/Mtrie.java
@@ -19,6 +19,7 @@
 
 package zmq;
 
+import java.nio.ByteBuffer;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -350,7 +351,7 @@ public class Mtrie
     }
 
     //  Signal all the matching pipes.
-    public void match(byte[] data, int size, IMtrieHandler func, Object arg)
+    public void match(ByteBuffer data, int size, IMtrieHandler func, Object arg)
     {
         Mtrie current = this;
         int idx = 0;
@@ -373,7 +374,7 @@ public class Mtrie
                 break;
             }
 
-            byte c = data[idx];
+            byte c = data.get(idx);
             //  If there's one subnode (optimisation).
             if (current.count == 1) {
                 if (c != current.min) {

--- a/src/main/java/zmq/Trie.java
+++ b/src/main/java/zmq/Trie.java
@@ -19,6 +19,8 @@
 
 package zmq;
 
+import java.nio.ByteBuffer;
+
 public class Trie
 {
     private int refcnt;
@@ -213,7 +215,7 @@ public class Trie
     }
 
     //  Check whether particular key is in the trie.
-    public boolean check(byte[] data)
+    public boolean check(ByteBuffer data)
     {
         //  This function is on critical path. It deliberately doesn't use
         //  recursion to get a bit better performance.
@@ -226,13 +228,13 @@ public class Trie
             }
 
             //  We've checked all the data and haven't found matching subscription.
-            if (data.length == start) {
+            if (data.remaining() == start) {
                 return false;
             }
 
             //  If there's no corresponding slot for the first character
             //  of the prefix, the message does not match.
-            byte c = data[start];
+            byte c = data.get(start);
             if (c < current.min || c >= current.min + current.count) {
                 return false;
             }

--- a/src/main/java/zmq/XPub.java
+++ b/src/main/java/zmq/XPub.java
@@ -204,7 +204,7 @@ class XPub extends SocketBase
 
         //  For the first part of multi-part message, find the matching pipes.
         if (!more) {
-            subscriptions.match(msg.data(), msg.size(),
+            subscriptions.match(msg.buf(), msg.size(),
                     markAsMatching, this);
         }
 

--- a/src/main/java/zmq/XSub.java
+++ b/src/main/java/zmq/XSub.java
@@ -248,6 +248,6 @@ public class XSub extends SocketBase
 
     private boolean match(Msg msg)
     {
-        return subscriptions.check(msg.data());
+        return subscriptions.check(msg.buf());
     }
 }


### PR DESCRIPTION
Fixes #323.
Addresses unnecessary byte copies when Msg contains DirectByteBuffer or HeapByteBuffers with position > 0.