### PR TITLE
receiver.close() invocation is missed in msreader example

### DIFF
--- a/src/test/java/guide/msreader.java
+++ b/src/test/java/guide/msreader.java
@@ -56,6 +56,7 @@ public class msreader {
             //  No activity, so sleep for 1 msec
             Thread.sleep(1000);
         }
+        receiver.close ();
         subscriber.close ();
         context.term ();
     }


### PR DESCRIPTION
Compared with zguide msreader code, the close operation is missed?