### PR TITLE
Do not parse CURVE keys as Strings

### DIFF
--- a/src/main/java/zmq/Options.java
+++ b/src/main/java/zmq/Options.java
@@ -473,25 +473,29 @@ public class Options
             // TODO V4 setting a curve key as null does change the mechanism type ?
             result.set(false);
             return null;
-        } else {
+        }
+        else {
             byte[] key = null;
             // if the optval is already the key don't do any parsing
             if (optval instanceof byte[] && ((byte[]) optval).length == CURVE_KEYSIZE) {
                 key = (byte[]) optval;
                 result.set(true);
                 errno.set(0);
-            } else {
+            }
+            else {
                 String val = parseString(option, optval);
                 int length = val.length();
                 if (length == CURVE_KEYSIZE_Z85) {
                     key = Z85.decode(val);
                     result.set(true);
                     errno.set(0);
-                } else if (length == CURVE_KEYSIZE) {
+                }
+                else if (length == CURVE_KEYSIZE) {
                     key = val.getBytes(ZMQ.CHARSET);
                     result.set(true);
                     errno.set(0);
-                } else {
+                }
+                else {
                     result.set(false);
                     errno.set(ZError.EINVAL);
                 }

--- a/src/main/java/zmq/Options.java
+++ b/src/main/java/zmq/Options.java
@@ -473,28 +473,33 @@ public class Options
             // TODO V4 setting a curve key as null does change the mechanism type ?
             result.set(false);
             return null;
-        }
-        else {
-            String val = parseString(option, optval);
+        } else {
             byte[] key = null;
-            int length = val.length();
-            if (length == CURVE_KEYSIZE_Z85) {
-                key = Z85.decode(val);
+            // if the optval is already the key don't do any parsing
+            if (optval instanceof byte[] && ((byte[]) optval).length == CURVE_KEYSIZE) {
+                key = (byte[]) optval;
                 result.set(true);
                 errno.set(0);
-            }
-            else if (length == CURVE_KEYSIZE) {
-                key = val.getBytes(ZMQ.CHARSET);
-                result.set(true);
-                errno.set(0);
-            }
-            else {
-                result.set(false);
-                errno.set(ZError.EINVAL);
+            } else {
+                String val = parseString(option, optval);
+                int length = val.length();
+                if (length == CURVE_KEYSIZE_Z85) {
+                    key = Z85.decode(val);
+                    result.set(true);
+                    errno.set(0);
+                } else if (length == CURVE_KEYSIZE) {
+                    key = val.getBytes(ZMQ.CHARSET);
+                    result.set(true);
+                    errno.set(0);
+                } else {
+                    result.set(false);
+                    errno.set(ZError.EINVAL);
+                }
             }
             if (key != null) {
                 mechanism = Mechanisms.CURVE;
             }
+
             return key;
         }
     }

--- a/src/test/java/zmq/io/mechanism/SecurityCurveTest.java
+++ b/src/test/java/zmq/io/mechanism/SecurityCurveTest.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.assertThat;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.Socket;
-import java.util.Arrays;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -128,7 +127,6 @@ public class SecurityCurveTest
 
             byte[] testBytes = "hello-world".getBytes();
 
-            System.out.println("Sending bytes: " + Arrays.toString(testBytes));
             clientSocket.send(testBytes);
 
             byte[] recv = serverSocket.recv();

--- a/src/test/java/zmq/io/mechanism/SecurityCurveTest.java
+++ b/src/test/java/zmq/io/mechanism/SecurityCurveTest.java
@@ -1,6 +1,9 @@
 package zmq.io.mechanism;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
@@ -92,13 +95,15 @@ public class SecurityCurveTest
     private String connectionString;
 
     @Before
-    public void before() throws Exception {
+    public void before() throws Exception
+    {
         int port = Utils.findOpenPort();
         connectionString = "tcp://127.0.0.1:" + port;
     }
 
     @Test
-    public void testPlainCurveKeys() throws Exception {
+    public void testPlainCurveKeys() throws Exception
+    {
 
         byte[][] serverKeyPair = new Curve().keypair();
         byte[] serverPublicKey = serverKeyPair[0];
@@ -132,7 +137,8 @@ public class SecurityCurveTest
     }
 
     @Test
-    public void testCurveMechanismSecurity() throws IOException, InterruptedException {
+    public void testCurveMechanismSecurity() throws IOException, InterruptedException
+    {
         Curve cryptoBox = new Curve();
         //  Generate new keypairs for this test
         //  We'll generate random test keys at startup


### PR DESCRIPTION
When setting the CURVE keys for ZMQ.Sockets the given byte array was parsed as a String although it already contained the raw key bytes.
This caused our application to fail because it was not clear that the byte arrays created by the Curve.keypair()-method were not allowed to be used directly. 
Instead we head to create Z85 encoded Strings and get their byte value UTF-8. This PR fixed this behaviour.

Also added a regression test for this bug.