### PR TITLE
#413 ZMQ.ZMQ_TCP_ACCEPT_FILTER NullPointerException fix changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.4.1 (unreleased)
+
+### Changed
+
+* [#413](https://github.com/zeromq/jeromq/pull/413): fixed a NullPointerException when ZMQ.ZMQ_TCP_ACCEPT_FILTER is used
+
 ## v0.4.0 (2017-03-22)
 
 ### Added


### PR DESCRIPTION
i've added a 0.4.1 release to the changelog.  this is also my way of asking for a release build, though i can open an issue ticket if that's better. i realize you just cut a release a couple weeks ago, but that means your machine is already set up to do it again, right? :)