### PR TITLE
Implement ZMQ_REQ_RELAXED and ZMQ_REQ_CORRELATE sockopts

### DIFF
--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -717,6 +717,49 @@ public class ZMQ
         }
 
         /**
+         * The 'ZMQ_REQ_CORRELATE' option causes a socket to send a request ID
+         * frame with every message. This means that the outgoing message
+         * is [request id, (empty frame), payload]. Any message not having those
+         * first two frames is discarded.
+         * See also ZMQ_REQ_RELAXED.
+         * @param correlate Whether to enable outgoing request ids.
+         */
+        public final void setReqCorrelate(boolean correlate)
+        {
+            setsockopt(zmq.ZMQ.ZMQ_REQ_CORRELATE, correlate ? 1 : 0);
+        }
+
+        /**
+         * @see #setReqCorrelate(boolean)
+         * @return state of the ZMQ_REQ_CORRELATE option.
+         */
+        public final boolean getReqCorrelate()
+        {
+            return base.getSocketOpt(zmq.ZMQ.ZMQ_REQ_CORRELATE) > 0;
+        }
+
+        /**
+         * The 'ZMQ_REQ_RELAXED' option relaxes the strict lock-step requirement
+         * of REQ sockets. Instead, it allows for several requests to be sent
+         * sequentially. If enabled, also enable ZMQ_REQ_CORRELATE in order to
+         * receive the correct responses to requests.
+          @param relaxed
+         */
+        public final void setReqRelaxed(boolean relaxed)
+        {
+            setsockopt(zmq.ZMQ.ZMQ_REQ_RELAXED, relaxed ? 1 : 0);
+        }
+
+        /**
+         * @see #setReqRelaxed(boolean)
+         * @return state of the ZMQ_REQ_RELAXED option.
+         */
+        public final boolean getReqRelaxed()
+        {
+            return base.getSocketOpt(zmq.ZMQ.ZMQ_REQ_CORRELATE) > 0;
+        }
+
+        /**
          * @see #setMulticastLoop(boolean)
          *
          * @return the Multicast Loop.

--- a/src/main/java/zmq/Options.java
+++ b/src/main/java/zmq/Options.java
@@ -3,7 +3,6 @@ package zmq;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
 import zmq.TcpAddress.TcpAddressMask;
 
 public class Options
@@ -47,6 +46,12 @@ public class Options
     //  Maximum interval between attempts to reconnect, in milliseconds.
     //  Default 0 (unused)
     int reconnectIvlMax;
+
+    // if the REQ socket has correlation enabled (= is sending request IDs)
+    int reqCorrelate;
+
+    // if the REQ FSM is not strictly adhered to
+    int reqRelaxed;
 
     //  Maximum backlog for pending connections.
     int backlog;
@@ -113,6 +118,8 @@ public class Options
         linger = -1;
         reconnectIvl = 100;
         reconnectIvlMax = 0;
+        reqCorrelate = 0;
+        reqRelaxed = 0;
         backlog = 100;
         maxMsgSize = -1;
         recvTimeout = -1;
@@ -393,6 +400,12 @@ public class Options
 
         case ZMQ.ZMQ_RECONNECT_IVL_MAX:
             return reconnectIvlMax;
+
+            case ZMQ.ZMQ_REQ_CORRELATE:
+                return reqCorrelate;
+
+            case ZMQ.ZMQ_REQ_RELAXED:
+                return reqRelaxed;
 
         case ZMQ.ZMQ_BACKLOG:
             return backlog;

--- a/src/main/java/zmq/Options.java
+++ b/src/main/java/zmq/Options.java
@@ -221,6 +221,14 @@ public class Options
                 throw new IllegalArgumentException("reconnectIvlMax " + optval);
             }
 
+                return;
+
+        case ZMQ.ZMQ_REQ_CORRELATE:
+            reqCorrelate = (Integer) optval;
+            return;
+
+        case ZMQ.ZMQ_REQ_RELAXED:
+            reqRelaxed = (Integer) optval;
             return;
 
         case ZMQ.ZMQ_BACKLOG:

--- a/src/main/java/zmq/ZMQ.java
+++ b/src/main/java/zmq/ZMQ.java
@@ -85,6 +85,8 @@ public class ZMQ
     public static final int ZMQ_TCP_ACCEPT_FILTER = 38;
     public static final int ZMQ_DELAY_ATTACH_ON_CONNECT = 39;
     public static final int ZMQ_XPUB_VERBOSE = 40;
+    public static final int ZMQ_REQ_CORRELATE = 52;
+    public static final int ZMQ_REQ_RELAXED = 53;
     // TODO: more constants
     public static final int ZMQ_ROUTER_HANDOVER = 56;
     public static final int ZMQ_XPUB_NODROP = 69;

--- a/src/test/java/zmq/TestReqCorrelateRelaxed.java
+++ b/src/test/java/zmq/TestReqCorrelateRelaxed.java
@@ -1,0 +1,132 @@
+package zmq;
+
+import java.util.Arrays;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+
+/**
+ * This test does one setup, and runs a few tests on that setup.
+ *
+ * @author lbo
+ */
+public class TestReqCorrelateRelaxed
+{
+    private static final String PAYLOAD = "Payload";
+
+    /**
+     * Prepares sockets and runs actual tests.
+     *
+     * Doing it this way so order is guaranteed.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void overallSetup() throws Exception
+    {
+        Ctx ctx = ZMQ.init(1);
+        assertThat(ctx, notNullValue());
+
+        SocketBase dealer = ZMQ.socket(ctx, ZMQ.ZMQ_DEALER);
+        assertThat(dealer, notNullValue());
+        boolean brc = ZMQ.bind(dealer, "inproc://a");
+        assertThat(brc, is(true));
+
+        SocketBase reqClient = ZMQ.socket(ctx, ZMQ.ZMQ_REQ);
+        assertThat(reqClient, notNullValue());
+
+        reqClient.setSocketOpt(ZMQ.ZMQ_REQ_CORRELATE, 1);
+        reqClient.setSocketOpt(ZMQ.ZMQ_REQ_RELAXED, 1);
+
+        brc = ZMQ.connect(reqClient, "inproc://a");
+        assertThat(brc, is(true));
+
+        byte[] origRequestId = testReqSentFrames(dealer, reqClient);
+        testReqRecvGoodRequestId(dealer, reqClient, origRequestId);
+    }
+
+    /**
+     * Tests that the correct frames are sent by the REQ socket.
+     *
+     * @param dealer
+     * @param reqClient
+     * @throws Exception
+     * @returns the request ID that was received
+     */
+    public byte[] testReqSentFrames(SocketBase dealer, SocketBase reqClient) throws Exception
+    {
+        // Send simple payload over REQ socket
+        Msg request = new Msg(PAYLOAD.getBytes());
+
+        assertThat(ZMQ.sendMsg(reqClient, request, 0), is(PAYLOAD.getBytes().length));
+
+        // Verify that the right frames were sent: [request ID, empty frame, payload]
+        // 1. request ID
+        Msg receivedReqId = ZMQ.recv(dealer, 0);
+
+        assertThat(receivedReqId, notNullValue());
+        assertThat(receivedReqId.size(), is(Req.REQUEST_ID_LENGTH));
+        assertThat(receivedReqId.flags() & ZMQ.ZMQ_MORE, not(0));
+
+        byte[] buf = new byte[128];
+        int requestIdLen = receivedReqId.getBytes(0, buf, 0, 128);
+        assertThat(requestIdLen, is(Req.REQUEST_ID_LENGTH));
+
+        byte[] requestId = Arrays.copyOf(buf, Req.REQUEST_ID_LENGTH);
+
+        // 2. empty frame
+        Msg receivedEmpty = ZMQ.recv(dealer, 0);
+
+        assertThat(receivedEmpty, notNullValue());
+        assertThat(receivedEmpty.size(), is(0));
+        assertThat(receivedEmpty.flags() & ZMQ.ZMQ_MORE, not(0));
+
+        // 3. Payload
+        Msg receivedPayload = ZMQ.recv(dealer, 0);
+
+        assertThat(receivedPayload, notNullValue());
+        assertThat(receivedPayload.size(), is(PAYLOAD.getBytes().length));
+        assertThat(receivedPayload.flags() & ZMQ.ZMQ_MORE, is(0));
+
+        int receivedPayloadLen = receivedPayload.getBytes(0, buf, 0, 128);
+        assertThat(receivedPayloadLen, is(PAYLOAD.getBytes().length));
+
+        for (int i = 0; i < receivedPayloadLen; i++) {
+            assertThat(PAYLOAD.getBytes()[i], is(PAYLOAD.getBytes()[i]));
+        }
+
+        return requestId;
+    }
+
+    /**
+     * Test that REQ sockets with CORRELATE/RELAXED receive a response with
+     * correct request ID correctly.
+     *
+     * @param dealer
+     * @param reqClient
+     * @param origRequestId the request ID that was sent by the REQ socket
+     * earlier
+     * @throws Exception
+     */
+    public void testReqRecvGoodRequestId(SocketBase dealer, SocketBase reqClient, byte[] origRequestId) throws Exception
+    {
+        Msg requestId = new Msg(origRequestId);
+        Msg empty = new Msg();
+        Msg responsePayload = new Msg(PAYLOAD.getBytes());
+
+        // Send response
+        assertThat(ZMQ.send(dealer, requestId, ZMQ.ZMQ_SNDMORE), is(6));
+        assertThat(ZMQ.send(dealer, empty, ZMQ.ZMQ_SNDMORE), is(0));
+        assertThat(ZMQ.send(dealer, responsePayload, 0), is(responsePayload.size()));
+
+        // Receive response (payload only)
+        Msg receivedResponsePayload = reqClient.recv(0);
+        assertThat(receivedResponsePayload, notNullValue());
+
+        byte[] buf = new byte[128];
+        int payloadLen = receivedResponsePayload.getBytes(0, buf, 0, 128);
+        assertThat(payloadLen, is(PAYLOAD.getBytes().length));
+    }
+}


### PR DESCRIPTION
Incidentally fixes #346.

Small note: In `testReqRecvBadRequestId()`, I had a problem where the test would hang indefinitely. It seems that the two send actions before only delivered one `ACTIVATE_READ` (I think) command to the appropriate mailbox, is that possible? Anyway, for some reason jeromq waited for a command to arrive in the mailbox, but nothing came in. I worked around it by setting a timeout on the socket.

Also, it might be that there's one or another line that my IDE formatted (although I tried to avoid any of that).