### PR TITLE
Fix use of pollers w/ sockets that get destroyed in examples

### DIFF
--- a/src/test/java/guide/bstarcli.java
+++ b/src/test/java/guide/bstarcli.java
@@ -61,6 +61,7 @@ public class bstarcli
                     System.out.printf ("W: no response from server, failing over\n");
 
                     //  Old socket is confused; close it and open a new one
+                    poller.unregister(client);
                     ctx.destroySocket(client);
                     serverNbr = (serverNbr + 1) % 2;
                     Thread.sleep(SETTLE_DELAY);
@@ -68,6 +69,7 @@ public class bstarcli
                             server[serverNbr]);
                     client = ctx.createSocket(ZMQ.REQ);
                     client.connect(server[serverNbr]);
+                    poller.register(client, ZMQ.Poller.POLLIN);
 
                     //  Send request again, on new socket
                     client.send(request);

--- a/src/test/java/guide/lpclient.java
+++ b/src/test/java/guide/lpclient.java
@@ -67,10 +67,12 @@ public class lpclient
                 } else {
                     System.out.println("W: no response from server, retrying\n");
                     //  Old socket is confused; close it and open a new one
+                    poller.unregister(client);
                     ctx.destroySocket(client);
                     System.out.println("I: reconnecting to server\n");
                     client = ctx.createSocket(ZMQ.REQ);
                     client.connect(SERVER_ENDPOINT);
+                    poller.register(client, Poller.POLLIN);
                     //  Send request again, on new socket
                     client.send(request);
                 }


### PR DESCRIPTION
In #386, I moved the poller initialization code in these ZGuide examples up above the while loop, so that we're re-using the same poller instead of creating a new one on each iteration.

This broke the examples because of the retry pattern where we're destroying and re-creating the sockets that are being polled. When the poller polls again, it polls a socket that has been destroyed, resulting in a ClosedChannelException.

This PR fixes that by unregistering the socket that gets destroyed and registering the new one.