### PR TITLE
Minor refactoring in ZContext, Ctx, Reaper

### DIFF
--- a/src/main/java/org/zeromq/ZContext.java
+++ b/src/main/java/org/zeromq/ZContext.java
@@ -156,6 +156,16 @@ public class ZContext implements Closeable
     }
 
     /**
+     * @param ioThreads the number of ioThreads to set
+     * @deprecated This value should not be changed after the context is initialized.
+     */
+    @Deprecated
+    public void setIoThreads(int ioThreads)
+    {
+        return;
+    }
+
+    /**
      * @return the linger
      */
     public int getLinger()
@@ -180,6 +190,16 @@ public class ZContext implements Closeable
     }
 
     /**
+     * @param main whether or not the context is being set to main
+     * @deprecated This value should not be changed after the context is initialized.
+     */
+    @Deprecated
+    public void setMain(boolean main)
+    {
+        return;
+    }
+
+    /**
      * @return the context
      */
     public Context getContext()
@@ -195,6 +215,16 @@ public class ZContext implements Closeable
             }
         }
         return result;
+    }
+
+    /**
+     * @param ctx sets the underlying zmq.Context associated with this ZContext wrapper object
+     * @deprecated This value should not be changed after the ZContext is initialized.
+     */
+    @Deprecated
+    public void setContext(Context ctx)
+    {
+        return;
     }
 
     /**

--- a/src/main/java/org/zeromq/ZContext.java
+++ b/src/main/java/org/zeromq/ZContext.java
@@ -51,7 +51,7 @@ public class ZContext implements Closeable
      */
     public ZContext()
     {
-        this(null, true, 1);
+        this(1);
     }
 
     public ZContext(int ioThreads)

--- a/src/main/java/zmq/Reaper.java
+++ b/src/main/java/zmq/Reaper.java
@@ -115,10 +115,10 @@ public class Reaper extends ZObject implements IPollEvents, Closeable
     @Override
     protected void processReap(SocketBase socket)
     {
+        ++socketsReaping;
+
         //  Add the socket to the poller.
         socket.startReaping(poller);
-
-        ++socketsReaping;
     }
 
     @Override


### PR DESCRIPTION
This PR picks up where #274 left off.

Summary of changes:

- **ZContext**
  - Make the parameters set in the constructor final, and deprecate the setters for those parameters:
    - setIoThreads
    - setMain
    - setContext
  - Because it is no longer possible for the setters to set these parameters (results in a compile error), the deprecated setters are now no-ops. Any code utilizing these functions should be rewritten, which I think is a step in the right direction.

- **Ctx**
  - Move the code block for initialization of slots to a separate function, to reduce the size of createSocket(). (aesthetic change only)

- **Reaper**
  - Move duplicated code block to a function. (aesthetic change only)
  - Increment reap count before starting the reap instead of after.