### PR TITLE
Whitespace changes to make the style checker happy

### DIFF
--- a/src/main/java/org/zeromq/ZFrame.java
+++ b/src/main/java/org/zeromq/ZFrame.java
@@ -243,13 +243,12 @@ public class ZFrame
     }
 
     private static final String HEX_CHAR = "0123456789ABCDEF";
-        
+
     /**
      * @return frame data as a printable hex string
      */
     public String strhex()
     {
-
         StringBuilder b = new StringBuilder();
         for (byte aData : data) {
             int b1 = aData >>> 4 & 0xf;

--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -1497,7 +1497,7 @@ public class ZMQ
             items = new PollItem[size];
             timeout = -1L;
             next = 0;
-        
+
             freeSlots = new LinkedList<Integer>();
         }
 
@@ -1526,12 +1526,12 @@ public class ZMQ
 
         /**
          * Register a Channel for polling on all events.
-         * 
-         * @param channel 
+         *
+         * @param channel
          *            the Channel we are registering.
          * @return the index identifying this Channel in the poll set.
          */
-        public int register(SelectableChannel channel) 
+        public int register(SelectableChannel channel)
         {
             return register(channel, POLLIN | POLLOUT | POLLERR);
         }
@@ -1584,13 +1584,13 @@ public class ZMQ
 
         /**
          * Register a Socket for polling on the specified events.
-         * 
+         *
          * Automatically grow the internal representation if needed.
-         * 
+         *
          * @param item the PollItem we are registering.
          * @return the index identifying this Socket in the poll set.
          */
-        private int registerInternal(PollItem item) 
+        private int registerInternal(PollItem item)
         {
             int pos = -1;
 
@@ -1598,7 +1598,7 @@ public class ZMQ
                 // If there are free slots in our array, remove one
                 // from the free list and use it.
                 pos = freeSlots.remove();
-            } 
+            }
             else {
                 if (next >= items.length) {
                     PollItem[] nitems = new PollItem[items.length + SIZE_INCREMENT];
@@ -1621,7 +1621,6 @@ public class ZMQ
          */
         public void unregister(Socket socket)
         {
-
             unregisterInternal(socket);
         }
 
@@ -1638,7 +1637,7 @@ public class ZMQ
 
         /**
          * Unregister a Socket for polling on the specified events.
-         * 
+         *
          * @param socket the Socket to be unregistered
          */
         private void unregisterInternal(Object socket)

--- a/src/main/java/org/zeromq/ZMQException.java
+++ b/src/main/java/org/zeromq/ZMQException.java
@@ -4,7 +4,6 @@ import zmq.ZError;
 
 public class ZMQException extends RuntimeException
 {
-
     private static final long serialVersionUID = -978820750094924644L;
 
     private final int code;

--- a/src/main/java/org/zeromq/ZThread.java
+++ b/src/main/java/org/zeromq/ZThread.java
@@ -52,7 +52,7 @@ public class ZThread
             if (attachedRunnable != null) {
                 try {
                     attachedRunnable.run(args, ctx, pipe);
-                } 
+                }
                 catch (ZMQException e) {
                     if (e.getErrorCode() != Error.ETERM.getCode()) {
                         throw e;


### PR DESCRIPTION
The codebase is failing the current checkstyle rules, preventing `mvn install` (and other commands, I assume) from working.  This fixes all those style rule failures.