### PR TITLE
Revert "Revert "Make jeromq usable with Android API < 24""

### DIFF
--- a/src/main/java/zmq/io/net/tcp/TcpUtils.java
+++ b/src/main/java/zmq/io/net/tcp/TcpUtils.java
@@ -1,11 +1,13 @@
 package zmq.io.net.tcp;
 
 import java.io.IOException;
+import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
-import java.nio.channels.NetworkChannel;
+import java.nio.channels.Channel;
 import java.nio.channels.SelectableChannel;
+import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 
 import zmq.ZError;
@@ -15,7 +17,18 @@ public class TcpUtils
 {
     private static interface OptionSetter
     {
-        void setOption(Socket socket) throws SocketException;
+        boolean setOption(Socket socket) throws SocketException;
+
+        boolean setOption(ServerSocket socket) throws SocketException;
+    }
+
+    private abstract static class SocketOptionSetter implements OptionSetter
+    {
+        @Override
+        public boolean setOption(ServerSocket socket) throws SocketException
+        {
+            return false;
+        }
     }
 
     private TcpUtils()
@@ -27,12 +40,13 @@ public class TcpUtils
         // Disable Nagle's algorithm. We are doing data batching on 0MQ level,
         // so using Nagle wouldn't improve throughput in anyway, but it would
         // hurt latency.
-        setOption(channel, new OptionSetter()
+        setOption(channel, new SocketOptionSetter()
         {
             @Override
-            public void setOption(Socket socket) throws SocketException
+            public boolean setOption(Socket socket) throws SocketException
             {
                 socket.setTcpNoDelay(true);
+                return true;
             }
         });
     }
@@ -42,74 +56,95 @@ public class TcpUtils
             throws IOException
     {
         final boolean keepAlive = tcpKeepAlive == 1;
-        setOption(channel, new OptionSetter()
+        setOption(channel, new SocketOptionSetter()
         {
             @Override
-            public void setOption(Socket socket) throws SocketException
+            public boolean setOption(Socket socket) throws SocketException
             {
                 socket.setKeepAlive(keepAlive);
-            }
-        });
-    }
-
-    public static boolean setTcpReceiveBuffer(NetworkChannel channel, final int rcvbuf)
-    {
-        return setOption(channel, new OptionSetter()
-        {
-            @Override
-            public void setOption(Socket socket) throws SocketException
-            {
-                socket.setReceiveBufferSize(rcvbuf);
-            }
-        });
-    }
-
-    public static boolean setTcpSendBuffer(NetworkChannel channel, final int sndbuf)
-    {
-        return setOption(channel, new OptionSetter()
-        {
-            @Override
-            public void setOption(Socket socket) throws SocketException
-            {
-                socket.setSendBufferSize(sndbuf);
-            }
-        });
-    }
-
-    public static boolean setIpTypeOfService(NetworkChannel channel, final int tos)
-    {
-        return setOption(channel, new OptionSetter()
-        {
-            @Override
-            public void setOption(Socket socket) throws SocketException
-            {
-                socket.setTrafficClass(tos);
-            }
-        });
-    }
-
-    public static boolean setReuseAddress(NetworkChannel channel, final boolean reuse)
-    {
-        return setOption(channel, new OptionSetter()
-        {
-            @Override
-            public void setOption(Socket socket) throws SocketException
-            {
-                socket.setReuseAddress(reuse);
-            }
-        });
-    }
-
-    private static <T> boolean setOption(NetworkChannel channel, OptionSetter setter)
-    {
-        if (channel instanceof SocketChannel) {
-            try {
-                setter.setOption(((SocketChannel) channel).socket());
                 return true;
             }
-            catch (SocketException e) {
-                throw new ZError.IOException(e);
+        });
+    }
+
+    public static boolean setTcpReceiveBuffer(Channel channel, final int rcvbuf)
+    {
+        return setOption(channel, new OptionSetter()
+        {
+            @Override
+            public boolean setOption(Socket socket) throws SocketException
+            {
+                socket.setReceiveBufferSize(rcvbuf);
+                return true;
             }
+
+            @Override
+            public boolean setOption(ServerSocket socket) throws SocketException
+            {
+                socket.setReceiveBufferSize(rcvbuf);
+                return true;
+            }
+        });
+    }
+
+    public static boolean setTcpSendBuffer(Channel channel, final int sndbuf)
+    {
+        return setOption(channel, new SocketOptionSetter()
+        {
+            @Override
+            public boolean setOption(Socket socket) throws SocketException
+            {
+                socket.setSendBufferSize(sndbuf);
+                return true;
+            }
+        });
+    }
+
+    public static boolean setIpTypeOfService(Channel channel, final int tos)
+    {
+        return setOption(channel, new SocketOptionSetter()
+        {
+            @Override
+            public boolean setOption(Socket socket) throws SocketException
+            {
+                socket.setTrafficClass(tos);
+                return true;
+            }
+        });
+    }
+
+    public static boolean setReuseAddress(Channel channel, final boolean reuse)
+    {
+        return setOption(channel, new OptionSetter()
+        {
+            @Override
+            public boolean setOption(Socket socket) throws SocketException
+            {
+                socket.setReuseAddress(reuse);
+                return true;
+            }
+
+            @Override
+            public boolean setOption(ServerSocket socket) throws SocketException
+            {
+                socket.setReuseAddress(reuse);
+                return true;
+            }
+        });
+    }
+
+    private static boolean setOption(Channel channel, OptionSetter setter)
+    {
+        try {
+            if (channel instanceof ServerSocketChannel) {
+                return setter.setOption(((ServerSocketChannel) channel).socket());
+            }
+            else if (channel instanceof SocketChannel) {
+                return setter.setOption(((SocketChannel) channel).socket());
+            }
+        }
+        catch (SocketException e) {
+            throw new ZError.IOException(e);
         }
         return false;
     }


### PR DESCRIPTION
Reverts zeromq/jeromq#458 to reinstate possibility to use lib in Android environment, as the failing tests are fixed.