### PR TITLE
Use OpenJDK 8 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 install: mvn install --quiet -DskipTests=true -Dgpg.skip=true
 language: java
 jdk:
-  - openjdk7
+  - openjdk8
 


### PR DESCRIPTION
The patch in #366 uses the new Java Time API, which is only available in Java 8.

Alternatively (if you think that's the better way forward), I can try migrating my code to Java 7 (or lower).