### PR TITLE
Small changes

### DIFF
--- a/src/main/java/org/zeromq/ZActor.java
+++ b/src/main/java/org/zeromq/ZActor.java
@@ -39,8 +39,8 @@ import org.zeromq.ZPoller.EventsHandler;
  * <br/>
  * The provided {@link Actor} is living on the Plateau.
  * <br/>
- * The Plateau is made of the Stage where {@link Actor#stage(Socket, Socket, ZPoller, int) the effective processing occurs} and of the Backstage
- * where the provided actor can {@link Actor#backstage(Socket, ZPoller, int) send and receive} control messages to and from the ZActor.
+ * The Plateau is made of the Stage where {@link org.zeromq.ZActor.Actor#stage(org.zeromq.ZMQ.Socket, org.zeromq.ZMQ.Socket, org.zeromq.ZPoller, int) the effective processing occurs} and of the Backstage
+ * where the provided actor can {@link org.zeromq.ZActor.Actor#backstage(org.zeromq.ZMQ.Socket, org.zeromq.ZPoller, int) send and receive} control messages to and from the ZActor.
  * <br/>
  * From this side, the work is done via callbacks using the template-method pattern, applied with interfaces (?)
  * <p>

--- a/src/main/java/org/zeromq/ZBeacon.java
+++ b/src/main/java/org/zeromq/ZBeacon.java
@@ -7,6 +7,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.DatagramChannel;
 import java.util.Arrays;
@@ -131,7 +132,7 @@ public class ZBeacon
                         broadcastChannel.send(ByteBuffer.wrap(beacon), broadcastInetSocketAddress);
                         Thread.sleep(broadcastInterval);
                     }
-                    catch (InterruptedException interruptedException) {
+                    catch (InterruptedException | ClosedByInterruptException interruptedException) {
                         // Re-interrupt the thread so the caller can handle it.
                         Thread.currentThread().interrupt();
                         break;

--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -407,7 +407,7 @@ public class ZMQ
         }
     }
 
-    public static final class Socket implements Closeable
+    public static class Socket implements Closeable
     {
         //  This port range is defined by IANA for dynamic or private ports
         //  We use this when choosing a port for dynamic binding.

--- a/src/main/java/org/zeromq/ZPoller.java
+++ b/src/main/java/org/zeromq/ZPoller.java
@@ -62,7 +62,7 @@ import org.zeromq.ZMQ.Socket;
 <p>
  * The motivations of this rewriting are:
  * <br/>
- * - the bare poller use {@link zmq.ZMQ#poll(zmq.poll.PollItem[], int, long) this method} who does not allow
+ * - the bare poller used zmq.ZMQ#poll(zmq.poll.PollItem[], int, long). This method did not allow
  * to choose the selector used for polling, relying on a ThreadLocal, which is dangerous.
  * <br/>
  * - the bare poller use algorithms tailored for languages with manual allocation.

--- a/src/main/java/org/zeromq/ZProxy.java
+++ b/src/main/java/org/zeromq/ZProxy.java
@@ -38,7 +38,7 @@ import zmq.SocketBase;
  *  <br/>
  * <li>Proxy mechanism ensured by pluggable pumps
  *    <ul>
- *      <li>with built-in low-level {@link ZmqPump} (zmq.ZMQ): useful for performances
+ *      <li>with built-in low-level {@link org.zeromq.ZProxy.ZmqPump} (zmq.ZMQ): useful for performances
  *      <li>with built-in high-level  {@link org.zeromq.ZProxy.ZPump}  (ZeroMQ): useful for {@link org.zeromq.ZProxy.ZPump.Transformer message transformation}, lower performances
  *      <li>with your own-custom proxy pump implementing a {@link Pump 1-method interface}
  *    </ul>

--- a/src/main/java/zmq/io/SessionBase.java
+++ b/src/main/java/zmq/io/SessionBase.java
@@ -29,7 +29,7 @@ public class SessionBase extends Own implements Pipe.IPipeEvents, IPollEvents
 {
     //  If true, this session (re)connects to the peer. Otherwise, it's
     //  a transient session created by the listener.
-    private boolean active;
+    private final boolean active;
 
     //  Pipe connecting the session to its socket.
     private Pipe pipe;

--- a/src/main/java/zmq/socket/FQ.java
+++ b/src/main/java/zmq/socket/FQ.java
@@ -107,6 +107,7 @@ public class FQ
                 more = msg.hasMore();
                 if (!more) {
                     lastIn = currentPipe;
+                    assert (active > 0); // happens when multiple threads receive messages
                     current = (current + 1) % active;
                 }
                 return msg;


### PR DESCRIPTION
Assert on FQ to assess single-threading behavior on receive (related to #447)
ZMQ.Socket class is no longer final (fixes #446)
added jacoco coverage as a proposal
Small javadoc changes
Handle interrupt by close in ZBeacon (quite rare occurrences)