### PR TITLE
Ensure that the tests always use ports that aren't already in use

### DIFF
--- a/src/main/java/org/zeromq/Utils.java
+++ b/src/main/java/org/zeromq/Utils.java
@@ -1,0 +1,13 @@
+package org.zeromq;
+
+import java.io.IOException;
+
+public class Utils
+{
+    private Utils() {}
+
+    public static int findOpenPort() throws IOException
+    {
+        return zmq.Utils.findOpenPort();
+    }
+}

--- a/src/main/java/zmq/Utils.java
+++ b/src/main/java/zmq/Utils.java
@@ -3,6 +3,7 @@ package zmq;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Array;
+import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
 import java.nio.ByteBuffer;
@@ -10,7 +11,7 @@ import java.nio.channels.SelectableChannel;
 import java.nio.channels.SocketChannel;
 import java.security.SecureRandom;
 
-class Utils
+public class Utils
 {
     private Utils()
     {
@@ -21,6 +22,14 @@ class Utils
     public static int generateRandom()
     {
         return random.nextInt();
+    }
+
+    public static int findOpenPort() throws IOException
+    {
+        ServerSocket tmpSocket = new ServerSocket(0);
+        int portNumber = tmpSocket.getLocalPort();
+        tmpSocket.close();
+        return portNumber;
     }
 
     public static void tuneTcpSocket(SocketChannel ch) throws SocketException

--- a/src/test/java/org/zeromq/TestProxy.java
+++ b/src/test/java/org/zeromq/TestProxy.java
@@ -10,12 +10,15 @@ public class TestProxy
 {
     static class Client extends Thread
     {
+        private int port = -1;
         private Socket s = null;
         private String name = null;
-        public Client(Context ctx, String name)
+
+        public Client(Context ctx, String name, int port)
         {
             s = ctx.socket(ZMQ.REQ);
             this.name = name;
+            this.port = port;
 
             s.setIdentity(name.getBytes(ZMQ.CHARSET));
         }
@@ -23,7 +26,7 @@ public class TestProxy
         @Override
         public void run()
         {
-            s.connect("tcp://127.0.0.1:6660");
+            s.connect("tcp://127.0.0.1:" + port);
             s.send("hello", 0);
             String msg = s.recvStr(0);
             s.send("world", 0);
@@ -35,12 +38,15 @@ public class TestProxy
 
     static class Dealer extends Thread
     {
+        private int port = -1;
         private Socket s = null;
         private String name = null;
-        public Dealer(Context ctx, String name)
+
+        public Dealer(Context ctx, String name, int port)
         {
             s = ctx.socket(ZMQ.DEALER);
             this.name = name;
+            this.port = port;
 
             s.setIdentity(name.getBytes(ZMQ.CHARSET));
         }
@@ -50,7 +56,7 @@ public class TestProxy
         {
             System.out.println("Start dealer " + name);
 
-            s.connect("tcp://127.0.0.1:6661");
+            s.connect("tcp://127.0.0.1:" + port);
             int count = 0;
             while (count < 2) {
                 String msg = s.recvStr(0);
@@ -87,10 +93,15 @@ public class TestProxy
 
     static class Main extends Thread
     {
+        int frontendPort;
+        int backendPort;
         Context ctx;
-        Main(Context ctx)
+
+        Main(Context ctx, int frontendPort, int backendPort)
         {
             this.ctx = ctx;
+            this.frontendPort = frontendPort;
+            this.backendPort = backendPort;
         }
 
         @Override
@@ -99,11 +110,11 @@ public class TestProxy
             Socket frontend = ctx.socket(ZMQ.ROUTER);
 
             assertNotNull(frontend);
-            frontend.bind("tcp://127.0.0.1:6660");
+            frontend.bind("tcp://127.0.0.1:" + frontendPort);
 
             Socket backend = ctx.socket(ZMQ.DEALER);
             assertNotNull(backend);
-            backend.bind("tcp://127.0.0.1:6661");
+            backend.bind("tcp://127.0.0.1:" + backendPort);
 
             ZMQ.proxy(frontend, backend, null);
 
@@ -118,19 +129,22 @@ public class TestProxy
     @Test
     public void testProxy()  throws Exception
     {
+        int frontendPort = Utils.findOpenPort();
+        int backendPort = Utils.findOpenPort();
+
         Context ctx = ZMQ.context(1);
         assert (ctx != null);
 
-        Main mt = new Main(ctx);
+        Main mt = new Main(ctx, frontendPort, backendPort);
         mt.start();
-        new Dealer(ctx, "AA").start();
-        new Dealer(ctx, "BB").start();
+        new Dealer(ctx, "AA", backendPort).start();
+        new Dealer(ctx, "BB", backendPort).start();
 
         Thread.sleep(1000);
-        Thread c1 = new Client(ctx, "X");
+        Thread c1 = new Client(ctx, "X", frontendPort);
         c1.start();
 
-        Thread c2 = new Client(ctx, "Y");
+        Thread c2 = new Client(ctx, "Y", frontendPort);
         c2.start();
 
         c1.join();

--- a/src/test/java/org/zeromq/TestReqRouterThreadedTcp.java
+++ b/src/test/java/org/zeromq/TestReqRouterThreadedTcp.java
@@ -151,7 +151,7 @@ public class TestReqRouterThreadedTcp
     @Test
     public void testReqRouterTcp() throws Exception
     {
-        int port = 5962;
+        int port = Utils.findOpenPort();
         Server server = new Server(port);
 
         server.start();
@@ -174,7 +174,7 @@ public class TestReqRouterThreadedTcp
     @Test
     public void testReqRouterTcpPoll() throws Exception
     {
-        int port = 5963;
+        int port = Utils.findOpenPort();
         Server server = new Server(port);
 
         server.start();

--- a/src/test/java/org/zeromq/TestZMQ.java
+++ b/src/test/java/org/zeromq/TestZMQ.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.IOException;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.CharacterCodingException;
@@ -19,9 +21,12 @@ public class TestZMQ
 {
     static class Client extends Thread
     {
+        private int port = -1;
         private Socket s = null;
-        public Client(Context ctx)
+
+        public Client(Context ctx, int port)
         {
+            this.port = port;
             s = ctx.socket(ZMQ.PULL);
         }
 
@@ -29,7 +34,7 @@ public class TestZMQ
         public void run()
         {
             System.out.println("Start client thread ");
-            s.connect("tcp://127.0.0.1:6669");
+            s.connect("tcp://127.0.0.1:" + port);
             s.recv(0);
 
             s.close();
@@ -40,12 +45,14 @@ public class TestZMQ
     @Test
     public void testPollerPollout() throws Exception
     {
+        int port = Utils.findOpenPort();
+
         ZMQ.Context context = ZMQ.context(1);
-        Client client = new Client(context);
+        Client client = new Client(context, port);
 
         //  Socket to send messages to
         ZMQ.Socket sender = context.socket(ZMQ.PUSH);
-        sender.bind("tcp://127.0.0.1:6669");
+        sender.bind("tcp://127.0.0.1:" + port);
 
         ZMQ.Poller outItems;
         outItems = context.poller();
@@ -69,8 +76,9 @@ public class TestZMQ
     }
 
     @Test
-    public void testByteBufferSend() throws InterruptedException
+    public void testByteBufferSend() throws InterruptedException, IOException
     {
+        int port = Utils.findOpenPort();
         ZMQ.Context context = ZMQ.context(1);
         ByteBuffer bb = ByteBuffer.allocate(4).order(ByteOrder.nativeOrder());
         ZMQ.Socket push = null;
@@ -78,8 +86,8 @@ public class TestZMQ
         try {
             push = context.socket(ZMQ.PUSH);
             pull = context.socket(ZMQ.PULL);
-            pull.bind("tcp://*:12344");
-            push.connect("tcp://localhost:12344");
+            pull.bind("tcp://*:" + port);
+            push.connect("tcp://localhost:" + port);
             bb.put("PING".getBytes(ZMQ.CHARSET));
             bb.flip();
             push.sendByteBuffer(bb, 0);
@@ -106,8 +114,10 @@ public class TestZMQ
     }
 
     @Test
-    public void testByteBufferRecv() throws InterruptedException, CharacterCodingException
+    public void testByteBufferRecv()
+    throws InterruptedException, IOException, CharacterCodingException
     {
+        int port = Utils.findOpenPort();
         ZMQ.Context context = ZMQ.context(1);
         ByteBuffer bb = ByteBuffer.allocate(6).order(ByteOrder.nativeOrder());
         ZMQ.Socket push = null;
@@ -115,8 +125,8 @@ public class TestZMQ
         try {
             push = context.socket(ZMQ.PUSH);
             pull = context.socket(ZMQ.PULL);
-            pull.bind("tcp://*:12345");
-            push.connect("tcp://localhost:12345");
+            pull.bind("tcp://*:" + port);
+            push.connect("tcp://localhost:" + port);
             push.send("PING".getBytes(ZMQ.CHARSET), 0);
             pull.recvByteBuffer(bb, 0);
             bb.flip();
@@ -148,8 +158,10 @@ public class TestZMQ
     }
 
     @Test
-    public void testByteBufferLarge() throws InterruptedException, CharacterCodingException
+    public void testByteBufferLarge()
+    throws InterruptedException, IOException, CharacterCodingException
     {
+        int port = Utils.findOpenPort();
         ZMQ.Context context = ZMQ.context(1);
         int[] array = new int[2048 * 2000];
         for (int i = 0; i < array.length; ++i) {
@@ -165,8 +177,8 @@ public class TestZMQ
         try {
             push = context.socket(ZMQ.PUSH);
             pull = context.socket(ZMQ.PULL);
-            pull.bind("tcp://*:12345");
-            push.connect("tcp://localhost:12345");
+            pull.bind("tcp://*:" + port);
+            push.connect("tcp://localhost:" + port);
             push.sendByteBuffer(bSend, 0);
             pull.recvByteBuffer(bRec, 0);
             bRec.flip();
@@ -196,8 +208,10 @@ public class TestZMQ
     }
 
     @Test
-    public void testByteBufferLargeDirect() throws InterruptedException, CharacterCodingException
+    public void testByteBufferLargeDirect()
+    throws InterruptedException, IOException, CharacterCodingException
     {
+        int port = Utils.findOpenPort();
         ZMQ.Context context = ZMQ.context(1);
         int[] array = new int[2048 * 2000];
         for (int i = 0; i < array.length; ++i) {
@@ -213,8 +227,8 @@ public class TestZMQ
         try {
             push = context.socket(ZMQ.PUSH);
             pull = context.socket(ZMQ.PULL);
-            pull.bind("tcp://*:12345");
-            push.connect("tcp://localhost:12345");
+            pull.bind("tcp://*:" + port);
+            push.connect("tcp://localhost:" + port);
             push.sendByteBuffer(bSend, 0);
             pull.recvByteBuffer(bRec, 0);
             bRec.flip();
@@ -244,15 +258,16 @@ public class TestZMQ
     }
 
     @Test(expected = ZMQException.class)
-    public void testBindSameAddress()
+    public void testBindSameAddress() throws IOException
     {
+        int port = Utils.findOpenPort();
         ZMQ.Context context = ZMQ.context(1);
 
         ZMQ.Socket socket1 = context.socket(ZMQ.REQ);
         ZMQ.Socket socket2 = context.socket(ZMQ.REQ);
-        socket1.bind("tcp://*:12346");
+        socket1.bind("tcp://*:" + port);
         try {
-            socket2.bind("tcp://*:12346");
+            socket2.bind("tcp://*:" + port);
             fail("Exception not thrown");
         }
         catch (ZMQException e) {
@@ -319,7 +334,7 @@ public class TestZMQ
     }
 
     @Test
-    public void testEventConnectDelayed()
+    public void testEventConnectDelayed() throws IOException
     {
         Context context = ZMQ.context(1);
         ZMQ.Event event;
@@ -331,7 +346,9 @@ public class TestZMQ
         assertTrue(socket.monitor("inproc://monitor.socket", ZMQ.EVENT_CONNECT_DELAYED));
         monitor.connect("inproc://monitor.socket");
 
-        socket.connect("tcp://127.0.0.1:6751");
+        int randomPort = Utils.findOpenPort();
+
+        socket.connect("tcp://127.0.0.1:" + randomPort);
         event = ZMQ.Event.recv(monitor);
         assertNotNull("No event was received", event);
         assertEquals(ZMQ.EVENT_CONNECT_DELAYED, event.getEvent());
@@ -342,7 +359,8 @@ public class TestZMQ
     }
 
     @Test
-    public void testEventConnectRetried() throws InterruptedException
+    public void testEventConnectRetried()
+    throws InterruptedException, IOException
     {
         Context context = ZMQ.context(1);
         ZMQ.Event event;
@@ -354,7 +372,9 @@ public class TestZMQ
         assertTrue(socket.monitor("inproc://monitor.socket", ZMQ.EVENT_CONNECT_RETRIED));
         monitor.connect("inproc://monitor.socket");
 
-        socket.connect("tcp://127.0.0.1:6752");
+        int randomPort = Utils.findOpenPort();
+
+        socket.connect("tcp://127.0.0.1:" + randomPort);
         Thread.sleep(1000L); // on windows, this is required, otherwise test fails
         event = ZMQ.Event.recv(monitor);
         assertNotNull("No event was received", event);

--- a/src/test/java/org/zeromq/TestZProxy.java
+++ b/src/test/java/org/zeromq/TestZProxy.java
@@ -1,16 +1,33 @@
 package org.zeromq;
 
+import java.io.IOException;
+
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.zeromq.ZMQ.Socket;
 
 public class TestZProxy
 {
+    private int frontPort;
+    private int backPort;
+    private int capturePort1;
+    private int capturePort2;
+
+    @Before
+    public void setUp() throws IOException
+    {
+        frontPort    = Utils.findOpenPort();
+        backPort     = Utils.findOpenPort();
+        capturePort1 = Utils.findOpenPort();
+        capturePort2 = Utils.findOpenPort();
+    }
+
     @Test
     public void testAllOptionsAsync()
     {
@@ -117,13 +134,13 @@ public class TestZProxy
         public void configure(Socket socket, ZProxy.Plug place, Object[] extrArgs)
         {
             if (place == ZProxy.Plug.FRONT) {
-                socket.bind("tcp://127.0.0.1:6660");
+                socket.bind("tcp://127.0.0.1:" + frontPort);
             }
             if (place == ZProxy.Plug.BACK) {
-                socket.bind("tcp://127.0.0.1:6661");
+                socket.bind("tcp://127.0.0.1:" + backPort);
             }
             if (place == ZProxy.Plug.CAPTURE && socket != null) {
-                socket.bind("tcp://127.0.0.1:6662");
+                socket.bind("tcp://127.0.0.1:" + capturePort1);
             }
         }
 
@@ -132,19 +149,19 @@ public class TestZProxy
         {
 //            System.out.println("HOT restart msg : " + cfg);
             if (place == ZProxy.Plug.FRONT) {
-                socket.unbind("tcp://127.0.0.1:6660");
+                socket.unbind("tcp://127.0.0.1:" + frontPort);
                 waitSomeTime();
-                socket.bind("tcp://127.0.0.1:6660");
+                socket.bind("tcp://127.0.0.1:" + frontPort);
             }
             if (place == ZProxy.Plug.BACK) {
-                socket.unbind("tcp://127.0.0.1:6661");
+                socket.unbind("tcp://127.0.0.1:" + backPort);
                 waitSomeTime();
-                socket.bind("tcp://127.0.0.1:6661");
+                socket.bind("tcp://127.0.0.1:" + backPort);
             }
             if (place == ZProxy.Plug.CAPTURE && socket != null) {
-                socket.unbind("tcp://127.0.0.1:6662");
+                socket.unbind("tcp://127.0.0.1:" + capturePort1);
                 waitSomeTime();
-                socket.bind("tcp://127.0.0.1:5432");
+                socket.bind("tcp://127.0.0.1:" + capturePort2);
             }
             String msg = cfg.popString();
             return "COLD".equals(msg);

--- a/src/test/java/org/zeromq/ZBeaconTest.java
+++ b/src/test/java/org/zeromq/ZBeaconTest.java
@@ -1,5 +1,6 @@
 package org.zeromq;
 
+import java.io.IOException;
 import java.net.InetAddress;
 
 import org.junit.Test;
@@ -12,12 +13,13 @@ import static org.junit.Assert.assertEquals;
 public class ZBeaconTest
 {
     @Test
-    public void test() throws InterruptedException
+    public void test() throws InterruptedException, IOException
     {
         final CountDownLatch latch = new CountDownLatch(1);
         byte[] beacon = new byte[] { 'H', 'Y', 'D', 'R', 'A', 0x01, 0x12, 0x34 };
         byte[] prefix = new byte[] { 'H', 'Y', 'D', 'R', 'A', 0x01 };
-        ZBeacon zbeacon = new ZBeacon("255.255.255.255", 5670, beacon, false);
+        int port = Utils.findOpenPort();
+        ZBeacon zbeacon = new ZBeacon("127.0.0.1", port, beacon, false);
         zbeacon.setPrefix(prefix);
         zbeacon.setListener(new Listener()
         {

--- a/src/test/java/org/zeromq/ZSocketTest.java
+++ b/src/test/java/org/zeromq/ZSocketTest.java
@@ -1,5 +1,7 @@
 package org.zeromq;
 
+import java.io.IOException;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -7,12 +9,14 @@ import static org.junit.Assert.assertEquals;
 public class ZSocketTest
 {
     @Test
-    public void pushPullTest()
+    public void pushPullTest() throws IOException
     {
+        int port = Utils.findOpenPort();
+
         try (final ZSocket pull = new ZSocket(ZMQ.PULL);
              final ZSocket push = new ZSocket(ZMQ.PUSH)) {
-            pull.bind("tcp://*:7210");
-            push.connect("tcp://127.0.0.1:7210");
+            pull.bind("tcp://*:" + port);
+            push.connect("tcp://127.0.0.1:" + port);
 
             final String expected = "hello";
             push.sendStringUtf8(expected);

--- a/src/test/java/zmq/TcpAddressTest.java
+++ b/src/test/java/zmq/TcpAddressTest.java
@@ -2,6 +2,7 @@ package zmq;
 
 import org.junit.Test;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 
 import static org.junit.Assert.assertEquals;
@@ -9,10 +10,10 @@ import static org.junit.Assert.assertEquals;
 public class TcpAddressTest
 {
     @Test
-    public void parsesIpv6Address()
+    public void parsesIpv6Address() throws IOException
     {
         String addressString = "2000::a1";
-        int port = 9999;
+        int port = Utils.findOpenPort();
         TcpAddress address = new TcpAddress("[" + addressString + "]:" + port);
 
         InetSocketAddress expected = new InetSocketAddress(addressString, port);

--- a/src/test/java/zmq/TestConnectDelay.java
+++ b/src/test/java/zmq/TestConnectDelay.java
@@ -16,6 +16,9 @@ public class TestConnectDelay
         // of the messages getting queued, as connect() creates a
         // pipe immediately.
 
+        int pushPort1 = Utils.findOpenPort();
+        int pushPort2 = Utils.findOpenPort();
+
         Ctx context = ZMQ.createContext();
         assert (context != null);
 
@@ -24,7 +27,7 @@ public class TestConnectDelay
 
         int val = 0;
         ZMQ.setSocketOption(to, ZMQ.ZMQ_LINGER, val);
-        boolean rc = ZMQ.bind(to, "tcp://*:7555");
+        boolean rc = ZMQ.bind(to, "tcp://*:" + pushPort1);
         assert (rc);
 
         // Create a socket pushing to two endpoints - only 1 message should arrive.
@@ -33,9 +36,9 @@ public class TestConnectDelay
 
         val = 0;
         ZMQ.setSocketOption(from, ZMQ.ZMQ_LINGER, val);
-        rc = ZMQ.connect(from, "tcp://localhost:7556");
+        rc = ZMQ.connect(from, "tcp://localhost:" + pushPort2);
         assert (rc);
-        rc = ZMQ.connect(from, "tcp://localhost:7555");
+        rc = ZMQ.connect(from, "tcp://localhost:" + pushPort1);
         assert (rc);
 
         for (int i = 0; i < 10; ++i) {
@@ -77,11 +80,13 @@ public class TestConnectDelay
         // also set the delay attach on connect flag, which should
         // cause the pipe attachment to be delayed until the connection
         // succeeds.
+        int validPort   = Utils.findOpenPort();
+        int invalidPort = Utils.findOpenPort();
         Ctx context = ZMQ.createContext();
 
         SocketBase to = ZMQ.socket(context, ZMQ.ZMQ_PULL);
         assert (to != null);
-        boolean rc = ZMQ.bind(to, "tcp://*:7560");
+        boolean rc = ZMQ.bind(to, "tcp://*:" + validPort);
         assert (rc);
 
         int val = 0;
@@ -100,10 +105,10 @@ public class TestConnectDelay
         ZMQ.setSocketOption(from, ZMQ.ZMQ_DELAY_ATTACH_ON_CONNECT, val);
 
         // Connect to the invalid socket
-        rc = ZMQ.connect(from, "tcp://localhost:7561");
+        rc = ZMQ.connect(from, "tcp://localhost:" + invalidPort);
         assert (rc);
         // Connect to the valid socket
-        rc = ZMQ.connect(from, "tcp://localhost:7560");
+        rc = ZMQ.connect(from, "tcp://localhost:" + validPort);
         assert (rc);
 
         for (int i = 0; i < 10; ++i) {
@@ -141,6 +146,7 @@ public class TestConnectDelay
         // occurs with an existing connection that is broken. We will send
         // messages to a connected pipe, disconnect and verify the messages
         // block. Then we reconnect and verify messages flow again.
+        int port = Utils.findOpenPort();
         Ctx context = ZMQ.createContext();
 
         SocketBase backend = ZMQ.socket(context, ZMQ.ZMQ_DEALER);
@@ -159,10 +165,10 @@ public class TestConnectDelay
         val = 1;
         ZMQ.setSocketOption(frontend, ZMQ.ZMQ_DELAY_ATTACH_ON_CONNECT, val);
 
-        boolean rc = ZMQ.bind(backend, "tcp://*:7760");
+        boolean rc = ZMQ.bind(backend, "tcp://*:" + port);
         assert (rc);
 
-        rc = ZMQ.connect(frontend, "tcp://localhost:7760");
+        rc = ZMQ.connect(frontend, "tcp://localhost:" + port);
         assert (rc);
 
         //  Ping backend to frontend so we know when the connection is up
@@ -190,7 +196,7 @@ public class TestConnectDelay
         backend = ZMQ.socket(context, ZMQ.ZMQ_DEALER);
         val = 0;
         ZMQ.setSocketOption(backend, ZMQ.ZMQ_LINGER, val);
-        rc = ZMQ.bind(backend, "tcp://*:7760");
+        rc = ZMQ.bind(backend, "tcp://*:" + port);
         assert (rc);
 
         //  Ping backend to frontend so we know when the connection is up

--- a/src/test/java/zmq/TestConnectResolve.java
+++ b/src/test/java/zmq/TestConnectResolve.java
@@ -1,5 +1,7 @@
 package zmq;
 
+import java.io.IOException;
+
 import org.junit.Test;
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
@@ -8,8 +10,9 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 public class TestConnectResolve
 {
     @Test
-    public void testConnectResolve()
+    public void testConnectResolve() throws IOException
     {
+        int port = Utils.findOpenPort();
         System.out.println("test_connect_resolve running...\n");
 
         Ctx ctx = ZMQ.init(1);
@@ -20,12 +23,12 @@ public class TestConnectResolve
         SocketBase sock = ZMQ.socket(ctx, ZMQ.ZMQ_PUB);
         assertThat(sock, notNullValue());
 
-        boolean brc = ZMQ.connect(sock, "tcp://localhost:1234");
+        boolean brc = ZMQ.connect(sock, "tcp://localhost:" + port);
         assertThat(brc, is(true));
 
         /*
         try {
-            brc = ZMQ.connect (sock, "tcp://foobar123xyz:1234");
+            brc = ZMQ.connect (sock, "tcp://foobar123xyz:" + port);
             assertTrue(false);
         } catch (IllegalArgumentException e) {
         }

--- a/src/test/java/zmq/TestLastEndpoint.java
+++ b/src/test/java/zmq/TestLastEndpoint.java
@@ -1,5 +1,6 @@
 package zmq;
 
+import java.io.IOException;
 import java.util.UUID;
 
 import org.junit.Test;
@@ -19,8 +20,11 @@ public class TestLastEndpoint
     }
 
     @Test
-    public void testLastEndpoint()
+    public void testLastEndpoint() throws IOException
     {
+        int port1 = Utils.findOpenPort();
+        int port2 = Utils.findOpenPort();
+
         //  Create the infrastructure
         Ctx ctx = ZMQ.init(1);
         assertThat(ctx, notNullValue());
@@ -28,8 +32,8 @@ public class TestLastEndpoint
         SocketBase sb = ZMQ.socket(ctx, ZMQ.ZMQ_ROUTER);
         assertThat(sb, notNullValue());
 
-        bindAndVerify(sb, "tcp://127.0.0.1:5560");
-        bindAndVerify(sb, "tcp://127.0.0.1:5561");
+        bindAndVerify(sb, "tcp://127.0.0.1:" + port1);
+        bindAndVerify(sb, "tcp://127.0.0.1:" + port2);
         bindAndVerify(sb, "ipc:///tmp/testep" + UUID.randomUUID().toString());
 
         sb.close();

--- a/src/test/java/zmq/TestMonitor.java
+++ b/src/test/java/zmq/TestMonitor.java
@@ -72,7 +72,8 @@ public class TestMonitor
     @Test
     public void testMonitor() throws Exception
     {
-        String addr = "tcp://127.0.0.1:5590";
+        int port = Utils.findOpenPort();
+        String addr = "tcp://127.0.0.1:" + port;
         SocketMonitor [] threads = new SocketMonitor [3];
         //  Create the infrastructure
         Ctx ctx = ZMQ.init(1);

--- a/src/test/java/zmq/TestPairTcp.java
+++ b/src/test/java/zmq/TestPairTcp.java
@@ -1,5 +1,7 @@
 package zmq;
 
+import java.io.IOException;
+
 import org.junit.Test;
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
@@ -10,18 +12,19 @@ public class TestPairTcp
     //  Create REQ/ROUTER wiring.
 
     @Test
-    public void testPairTpc()
+    public void testPairTcp() throws IOException
     {
+        int port = Utils.findOpenPort();
         Ctx ctx = ZMQ.init(1);
         assertThat(ctx, notNullValue());
         SocketBase sb = ZMQ.socket(ctx, ZMQ.ZMQ_PAIR);
         assertThat(sb, notNullValue());
-        boolean brc = ZMQ.bind(sb, "tcp://127.0.0.1:6570");
+        boolean brc = ZMQ.bind(sb, "tcp://127.0.0.1:" + port);
         assertThat(brc, is(true));
 
         SocketBase sc = ZMQ.socket(ctx, ZMQ.ZMQ_PAIR);
         assertThat(sc, notNullValue());
-        brc = ZMQ.connect(sc, "tcp://127.0.0.1:6570");
+        brc = ZMQ.connect(sc, "tcp://127.0.0.1:" + port);
         assertThat(brc, is(true));
 
         Helper.bounce(sb, sc);

--- a/src/test/java/zmq/TestPubsubTcp.java
+++ b/src/test/java/zmq/TestPubsubTcp.java
@@ -10,12 +10,13 @@ public class TestPubsubTcp
     @Test
     public void testPubsubTcp() throws Exception
     {
+        int port = Utils.findOpenPort();
         Ctx ctx = ZMQ.init(1);
         assertThat(ctx, notNullValue());
 
         SocketBase sb = ZMQ.socket(ctx, ZMQ.ZMQ_PUB);
         assertThat(sb, notNullValue());
-        boolean rc = ZMQ.bind(sb, "tcp://127.0.0.1:7660");
+        boolean rc = ZMQ.bind(sb, "tcp://127.0.0.1:" + port);
         assertThat(rc, is(true));
 
         SocketBase sc = ZMQ.socket(ctx, ZMQ.ZMQ_SUB);
@@ -23,7 +24,7 @@ public class TestPubsubTcp
 
         sc.setSocketOpt(ZMQ.ZMQ_SUBSCRIBE, "topic");
 
-        rc = ZMQ.connect(sc, "tcp://127.0.0.1:7660");
+        rc = ZMQ.connect(sc, "tcp://127.0.0.1:" + port);
         assertThat(rc, is(true));
 
         ZMQ.sleep(2);

--- a/src/test/java/zmq/TestReqrepDevice.java
+++ b/src/test/java/zmq/TestReqrepDevice.java
@@ -1,5 +1,7 @@
 package zmq;
 
+import java.io.IOException;
+
 import org.junit.Test;
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
@@ -10,8 +12,11 @@ public class TestReqrepDevice
     //  Create REQ/ROUTER wiring.
 
     @Test
-    public void testReprepDevice()
+    public void testReprepDevice() throws IOException
     {
+        int routerPort = Utils.findOpenPort();
+        int dealerPort = Utils.findOpenPort();
+
         boolean brc;
         Ctx ctx = ZMQ.init(1);
         assertThat(ctx, notNullValue());
@@ -20,26 +25,26 @@ public class TestReqrepDevice
         SocketBase dealer = ZMQ.socket(ctx, ZMQ.ZMQ_DEALER);
         assertThat(dealer, notNullValue());
 
-        brc = ZMQ.bind(dealer, "tcp://127.0.0.1:5580");
+        brc = ZMQ.bind(dealer, "tcp://127.0.0.1:" + dealerPort);
         assertThat(brc , is(true));
 
         SocketBase router = ZMQ.socket(ctx, ZMQ.ZMQ_ROUTER);
         assertThat(router, notNullValue());
 
-        brc = ZMQ.bind(router, "tcp://127.0.0.1:5581");
+        brc = ZMQ.bind(router, "tcp://127.0.0.1:" + routerPort);
         assertThat(brc , is(true));
 
         //  Create a worker.
         SocketBase rep = ZMQ.socket(ctx, ZMQ.ZMQ_REP);
         assertThat(rep, notNullValue());
 
-        brc = ZMQ.connect(rep, "tcp://127.0.0.1:5580");
+        brc = ZMQ.connect(rep, "tcp://127.0.0.1:" + dealerPort);
         assertThat(brc , is(true));
 
         SocketBase req = ZMQ.socket(ctx, ZMQ.ZMQ_REQ);
         assertThat(req, notNullValue());
 
-        brc = ZMQ.connect(req, "tcp://127.0.0.1:5581");
+        brc = ZMQ.connect(req, "tcp://127.0.0.1:" + routerPort);
         assertThat(brc, is(true));
 
         //  Send a request.

--- a/src/test/java/zmq/TestReqrepTcp.java
+++ b/src/test/java/zmq/TestReqrepTcp.java
@@ -10,17 +10,18 @@ public class TestReqrepTcp
     @Test
     public void testReqrepTcp() throws Exception
     {
+        int port = Utils.findOpenPort();
         Ctx ctx = ZMQ.init(1);
         assertThat(ctx, notNullValue());
 
         SocketBase sb = ZMQ.socket(ctx, ZMQ.ZMQ_REP);
         assertThat(sb, notNullValue());
-        boolean rc = ZMQ.bind(sb, "tcp://127.0.0.1:7560");
+        boolean rc = ZMQ.bind(sb, "tcp://127.0.0.1:" + port);
         assertThat(rc, is(true));
 
         SocketBase sc = ZMQ.socket(ctx, ZMQ.ZMQ_REQ);
         assertThat(sc, notNullValue());
-        rc = ZMQ.connect(sc, "tcp://127.0.0.1:7560");
+        rc = ZMQ.connect(sc, "tcp://127.0.0.1:" + port);
         assertThat(rc, is(true));
 
         Helper.bounce(sb, sc);

--- a/src/test/java/zmq/TestRouterHandover.java
+++ b/src/test/java/zmq/TestRouterHandover.java
@@ -15,11 +15,13 @@ public class TestRouterHandover
         int rc;
         boolean brc;
 
+        int port = Utils.findOpenPort();
+
         Ctx ctx = ZMQ.init(1);
         assertThat(ctx, notNullValue());
 
         SocketBase router = ZMQ.socket(ctx, ZMQ.ZMQ_ROUTER);
-        brc = ZMQ.bind(router, "tcp://127.0.0.1:15561");
+        brc = ZMQ.bind(router, "tcp://127.0.0.1:" + port);
         assertThat(brc , is(true));
 
         // Enable the handover flag
@@ -32,7 +34,7 @@ public class TestRouterHandover
 
         ZMQ.setSocketOption(dealerOne, ZMQ.ZMQ_IDENTITY, "X");
 
-        brc = ZMQ.connect(dealerOne, "tcp://127.0.0.1:15561");
+        brc = ZMQ.connect(dealerOne, "tcp://127.0.0.1:" + port);
         assertThat(brc, is(true));
 
         // Get message from dealer to know when connection is ready
@@ -52,7 +54,7 @@ public class TestRouterHandover
 
         ZMQ.setSocketOption(dealerTwo, ZMQ.ZMQ_IDENTITY, "X");
 
-        brc = ZMQ.connect(dealerTwo, "tcp://127.0.0.1:15561");
+        brc = ZMQ.connect(dealerTwo, "tcp://127.0.0.1:" + port);
         assertThat(brc, is(true));
 
         // Get message from dealer to know when connection is ready

--- a/src/test/java/zmq/TestRouterMandatory.java
+++ b/src/test/java/zmq/TestRouterMandatory.java
@@ -13,6 +13,8 @@ public class TestRouterMandatory
         int rc;
         boolean brc;
 
+        int port = Utils.findOpenPort();
+
         Ctx ctx = ZMQ.init(1);
         assertThat(ctx, notNullValue());
 
@@ -20,7 +22,7 @@ public class TestRouterMandatory
         ZMQ.setSocketOption(sa, ZMQ.ZMQ_SNDHWM, 1);
         assertThat(sa, notNullValue());
 
-        brc = ZMQ.bind(sa, "tcp://127.0.0.1:15560");
+        brc = ZMQ.bind(sa, "tcp://127.0.0.1:" + port);
         assertThat(brc , is(true));
 
         // Sending a message to an unknown peer with the default setting
@@ -46,7 +48,7 @@ public class TestRouterMandatory
         ZMQ.setSocketOption(sb, ZMQ.ZMQ_RCVHWM, 1);
         ZMQ.setSocketOption(sb, ZMQ.ZMQ_IDENTITY, "X");
 
-        brc = ZMQ.connect(sb, "tcp://127.0.0.1:15560");
+        brc = ZMQ.connect(sb, "tcp://127.0.0.1:" + port);
 
         // wait until connect
         Thread.sleep(1000);

--- a/src/test/java/zmq/TestSubForward.java
+++ b/src/test/java/zmq/TestSubForward.java
@@ -1,5 +1,7 @@
 package zmq;
 
+import java.io.IOException;
+
 import org.junit.Test;
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
@@ -11,27 +13,31 @@ public class TestSubForward
     //  Create REQ/ROUTER wiring.
 
     @Test
-    public void testSubForward()
+    public void testSubForward() throws IOException
     {
+        int port1 = Utils.findOpenPort();
+        int port2 = Utils.findOpenPort();
+
         Ctx ctx = ZMQ.init(1);
         assertThat(ctx, notNullValue());
+
         SocketBase xpub = ZMQ.socket(ctx, ZMQ.ZMQ_XPUB);
         assertThat(xpub, notNullValue());
-        boolean rc = ZMQ.bind(xpub, "tcp://127.0.0.1:5570");
+        boolean rc = ZMQ.bind(xpub, "tcp://127.0.0.1:" + port1);
 
         SocketBase xsub = ZMQ.socket(ctx, ZMQ.ZMQ_XSUB);
         assertThat(xsub, notNullValue());
-        rc = ZMQ.bind(xsub, "tcp://127.0.0.1:5571");
+        rc = ZMQ.bind(xsub, "tcp://127.0.0.1:" + port2);
         assertThat(rc, is(true));
 
         SocketBase pub = ZMQ.socket(ctx, ZMQ.ZMQ_PUB);
         assertThat(pub, notNullValue());
-        rc = ZMQ.connect(pub, "tcp://127.0.0.1:5571");
+        rc = ZMQ.connect(pub, "tcp://127.0.0.1:" + port2);
         assertThat(rc, is(true));
 
         SocketBase sub = ZMQ.socket(ctx, ZMQ.ZMQ_SUB);
         assertThat(sub, notNullValue());
-        rc = ZMQ.connect(sub, "tcp://127.0.0.1:5570");
+        rc = ZMQ.connect(sub, "tcp://127.0.0.1:" + port1);
         assertThat(rc, is(true));
 
         ZMQ.setSocketOption(sub, ZMQ.ZMQ_SUBSCRIBE, "");

--- a/src/test/java/zmq/TestTermEndpoint.java
+++ b/src/test/java/zmq/TestTermEndpoint.java
@@ -10,7 +10,8 @@ public class TestTermEndpoint
     @Test
     public void testTermEndpoint() throws Exception
     {
-        String ep = "tcp://127.0.0.1:7590";
+        int port = Utils.findOpenPort();
+        String ep = "tcp://127.0.0.1:" + port;
         Ctx ctx = ZMQ.init(1);
         assertThat(ctx, notNullValue());
 

--- a/src/test/java/zmq/TooManyOpenFilesTester.java
+++ b/src/test/java/zmq/TooManyOpenFilesTester.java
@@ -156,7 +156,7 @@ public class TooManyOpenFilesTester
         for (int index = 0; index < 10000; ++index) {
             long start = System.currentTimeMillis();
             List<Pair> pairs = new ArrayList<Pair>();
-            int port = 5963;
+            int port = Utils.findOpenPort();
 
             for (int idx = 0; idx < 20; ++idx) {
                 Pair pair = testWithPoll(port + idx);


### PR DESCRIPTION
This makes the tests more deterministic by not using hard-coded ports that might already be in use by another process on your computer. I've noticed tests failing both on my machine and in Travis builds for this reason. Instead, we can use the ServerSocket constructor (wrapped up in a new util method, `findOpenPort`) to find ports that are guaranteed to be available.

Fixes #385.