### PR TITLE
Allow ZMQ.Context / ZContext to manage closing poll selectors

### DIFF
--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -335,7 +335,6 @@ public class ZMQ
          * Create a new Poller within this context, with a default size.
          *
          * @return the newly created Poller.
-         * @deprecated Use poller constructor
          */
         public Poller poller()
         {
@@ -350,7 +349,6 @@ public class ZMQ
          * @param size
          *            the poller initial size.
          * @return the newly created Poller.
-         * @deprecated Use poller constructor
          */
         public Poller poller(int size)
         {
@@ -1495,6 +1493,15 @@ public class ZMQ
         // When socket is removed from polling, store free slots here
         private LinkedList<Integer> freeSlots;
 
+        /**
+         * Create a new Poller, with a specified initial size, that is not
+         * associated with any context.
+         *
+         * @param size
+         *            the poller initial size.
+         * @return the newly created Poller.
+         * @deprecated Use ZMQ.Context.poller or ZContext.createPoller instead.
+         */
         public Poller(int size)
         {
             this (null, size);

--- a/src/main/java/zmq/Ctx.java
+++ b/src/main/java/zmq/Ctx.java
@@ -343,7 +343,6 @@ public class Ctx
         try {
             int tid = socket.getTid();
             emptySlots.add(tid);
-            slots[tid].close();
             slots[tid] = null;
 
             //  Remove the socket from the list of sockets.
@@ -354,9 +353,6 @@ public class Ctx
             if (terminating && sockets.isEmpty()) {
                 reaper.stop();
             }
-        }
-        catch (IOException e) {
-            throw new RuntimeException(e);
         }
         finally {
             slotSync.unlock();

--- a/src/main/java/zmq/Ctx.java
+++ b/src/main/java/zmq/Ctx.java
@@ -341,6 +341,7 @@ public class Ctx
         try {
             int tid = socket.getTid();
             emptySlots.add(tid);
+            slots[tid].close();
             slots[tid] = null;
 
             //  Remove the socket from the list of sockets.
@@ -351,6 +352,9 @@ public class Ctx
             if (terminating && sockets.isEmpty()) {
                 reaper.stop();
             }
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
         }
         finally {
             slotSync.unlock();

--- a/src/main/java/zmq/Ctx.java
+++ b/src/main/java/zmq/Ctx.java
@@ -133,6 +133,8 @@ public class Ctx
         termMailbox.close();
 
         tag = 0xdeadbeef;
+
+        zmq.ZMQ.closePollSelector();
     }
 
     //  Returns false if object is not a context.

--- a/src/main/java/zmq/Ctx.java
+++ b/src/main/java/zmq/Ctx.java
@@ -376,6 +376,7 @@ public class Ctx
     {
         try {
             Selector selector = Selector.open();
+            assert (selector != null);
             selectors.add(selector);
             return selector;
         }

--- a/src/main/java/zmq/ZMQ.java
+++ b/src/main/java/zmq/ZMQ.java
@@ -785,18 +785,6 @@ public class ZMQ
 
     private static final ThreadLocal<PollSelector> POLL_SELECTOR = new ThreadLocal<PollSelector>();
 
-    /**
-     * Closes the poll selector on the current thread.
-     */
-    public static void closePollSelector()
-    {
-        PollSelector selector = POLL_SELECTOR.get();
-        if (selector != null) {
-            selector.close();
-        }
-        POLL_SELECTOR.remove();
-    }
-
     // GC closes selector handle
     private static class PollSelector
     {

--- a/src/main/java/zmq/ZMQ.java
+++ b/src/main/java/zmq/ZMQ.java
@@ -785,6 +785,18 @@ public class ZMQ
 
     private static final ThreadLocal<PollSelector> POLL_SELECTOR = new ThreadLocal<PollSelector>();
 
+    /**
+     * Closes the poll selector on the current thread.
+     */
+    public static void closePollSelector()
+    {
+        PollSelector selector = POLL_SELECTOR.get();
+        if (selector != null) {
+            selector.close();
+        }
+        POLL_SELECTOR.remove();
+    }
+
     // GC closes selector handle
     private static class PollSelector
     {
@@ -822,14 +834,23 @@ public class ZMQ
             return selector;
         }
 
+        void close()
+        {
+            if (selector != null) {
+                try {
+                    selector.close();
+                    selector = null;
+                }
+                catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
         @Override
         public void finalize()
         {
-            try {
-                selector.close();
-            }
-            catch (IOException e) {
-            }
+            close();
             try {
                 super.finalize();
             }

--- a/src/test/java/org/zeromq/TestReqRouterThreadedTcp.java
+++ b/src/test/java/org/zeromq/TestReqRouterThreadedTcp.java
@@ -83,7 +83,7 @@ public class TestReqRouterThreadedTcp
 
             client.send("DATA");
 
-            inBetween(client);
+            inBetween(ctx, client);
 
             String reply = client.recvStr();
             assertThat(reply, notNullValue());
@@ -100,7 +100,7 @@ public class TestReqRouterThreadedTcp
          * Called between the request-reply cycle.
          * @param client the socket participating to the cycle of request-reply
          */
-        protected void inBetween(Socket client)
+        protected void inBetween(ZContext ctx, Socket client)
         {
             // to be overriden
         }
@@ -115,7 +115,7 @@ public class TestReqRouterThreadedTcp
 
         // same results
 //        @Override
-//        protected void inBetween(Socket client) {
+//        protected void inBetween(ZContext ctx, Socket client) {
 //            // Poll socket for a reply, with timeout
 //            PollItem items[] = { new PollItem(client, ZMQ.Poller.POLLIN) };
 //            int rc = ZMQ.poll(items, 1, REQUEST_TIMEOUT);
@@ -129,10 +129,10 @@ public class TestReqRouterThreadedTcp
          * This should activate the prefetching mechanism.
          */
         @Override
-        protected void inBetween(Socket client)
+        protected void inBetween(ZContext ctx, Socket client)
         {
             // Poll socket for a reply, with timeout
-            ZMQ.Poller poller = new ZMQ.Poller(1);
+            ZMQ.Poller poller = ctx.createPoller(1);
             poller.register(client, ZMQ.Poller.POLLIN);
 
             int rc = poller.poll(REQUEST_TIMEOUT);

--- a/src/test/java/org/zeromq/TestZContext.java
+++ b/src/test/java/org/zeromq/TestZContext.java
@@ -19,15 +19,4 @@ public class TestZContext
         ctx.close();
         Assert.assertEquals(0, ctx.getSockets().size());
     }
-
-    @Test
-    public void testZContextSocketCloseBeforeContextClose()
-    {
-        ZContext ctx = new ZContext();
-        Socket s1 = ctx.createSocket(ZMQ.PUSH);
-        Socket s2 = ctx.createSocket(ZMQ.PULL);
-        s1.close();
-        s2.close();
-        ctx.close();
-    }
 }

--- a/src/test/java/org/zeromq/TestZContext.java
+++ b/src/test/java/org/zeromq/TestZContext.java
@@ -19,4 +19,15 @@ public class TestZContext
         ctx.close();
         Assert.assertEquals(0, ctx.getSockets().size());
     }
+
+    @Test
+    public void testZContextSocketCloseBeforeContextClose()
+    {
+        ZContext ctx = new ZContext();
+        Socket s1 = ctx.createSocket(ZMQ.PUSH);
+        Socket s2 = ctx.createSocket(ZMQ.PULL);
+        s1.close();
+        s2.close();
+        ctx.close();
+    }
 }

--- a/src/test/java/zmq/TooManyOpenFilesTester.java
+++ b/src/test/java/zmq/TooManyOpenFilesTester.java
@@ -59,34 +59,34 @@ public class TooManyOpenFilesTester
         @Override
         public void run()
         {
-            Ctx ctx = ZMQ.zmqInit(1);
+            Ctx ctx = ZMQ.init(1);
 
-            SocketBase server = ZMQ.zmq_socket(ctx, ZMQ.ZMQ_ROUTER);
+            SocketBase server = ZMQ.socket(ctx, ZMQ.ZMQ_ROUTER);
 
-            ZMQ.zmq_bind(server, "tcp://localhost:" + port);
+            ZMQ.bind(server, "tcp://localhost:" + port);
 
-            Msg msg = ZMQ.zmq_recv(server, 0);
+            Msg msg = ZMQ.recv(server, 0);
 
             Msg address = msg;
 
             poll(server);
 
-            msg = ZMQ.zmq_recv(server, 0);
+            msg = ZMQ.recv(server, 0);
             Msg delimiter = msg;
 
             poll(server);
 
-            msg = ZMQ.zmq_recv(server, 0);
+            msg = ZMQ.recv(server, 0);
 
             // only one echo message for this server
 
-            ZMQ.zmq_send(server, address, ZMQ.ZMQ_SNDMORE);
-            ZMQ.zmq_send(server, delimiter, ZMQ.ZMQ_SNDMORE);
-            ZMQ.zmq_send(server, msg, 0);
+            ZMQ.send(server, address, ZMQ.ZMQ_SNDMORE);
+            ZMQ.send(server, delimiter, ZMQ.ZMQ_SNDMORE);
+            ZMQ.send(server, msg, 0);
 
             // Clean up.
-            ZMQ.zmq_close(server);
-            ZMQ.zmq_term(ctx);
+            ZMQ.close(server);
+            ZMQ.term(ctx);
         }
     }
 
@@ -113,24 +113,24 @@ public class TooManyOpenFilesTester
         @Override
         public void run()
         {
-            Ctx ctx = ZMQ.zmqInit(1);
+            Ctx ctx = ZMQ.init(1);
 
-            SocketBase client = ZMQ.zmq_socket(ctx, ZMQ.ZMQ_REQ);
+            SocketBase client = ZMQ.socket(ctx, ZMQ.ZMQ_REQ);
 
-            ZMQ.zmq_setsockopt(client, ZMQ.ZMQ_IDENTITY, "ID");
-            ZMQ.zmq_connect(client, "tcp://localhost:" + port);
+            ZMQ.setSocketOption(client, ZMQ.ZMQ_IDENTITY, "ID");
+            ZMQ.connect(client, "tcp://localhost:" + port);
 
-            ZMQ.zmq_send(client, "DATA", 0);
+            ZMQ.send(client, "DATA", 0);
 
             inBetween(client);
 
-            Msg reply = ZMQ.zmq_recv(client, 0);
+            Msg reply = ZMQ.recv(client, 0);
             assertThat(reply, notNullValue());
             assertThat(new String(reply.data(), ZMQ.CHARSET), is("DATA"));
 
             // Clean up.
-            ZMQ.zmq_close(client);
-            ZMQ.zmq_term(ctx);
+            ZMQ.close(client);
+            ZMQ.term(ctx);
 
             finished.set(true);
         }
@@ -153,7 +153,7 @@ public class TooManyOpenFilesTester
     {
         // Poll socket for a reply, with timeout
         PollItem item = new PollItem(socket, ZMQ.ZMQ_POLLIN);
-        int rc = zmq.ZMQ.zmq_poll(new PollItem[] { item }, REQUEST_TIMEOUT);
+        int rc = zmq.ZMQ.poll(new PollItem[] { item }, REQUEST_TIMEOUT);
         assertThat(rc, is(1));
 
         boolean readable = item.isReadable();

--- a/src/test/java/zmq/TooManyOpenFilesTester.java
+++ b/src/test/java/zmq/TooManyOpenFilesTester.java
@@ -1,0 +1,227 @@
+package zmq;
+
+/*
+ Copyright (c) 2007-2014 Contributors as noted in the AUTHORS file
+
+ This file is part of 0MQ.
+
+ 0MQ is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by
+ the Free Software Foundation; either version 3 of the License, or
+ (at your option) any later version.
+
+ 0MQ is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+/**
+ * Tests exhaustion of java file pipes,
+ * each component being on a separate thread.
+ * @author fred
+ *
+ */
+public class TooManyOpenFilesTester
+{
+    private static final long REQUEST_TIMEOUT = 1000; // msecs
+
+    /**
+     * A simple server for one reply only.
+     * @author fred
+     *
+     */
+    private class Server extends Thread
+    {
+        private final int port;
+
+        /**
+         * Creates a new server.
+         * @param port the port to which to connect.
+         */
+        public Server(int port)
+        {
+            this.port = port;
+        }
+
+        @Override
+        public void run()
+        {
+            Ctx ctx = ZMQ.zmqInit(1);
+
+            SocketBase server = ZMQ.zmq_socket(ctx, ZMQ.ZMQ_ROUTER);
+
+            ZMQ.zmq_bind(server, "tcp://localhost:" + port);
+
+            Msg msg = ZMQ.zmq_recv(server, 0);
+
+            Msg address = msg;
+
+            poll(server);
+
+            msg = ZMQ.zmq_recv(server, 0);
+            Msg delimiter = msg;
+
+            poll(server);
+
+            msg = ZMQ.zmq_recv(server, 0);
+
+            // only one echo message for this server
+
+            ZMQ.zmq_send(server, address, ZMQ.ZMQ_SNDMORE);
+            ZMQ.zmq_send(server, delimiter, ZMQ.ZMQ_SNDMORE);
+            ZMQ.zmq_send(server, msg, 0);
+
+            // Clean up.
+            ZMQ.zmq_close(server);
+            ZMQ.zmq_term(ctx);
+        }
+    }
+
+    /**
+     * Simple client.
+     * @author fred
+     *
+     */
+    private class Client extends Thread
+    {
+        private final int port;
+
+        final AtomicBoolean finished = new AtomicBoolean();
+
+        /**
+         * Creates a new client.
+         * @param port the port to which to connect.
+         */
+        public Client(int port)
+        {
+            this.port = port;
+        }
+
+        @Override
+        public void run()
+        {
+            Ctx ctx = ZMQ.zmqInit(1);
+
+            SocketBase client = ZMQ.zmq_socket(ctx, ZMQ.ZMQ_REQ);
+
+            ZMQ.zmq_setsockopt(client, ZMQ.ZMQ_IDENTITY, "ID");
+            ZMQ.zmq_connect(client, "tcp://localhost:" + port);
+
+            ZMQ.zmq_send(client, "DATA", 0);
+
+            inBetween(client);
+
+            Msg reply = ZMQ.zmq_recv(client, 0);
+            assertThat(reply, notNullValue());
+            assertThat(new String(reply.data(), ZMQ.CHARSET), is("DATA"));
+
+            // Clean up.
+            ZMQ.zmq_close(client);
+            ZMQ.zmq_term(ctx);
+
+            finished.set(true);
+        }
+
+        /**
+         * Called between the request-reply cycle.
+         * @param client the socket participating to the cycle of request-reply
+         */
+        protected void inBetween(SocketBase client)
+        {
+            poll(client);
+        }
+    }
+
+    /**
+     * Polls while keeping the selector opened.
+     * @param socket the socket to poll
+     */
+    private void poll(SocketBase socket)
+    {
+        // Poll socket for a reply, with timeout
+        PollItem item = new PollItem(socket, ZMQ.ZMQ_POLLIN);
+        int rc = zmq.ZMQ.zmq_poll(new PollItem[] { item }, REQUEST_TIMEOUT);
+        assertThat(rc, is(1));
+
+        boolean readable = item.isReadable();
+        assertThat(readable, is(true));
+    }
+
+    /**
+     * Test exhaustion of java pipes.
+     * Exhaustion can currently come from {@link zmq.Signaler} that are not closed
+     * or from {@link Selector} that are not closed.
+     * @throws Exception if something bad occurs.
+     */
+    @Test
+    public void testReqRouterTcpPoll() throws Exception
+    {
+        // we have no direct way to test this, except by running a bunch of tests and waiting for the failure to happen...
+        // crashed on iteration 3000-ish in my machine for poll selectors; on iteration 16-ish for sockets
+        for (int index = 0; index < 10000; ++index) {
+            long start = System.currentTimeMillis();
+            List<Pair> pairs = new ArrayList<Pair>();
+            int port = 5963;
+
+            for (int idx = 0; idx < 20; ++idx) {
+                Pair pair = testWithPoll(port + idx);
+                pairs.add(pair);
+            }
+
+            for (Pair p : pairs) {
+                p.server.join();
+                p.client.join();
+            }
+
+            boolean finished = true;
+            for (Pair p : pairs) {
+                finished &= p.client.finished.get();
+            }
+            long end = System.currentTimeMillis();
+            assertThat(finished, is(true));
+
+            System.out.printf(
+                    "Test %s finished in %s millis.\n",
+                    index, (end - start));
+        }
+    }
+
+    /**
+     * Dummy class to help keep relation between client and server.
+     * @author fred
+     *
+     */
+    private class Pair
+    {
+        private Client client;
+        private Server server;
+    }
+
+    private Pair testWithPoll(int port)
+    {
+        Server server = new Server(port);
+
+        server.start();
+
+        Client client = new Client(port);
+        client.start();
+
+        Pair pair = new Pair();
+        pair.server = server;
+        pair.client = client;
+        return pair;
+    }
+}


### PR DESCRIPTION
This PR picks up where #230 left off. The goal of this is to ensure that polling Selector resources are deallocated, in order to avoid "Too many open files" problems.

- I started with #230 and rebased on top of current master. There were no conflicts to resolve. I did have to update the ZMQ static method names in @fredoboulo 's new test file, as the method names had changed in master since he opened his PR.

- Per @trevorbernard 's suggestion, I un-reverted the fix in https://github.com/zeromq/jeromq/commit/4a19a453645d9c584345cb24868e9ff9b1fe02bd. I don't understand the full context, but it seems to me like this was fixed for a reason, and it's generally good for our code to be faithful to libzmq code. @trevorbernard also noted that shutdown would hang without that fix.

- There was a test that was removed for no apparent reason in that PR, so I added it back. The test passes.

- #230 added a null check in the PollSelector class. I've left that in, as it is better than just calling `selector.close()`.

- I did not include the `closePollSelector()` step that #230 added to the ZMQ.Context's `destroy` method. The implementation was to close the ThreadLocal `POLL_SELECTOR`, which @trevorbernard noted would not work in multithread use cases.

- I implemented a way for contexts to manage and deallocate poll selectors:
  - Both ZMQ.Context and ZContext now have a `List<Selector> selectors`.
  - Both types of context have a new method that will create a selector, adding it to the list of known selectors.
  - When the context is destroyed, we iterate through each selector, check if it is non-null, and if so, we close it, ensuring that resources are deallocated.
  - To make use of this, you must create the poller via `ZMQ.Context.poller()` / `ZMQ.Context.poller(int size)` or `ZContext.createPoller(int size)`, depending on which type of context you're using.

- Note that this PR does not affect ZPoller in any way. ZPoller does not use any of this code, and the tests are all passing.