### PR TITLE
#412 tcp accept filter null pointer exception fix

### DIFF
--- a/src/main/java/zmq/TcpListener.java
+++ b/src/main/java/zmq/TcpListener.java
@@ -145,18 +145,12 @@ public class TcpListener extends Own implements IPollEvents
     }
 
     //  Accept the new connection. Returns the file descriptor of the
-    //  newly created connection. The function may return retired_fd
+    //  newly created connection. The function may throw IOException
     //  if the connection was dropped while waiting in the listen backlog
     //  or was denied because of accept filters.
-    private SocketChannel accept()
+    private SocketChannel accept() throws IOException
     {
-        Socket sock = null;
-        try {
-            sock = handle.socket().accept();
-        }
-        catch (IOException e) {
-            return null;
-        }
+        Socket sock = handle.socket().accept();
 
         if (!options.tcpAcceptFilters.isEmpty()) {
             boolean matched = false;
@@ -172,7 +166,7 @@ public class TcpListener extends Own implements IPollEvents
                 }
                 catch (IOException e) {
                 }
-                return null;
+                throw new IOException("address does not match accept filter");
             }
         }
         return sock.getChannel();


### PR DESCRIPTION
simple fix for #412 . i am only changing 1 private method (`TcpListener::accept`). that method is only used in one place.  i am changing the method to throw an `IOException` instead of returning null.  returning null is guaranteed to cause a `NullPoinerException` which is guaranteed to stop the `Poller::run` loop.  an `IOException` will instead be caught by an existing catch block in `TcpListener::acceptEvent` and handled gracefully (sent to the monitor socket or ignored).