### PR TITLE
Poller.destroy: don't swallow InterruptedException

### DIFF
--- a/src/main/java/org/zeromq/ZBeacon.java
+++ b/src/main/java/org/zeromq/ZBeacon.java
@@ -132,6 +132,8 @@ public class ZBeacon
                         Thread.sleep(broadcastInterval);
                     }
                     catch (InterruptedException interruptedException) {
+                        // Re-interrupt the thread so the caller can handle it.
+                        Thread.currentThread().interrupt();
                         break;
                     }
                     catch (Exception exception) {

--- a/src/main/java/zmq/poll/Poller.java
+++ b/src/main/java/zmq/poll/Poller.java
@@ -96,6 +96,8 @@ public final class Poller extends PollerBase implements Runnable
         }
         catch (InterruptedException e) {
             e.printStackTrace();
+            // Re-interrupt the thread so the caller can handle it.
+            Thread.currentThread().interrupt();
         }
         finally {
             ctx.closeSelector(selector);


### PR DESCRIPTION
I read [this](http://www.yegor256.com/2015/10/20/interrupted-exception.html) today and learned about how to properly handle an InterruptedException. Because of #116, I was curious to see if there are any places in the codebase where we aren't doing this the right way, and I think I found two places where we are swallowing an InterruptedException.

I don't think this fixes #116, but I believe this to be a step in the right direction. Perhaps the problem re: #116 is that we aren't checking `Thread.interrupted()` often enough in the low-level code. I'm still trying to figure that one out.