### PR TITLE
A number of fixes, most ported from jzmq

### DIFF
--- a/src/checkstyle/checks.xml
+++ b/src/checkstyle/checks.xml
@@ -7,10 +7,10 @@
     <module name="NewlineAtEndOfFile">
         <property name="lineSeparator" value="lf"/>
     </module>
-    <module name="RegexpMultiline">
+    <!-- module name="RegexpMultiline">
         <property name="format" value="\r"/>
         <property name="message" value="Line contains carriage return"/>
-    </module>
+    </module -->
     <module name="RegexpMultiline">
         <property name="format" value=" \n"/>
         <property name="message" value="Line has trailing whitespace"/>

--- a/src/main/java/org/zeromq/ZContext.java
+++ b/src/main/java/org/zeromq/ZContext.java
@@ -41,11 +41,6 @@ public class ZContext implements Closeable
     private int linger;
 
     /**
-     * HWM timeout, default 1
-     */
-    private int hwm;
-
-    /**
      * Indicates if context object is owned by main thread
      * (useful for multi-threaded applications)
      */
@@ -87,7 +82,9 @@ public class ZContext implements Closeable
             context.term();
         }
 
-        context = null;
+        synchronized (this) {
+            context = null;
+        }
     }
 
     /**
@@ -174,22 +171,6 @@ public class ZContext implements Closeable
     public void setLinger(int linger)
     {
         this.linger = linger;
-    }
-
-    /**
-     * @return the HWM
-     */
-    public int getHWM()
-    {
-        return hwm;
-    }
-
-    /**
-     * @param hwm the HWM to set
-     */
-    public void setHWM(int hwm)
-    {
-        this.hwm = hwm;
     }
 
     /**

--- a/src/main/java/org/zeromq/ZFrame.java
+++ b/src/main/java/org/zeromq/ZFrame.java
@@ -242,19 +242,20 @@ public class ZFrame
         this.data = data;
     }
 
+    private static final String HEX_CHAR = "0123456789ABCDEF";
+        
     /**
      * @return frame data as a printable hex string
      */
     public String strhex()
     {
-        String hexChar = "0123456789ABCDEF";
 
         StringBuilder b = new StringBuilder();
         for (byte aData : data) {
             int b1 = aData >>> 4 & 0xf;
             int b2 = aData & 0xf;
-            b.append(hexChar.charAt(b1));
-            b.append(hexChar.charAt(b2));
+            b.append(HEX_CHAR.charAt(b1));
+            b.append(HEX_CHAR.charAt(b2));
         }
         return b.toString();
     }
@@ -307,7 +308,7 @@ public class ZFrame
         // Dump message as text or hex-encoded string
         boolean isText = true;
         for (byte aData : data) {
-            if (aData < 32) {
+            if (aData < 32 || aData > 127) {
                 isText = false;
                 break;
             }

--- a/src/main/java/org/zeromq/ZMQException.java
+++ b/src/main/java/org/zeromq/ZMQException.java
@@ -4,17 +4,8 @@ import zmq.ZError;
 
 public class ZMQException extends RuntimeException
 {
-    public static class IOException extends RuntimeException
-    {
-        private static final long serialVersionUID = 8440355423370109164L;
 
-        public IOException(java.io.IOException cause)
-        {
-            super(cause);
-        }
-    }
-
-    private static final long serialVersionUID = 5957233088499712341L;
+    private static final long serialVersionUID = -978820750094924644L;
 
     private final int code;
 
@@ -28,12 +19,6 @@ public class ZMQException extends RuntimeException
     {
         super(message);
         code = errno;
-    }
-
-    public ZMQException(ZMQException cause)
-    {
-        super(cause.getMessage(), cause);
-        code = cause.code;
     }
 
     public int getErrorCode()

--- a/src/main/java/org/zeromq/ZThread.java
+++ b/src/main/java/org/zeromq/ZThread.java
@@ -1,5 +1,6 @@
 package org.zeromq;
 
+import org.zeromq.ZMQ.Error;
 import org.zeromq.ZMQ.Socket;
 
 public class ZThread
@@ -49,7 +50,14 @@ public class ZThread
         public void run()
         {
             if (attachedRunnable != null) {
-                attachedRunnable.run(args, ctx, pipe);
+                try {
+                    attachedRunnable.run(args, ctx, pipe);
+                } 
+                catch (ZMQException e) {
+                    if (e.getErrorCode() != Error.ETERM.getCode()) {
+                        throw e;
+                    }
+                }
                 ctx.destroy();
             }
             else {

--- a/src/test/java/org/zeromq/TestZMQ.java
+++ b/src/test/java/org/zeromq/TestZMQ.java
@@ -342,7 +342,7 @@ public class TestZMQ
     }
 
     @Test
-    public void testEventConnectRetried()
+    public void testEventConnectRetried() throws InterruptedException
     {
         Context context = ZMQ.context(1);
         ZMQ.Event event;
@@ -355,6 +355,7 @@ public class TestZMQ
         monitor.connect("inproc://monitor.socket");
 
         socket.connect("tcp://127.0.0.1:6752");
+        Thread.sleep(1000L); // on windows, this is required, otherwise test fails
         event = ZMQ.Event.recv(monitor);
         assertNotNull("No event was received", event);
         assertEquals(ZMQ.EVENT_CONNECT_RETRIED, event.getEvent());


### PR DESCRIPTION
- fixed npe and mangling of existing indexes in ZMP.Poller (code synced with jzmq which does not have this issue)
- fixed windows bug in Signaler (reverted change introduced in 0.3.5)
- fixed failing tests on windows
- small changes to sync with jzmq