### PR TITLE
When polling and the context is terminated, don't throw ZError.IOException

### DIFF
--- a/src/main/java/zmq/Ctx.java
+++ b/src/main/java/zmq/Ctx.java
@@ -150,6 +150,8 @@ public class Ctx
     }
 
     //  Returns false if object is not a context.
+    //
+    //  This will also return false if terminate() has been called.
     public boolean checkTag()
     {
         return tag == 0xabadcafe;


### PR DESCRIPTION
This should fix #380 (Destroying a context while polling causes java.nio.channels.ClosedChannelException).

Summary of changes in this PR:

- When a Poller is created via a context (which is the recommended way to do it; see #386), `poller.context` is set to that context so the poller has a reference to it.

- When `poll` results in a ClosedChannelException or any other ZError.IOException, we check to see if the context is terminated, and if so, we catch the exception and return 0.