### PR TITLE
Typos and warning removals

### DIFF
--- a/src/main/java/org/zeromq/ManagedContext.java
+++ b/src/main/java/org/zeromq/ManagedContext.java
@@ -32,7 +32,7 @@ class ManagedContext
     {
         this.ctx = ZMQ.init(ZMQ.ZMQ_IO_THREADS_DFLT);
         this.lock = new ReentrantLock();
-        this.sockets = new HashSet<SocketBase>();
+        this.sockets = new HashSet<>();
     }
 
     static ManagedContext getInstance()

--- a/src/main/java/org/zeromq/ZActor.java
+++ b/src/main/java/org/zeromq/ZActor.java
@@ -464,8 +464,7 @@ public class ZActor extends ZStar
         @Override
         public Star create(ZContext ctx, Socket pipe, Selector sel, int count, Star previous, Object[] args)
         {
-            Star star = new ZActor.Double(ctx, pipe, sel, actor, args);
-            return star;
+            return new ZActor.Double(ctx, pipe, sel, actor, args);
         }
 
         @Override
@@ -509,7 +508,7 @@ public class ZActor extends ZStar
             final List<Socket> created = actor.createSockets(ctx, args);
             assert (created != null);
 
-            sockets = new ArrayList<Socket>(created);
+            sockets = new ArrayList<>(created);
 
             poller = new ZPoller(selector);
             poller.setGlobalHandler(this);

--- a/src/main/java/org/zeromq/ZAgent.java
+++ b/src/main/java/org/zeromq/ZAgent.java
@@ -88,8 +88,13 @@ public interface ZAgent
      */
     Socket pipe();
 
-    public static class Creator
+    class Creator
     {
+        private Creator()
+        {
+            super();
+        }
+
         public static ZAgent create(Socket pipe, String lock)
         {
             return new SimpleAgent(pipe, lock);
@@ -210,7 +215,7 @@ public interface ZAgent
      */
     // Contract for selector creation.
     // will be called in backstage side.
-    public static interface SelectorCreator
+    interface SelectorCreator
     {
         /**
          * Creates and opens a selector.
@@ -227,7 +232,7 @@ public interface ZAgent
     }
 
     // very simple selector creator
-    public static class VerySimpleSelectorCreator implements SelectorCreator
+    class VerySimpleSelectorCreator implements SelectorCreator
     {
         @Override
         public Selector create() throws IOException

--- a/src/main/java/org/zeromq/ZContext.java
+++ b/src/main/java/org/zeromq/ZContext.java
@@ -61,7 +61,7 @@ public class ZContext implements Closeable
 
     private ZContext(Context context, boolean main, int ioThreads)
     {
-        sockets = new CopyOnWriteArrayList<Socket>();
+        sockets = new CopyOnWriteArrayList<>();
         this.context = context;
         this.ioThreads = ioThreads;
         this.main = main;

--- a/src/main/java/org/zeromq/ZLoop.java
+++ b/src/main/java/org/zeromq/ZLoop.java
@@ -37,7 +37,7 @@ public class ZLoop
             errors = 0;
         }
 
-    };
+    }
 
     private class STimer
     {
@@ -74,10 +74,10 @@ public class ZLoop
         assert (context != null);
         this.context = context;
 
-        pollers = new ArrayList<SPoller>();
-        timers = new ArrayList<STimer>();
-        zombies = new ArrayList<Object>();
-        newTimers = new ArrayList<STimer>();
+        pollers = new ArrayList<>();
+        timers = new ArrayList<>();
+        zombies = new ArrayList<>();
+        newTimers = new ArrayList<>();
     }
 
     public ZLoop(ZContext ctx)

--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -939,7 +939,7 @@ public class ZMQ
          */
         public boolean setHWM(int hwm)
         {
-            boolean set = true;
+            boolean set = false;
             set |= setSndHWM(hwm);
             set |= setRcvHWM(hwm);
             return set;
@@ -2287,7 +2287,7 @@ public class ZMQ
             return (byte[]) base.getSocketOptx(zmq.ZMQ.ZMQ_CURVE_SECRETKEY);
         }
 
-        public static enum Mechanism
+        public enum Mechanism
         {
             NULL(Mechanisms.NULL),
             PLAIN(Mechanisms.PLAIN),
@@ -2650,7 +2650,7 @@ public class ZMQ
             timeout = -1L;
             next = 0;
 
-            freeSlots = new LinkedList<Integer>();
+            freeSlots = new LinkedList<>();
         }
 
         /**
@@ -2744,7 +2744,7 @@ public class ZMQ
          */
         private int registerInternal(PollItem item)
         {
-            int pos = -1;
+            int pos;
 
             if (!freeSlots.isEmpty()) {
                 // If there are free slots in our array, remove one

--- a/src/main/java/org/zeromq/ZPoller.java
+++ b/src/main/java/org/zeromq/ZPoller.java
@@ -73,7 +73,7 @@ import org.zeromq.ZMQ.Socket;
 public class ZPoller implements Closeable
 {
     // contract for events
-    public static interface EventsHandler
+    public interface EventsHandler
     {
         /**
          * Called when the poller intercepts events.
@@ -95,7 +95,7 @@ public class ZPoller implements Closeable
     }
 
     // contract for items. Useful for providing own implementation.
-    public static interface ItemHolder
+    public interface ItemHolder
     {
         // the inner ZMQ poll item
         zmq.poll.PollItem item();
@@ -108,7 +108,7 @@ public class ZPoller implements Closeable
     }
 
     // contract for items creation. Useful for delegating.
-    public static interface ItemCreator
+    public interface ItemCreator
     {
         /**
          * Creates a new holder for a poll item.
@@ -473,7 +473,7 @@ public class ZPoller implements Closeable
     {
         // get all the raw items
         final Collection<ItemHolder> all = items();
-        final Set<zmq.poll.PollItem> pollItems = new HashSet<zmq.poll.PollItem>(all.size());
+        final Set<zmq.poll.PollItem> pollItems = new HashSet<>(all.size());
         for (ItemHolder holder : all) {
             pollItems.add(holder.item());
         }

--- a/src/main/java/org/zeromq/ZProxy.java
+++ b/src/main/java/org/zeromq/ZProxy.java
@@ -121,15 +121,15 @@ public class ZProxy
     /**
      * Possible places for sockets in the proxy.
      */
-    public static enum Plug
+    public enum Plug
     {
         FRONT, // The position of the frontend socket.
         BACK, // The position of the backend socket.
-        CAPTURE; // The position of the capture socket.
+        CAPTURE // The position of the capture socket.
     }
 
     // Contract for socket creation and customizable configuration in proxy threading.
-    public static interface Proxy
+    public interface Proxy
     {
         /**
          * Creates and initializes (bind, options ...) the socket for the given plug in the proxy.
@@ -240,7 +240,7 @@ public class ZProxy
     public static ZProxy newZProxy(ZContext ctx, String name, SelectorCreator selector, Proxy sockets,
                                    String motdelafin, Object... args)
     {
-        return new ZProxy(ctx, name, selector, sockets, new ZPump(), null, args);
+        return new ZProxy(ctx, name, selector, sockets, new ZPump(), motdelafin, args);
     }
 
     public static ZProxy newZProxy(ZContext ctx, String name, Proxy sockets, String motdelafin, Object... args)
@@ -537,7 +537,7 @@ public class ZProxy
     }
 
     // to handle commands in a more java-centric way
-    public static enum Command
+    public enum Command
     {
         START,
         PAUSE,
@@ -545,7 +545,7 @@ public class ZProxy
         RESTART,
         EXIT,
         STATUS,
-        CONFIG;
+        CONFIG
     }
 
     // commands for the control pipe
@@ -558,13 +558,13 @@ public class ZProxy
     private static final String CONFIG  = Command.CONFIG.name();
 
     // to handle states in a more java-centric way
-    public static enum State
+    public enum State
     {
         ALIVE,
         STARTED,
         PAUSED,
         STOPPED,
-        EXITED;
+        EXITED
     }
 
     // state responses from the control pipe
@@ -629,8 +629,7 @@ public class ZProxy
         int count = 1;
         count += args.length;
 
-        Object[] vars = null;
-        vars = new Object[count];
+        Object[] vars = new Object[count];
 
         vars[0] = sockets;
         Actor shadow = null;
@@ -657,7 +656,7 @@ public class ZProxy
     }
 
     // defines a pump that will flow messages from one socket to another
-    public static interface Pump
+    public interface Pump
     {
         /**
          * Transfers a message from one source to one destination, with an optional capture.
@@ -784,7 +783,7 @@ public class ZProxy
                 return false;
             }
             else if (STOP.equals(cmd)) {
-                stop(poller);
+                stop();
                 return status().send(pipe);
             }
             else if (PAUSE.equals(cmd)) {
@@ -794,7 +793,7 @@ public class ZProxy
             else if (RESTART.equals(cmd)) {
                 String val = pipe.recvStr();
                 boolean hot = Boolean.parseBoolean(val);
-                return restart(pipe, poller, hot);
+                return restart(pipe, hot);
             }
             else if (STATUS.equals(cmd)) {
                 return status().send(pipe);
@@ -877,7 +876,7 @@ public class ZProxy
             return true;
         }
 
-        private boolean stop(ZPoller poller)
+        private boolean stop()
         {
             // restart the actor in stopped state
             state.started = false;
@@ -888,7 +887,7 @@ public class ZProxy
         }
 
         // handles the restart command in both modes
-        private boolean restart(Socket pipe, ZPoller poller, boolean hot)
+        private boolean restart(Socket pipe, boolean hot)
         {
             state.restart = true;
             if (hot) {
@@ -941,7 +940,7 @@ public class ZProxy
                     state.hot = null;
 
                     // we perform a cold restart if the provider says so
-                    boolean cold = false;
+                    boolean cold;
                     ZMsg dup = cfg.duplicate();
 
                     try {
@@ -995,7 +994,7 @@ public class ZProxy
         private final Transformer transformer;
 
         // transforms one message into another
-        public static interface Transformer
+        public interface Transformer
         {
             /**
              * Transforms a ZMsg into another ZMsg.
@@ -1033,7 +1032,7 @@ public class ZProxy
         @Override
         public boolean flow(Plug splug, Socket source, Socket capture, Plug dplug, Socket destination)
         {
-            boolean success = false;
+            boolean success;
 
             // we read the whole message
             ZMsg msg = ZMsg.recvMsg(source);

--- a/src/main/java/org/zeromq/ZSocket.java
+++ b/src/main/java/org/zeromq/ZSocket.java
@@ -210,6 +210,9 @@ public class ZSocket implements AutoCloseable
     public byte[] receive(int flags)
     {
         final Msg msg = socketBase.recv(flags);
+        if (msg == null) {
+            return null;
+        }
         return msg.data();
     }
 

--- a/src/main/java/org/zeromq/ZStar.java
+++ b/src/main/java/org/zeromq/ZStar.java
@@ -69,7 +69,7 @@ public class ZStar implements ZAgent
      * Contract interface when acting in plain sight.
      */
     // contract interface for acting with the spot lights on
-    public static interface Star
+    public interface Star
     {
         /**
          * Called when the star is in the wings.<br/>
@@ -122,7 +122,7 @@ public class ZStar implements ZAgent
     /**
      * Utility class with callback for when the Star has finished its performances.
      */
-    public static interface TimeTaker
+    public interface TimeTaker
     {
         /**
          * Called when the show is finished but no cleaning is still done.
@@ -141,7 +141,7 @@ public class ZStar implements ZAgent
     }
 
     // contract for a creator of stars
-    public static interface Fortune extends TimeTaker
+    public interface Fortune extends TimeTaker
     {
         /**
          * This is the grand premiere!
@@ -184,7 +184,7 @@ public class ZStar implements ZAgent
     /**
      * Control for the end of the remote operations.
      */
-    public static interface Exit
+    public interface Exit
     {
         /**
          * Causes the current thread to wait in blocking mode until the end of the remote operations,
@@ -332,7 +332,7 @@ public class ZStar implements ZAgent
             set = new SimpleSet();
         }
 
-        final List<Object> train = new ArrayList<Object>(6 + bags.length);
+        final List<Object> train = new ArrayList<>(6 + bags.length);
 
         train.add(set);
         train.add(fortune);
@@ -582,7 +582,7 @@ public class ZStar implements ZAgent
         return agent.sign();
     }
 
-    public static interface Set
+    public interface Set
     {
         /**
          * Puts the performance name on the front door with big lights.
@@ -624,7 +624,7 @@ public class ZStar implements ZAgent
     /**
      * Utility class with calls surrounding the execution of the Star.
      */
-    public static interface Entourage extends TimeTaker
+    public interface Entourage extends TimeTaker
     {
         /**
          * Called when the show is about to start.

--- a/src/main/java/org/zeromq/ZThread.java
+++ b/src/main/java/org/zeromq/ZThread.java
@@ -11,12 +11,12 @@ public class ZThread
 
     public interface IAttachedRunnable
     {
-        public void run(Object[] args, ZContext ctx, Socket pipe);
+        void run(Object[] args, ZContext ctx, Socket pipe);
     }
 
     public interface IDetachedRunnable
     {
-        public void run(Object[] args);
+        void run(Object[] args);
     }
 
     private static class ShimThread extends Thread

--- a/src/main/java/zmq/Config.java
+++ b/src/main/java/zmq/Config.java
@@ -67,7 +67,7 @@ public enum Config
 
     private final int value;
 
-    private Config(int value)
+    Config(int value)
     {
         this.value = value;
     }

--- a/src/main/java/zmq/Ctx.java
+++ b/src/main/java/zmq/Ctx.java
@@ -59,7 +59,7 @@ public class Ctx
         }
     }
 
-    private static enum Side
+    private enum Side
     {
         CONNECT,
         BIND
@@ -337,7 +337,7 @@ public class Ctx
 
     public int get(int option)
     {
-        int rc = 0;
+        int rc;
         if (option == ZMQ.ZMQ_MAX_SOCKETS) {
             rc = maxSockets;
         }

--- a/src/main/java/zmq/Mailbox.java
+++ b/src/main/java/zmq/Mailbox.java
@@ -35,7 +35,7 @@ public final class Mailbox implements Closeable
     public Mailbox(Ctx ctx, String name, int tid)
     {
         this.errno = ctx.errno();
-        cpipe = new YPipe<Command>(Config.COMMAND_PIPE_GRANULARITY.getValue());
+        cpipe = new YPipe<>(Config.COMMAND_PIPE_GRANULARITY.getValue());
         sync = new ReentrantLock();
         signaler = new Signaler(ctx, tid, errno);
 
@@ -74,7 +74,7 @@ public final class Mailbox implements Closeable
 
     public Command recv(long timeout)
     {
-        Command cmd = null;
+        Command cmd;
         //  Try to get the command straight away.
         if (active) {
             cmd = cpipe.read();

--- a/src/main/java/zmq/Options.java
+++ b/src/main/java/zmq/Options.java
@@ -97,10 +97,10 @@ public class Options
 
     // TCP accept() filters
     //typedef std::vector <tcp_address_mask_t> tcp_accept_filters_t;
-    public final List<TcpAddress.TcpAddressMask> tcpAcceptFilters = new ArrayList<TcpAddress.TcpAddressMask>();
+    public final List<TcpAddress.TcpAddressMask> tcpAcceptFilters = new ArrayList<>();
 
     // IPC accept() filters
-    final List<IpcAddress.IpcAddressMask> ipcAcceptFilters = new ArrayList<IpcAddress.IpcAddressMask>();
+    final List<IpcAddress.IpcAddressMask> ipcAcceptFilters = new ArrayList<>();
 
     //  Security mechanism for all connections on this socket
     public Mechanisms mechanism = Mechanisms.NULL;
@@ -652,7 +652,7 @@ public class Options
             return (Boolean) optval;
         }
         else if (optval instanceof Integer) {
-            return (Integer) optval != 0 ? true : false;
+            return (Integer) optval != 0;
         }
         throw new IllegalArgumentException(optval + " is neither an integer or a boolean for option " + option);
     }

--- a/src/main/java/zmq/Own.java
+++ b/src/main/java/zmq/Own.java
@@ -73,7 +73,7 @@ public abstract class Own extends ZObject
 
     protected abstract void destroy();
 
-    //  A place to hook in when phyicallal destruction of the object
+    //  A place to hook in when physical destruction of the object
     //  is to be delayed.
     protected void processDestroy()
     {
@@ -101,7 +101,7 @@ public abstract class Own extends ZObject
         //  Catch up with counter of processed commands.
         processedSeqnum++;
 
-        //  We may have catched up and still have pending terms acks.
+        //  We may have caught up and still have pending terms acks.
         checkTermAcks();
     }
 
@@ -174,7 +174,7 @@ public abstract class Own extends ZObject
             return;
         }
 
-        //  As for the root of the ownership tree, there's noone to terminate it,
+        //  As for the root of the ownership tree, there's no one to terminate it,
         //  so it has to terminate itself.
         if (owner == null) {
             processTerm(options.linger);
@@ -191,7 +191,7 @@ public abstract class Own extends ZObject
         return terminating;
     }
 
-    //  Term handler is protocted rather than private so that it can
+    //  Term handler is protected rather than private so that it can
     //  be intercepted by the derived class. This is useful to add custom
     //  steps to the beginning of the termination process.
     @Override

--- a/src/main/java/zmq/Proxy.java
+++ b/src/main/java/zmq/Proxy.java
@@ -16,7 +16,7 @@ class Proxy
         return new Proxy().start(frontend, backend, capture, control);
     }
 
-    public static enum State
+    public enum State
     {
         ACTIVE,
         PAUSED,
@@ -38,7 +38,6 @@ class Proxy
         //  TODO: The current implementation drops messages when
         //  any of the pipes becomes full.
 
-        boolean success = true;
         int rc;
         int more;
         Msg msg;
@@ -89,7 +88,7 @@ class Proxy
                     }
 
                     //  Copy message to capture socket if any
-                    success = capture(capture, msg, more);
+                    boolean success = capture(capture, msg, more);
                     if (!success) {
                         return false;
                     }

--- a/src/main/java/zmq/Signaler.java
+++ b/src/main/java/zmq/Signaler.java
@@ -90,7 +90,7 @@ final class Signaler implements Closeable
 
     void send()
     {
-        int nbytes = 0;
+        int nbytes;
 
         while (true) {
             try {
@@ -112,7 +112,7 @@ final class Signaler implements Closeable
 
     boolean waitEvent(long timeout)
     {
-        int rc = 0;
+        int rc;
         boolean brc = (rcursor < wcursor.get());
         if (brc) {
             return true;
@@ -122,10 +122,8 @@ final class Signaler implements Closeable
                 // waitEvent(0) is called every read/send of SocketBase
                 // instant readiness is not strictly required
                 // On the other hand, we can save lots of system call and increase performance
-                if (!brc) {
-                    errno.set(ZError.EAGAIN);
-                }
-                return brc;
+                errno.set(ZError.EAGAIN);
+                return false;
 
             }
             else if (timeout < 0) {

--- a/src/main/java/zmq/ZMQ.java
+++ b/src/main/java/zmq/ZMQ.java
@@ -268,8 +268,7 @@ public class ZMQ
     public static Ctx createContext()
     {
         //  Create 0MQ context.
-        Ctx ctx = new Ctx();
-        return ctx;
+        return new Ctx();
     }
 
     private static void checkContext(Ctx ctx)
@@ -323,8 +322,7 @@ public class ZMQ
     public static SocketBase socket(Ctx ctx, int type)
     {
         checkContext(ctx);
-        SocketBase s = ctx.createSocket(type);
-        return s;
+        return ctx.createSocket(type);
     }
 
     private static void checkSocket(SocketBase s)
@@ -462,7 +460,7 @@ public class ZMQ
 
     public static boolean sendMsg(SocketBase socket, byte[]... data)
     {
-        int rc = 0;
+        int rc;
         if (data.length == 0) {
             return false;
         }
@@ -694,7 +692,7 @@ public class ZMQ
 
             //  Wait for events.
             try {
-                int rc = 0;
+                int rc;
                 if (waitMillis < 0) {
                     rc = selector.select(0);
                 }

--- a/src/main/java/zmq/io/SessionBase.java
+++ b/src/main/java/zmq/io/SessionBase.java
@@ -338,7 +338,7 @@ public class SessionBase extends Own implements Pipe.IPipeEvents, IPollEvents
     protected boolean zapEnabled()
     {
         return options.mechanism != Mechanisms.NULL
-                || (options.mechanism == Mechanisms.NULL && options.zapDomain != null && !options.zapDomain.isEmpty());
+                || (options.zapDomain != null && !options.zapDomain.isEmpty());
     }
 
     @Override

--- a/src/main/java/zmq/io/StreamEngine.java
+++ b/src/main/java/zmq/io/StreamEngine.java
@@ -153,7 +153,7 @@ public class StreamEngine implements IEngine, IPollEvents
     }
 
     // used to implement FSM actions
-    private static interface MessageProcessor
+    private interface MessageProcessor
     {
         Msg nextMsg();
 
@@ -176,7 +176,7 @@ public class StreamEngine implements IEngine, IPollEvents
     }
 
     //  Protocol revisions
-    private static enum Protocol
+    private enum Protocol
     {
         V0(-1),
         V1(0),
@@ -191,7 +191,7 @@ public class StreamEngine implements IEngine, IPollEvents
         }
     }
 
-    public static enum ErrorReason
+    public enum ErrorReason
     {
         PROTOCOL,
         CONNECTION,
@@ -630,7 +630,7 @@ public class StreamEngine implements IEngine, IPollEvents
         assert (session != null);
         assert (decoder != null);
 
-        boolean rc = false;
+        boolean rc;
         Msg msg = decoder.msg();
         rc = processMsg.processMsg(msg);
         if (!rc) {

--- a/src/main/java/zmq/io/coder/IDecoder.java
+++ b/src/main/java/zmq/io/coder/IDecoder.java
@@ -7,9 +7,9 @@ import zmq.util.ValueReference;
 
 public interface IDecoder
 {
-    public static interface Step
+    interface Step
     {
-        public static enum Result
+        enum Result
         {
             MORE_DATA(0),
             DECODED(1),
@@ -19,7 +19,7 @@ public interface IDecoder
             // reminder for c++ equivalent
             private final int code;
 
-            private Result(int code)
+            Result(int code)
             {
                 this.code = code;
             }

--- a/src/main/java/zmq/io/mechanism/Mechanism.java
+++ b/src/main/java/zmq/io/mechanism/Mechanism.java
@@ -96,7 +96,6 @@ public abstract class Mechanism
         assert (nameLength <= 255);
 
         int valueLength = value == null ? 0 : value.length;
-        assert (valueLength <= Integer.MAX_VALUE);
 
         buf.put((byte) nameLength);
         buf.put(nameB);
@@ -114,7 +113,6 @@ public abstract class Mechanism
         assert (nameLength <= 255);
 
         int valueLength = value == null ? 0 : value.length;
-        assert (valueLength <= Integer.MAX_VALUE);
 
         msg.put((byte) nameLength);
         msg.put(nameB);
@@ -224,7 +222,7 @@ public abstract class Mechanism
         boolean comparison = includeLength ? msg.get(0) == data.length() : true;
         if (comparison) {
             for (int idx = start; idx < data.length(); ++idx) {
-                comparison &= (msg.get(idx) == data.charAt(idx - start));
+                comparison = (msg.get(idx) == data.charAt(idx - start));
                 if (!comparison) {
                     break;
                 }
@@ -240,7 +238,7 @@ public abstract class Mechanism
         }
         boolean comparison = true;
         for (int idx = 0; idx < length; ++idx) {
-            comparison |= a1.get(idx + offset) == b[idx];
+            comparison = a1.get(idx + offset) == b[idx];
             if (!comparison) {
                 break;
             }
@@ -377,9 +375,8 @@ public abstract class Mechanism
         setUserId(msgs.get(5).data());
 
         //  Process metadata frame
-        int rc = parseMetadata(msgs.get(6), 0, true);
 
-        return rc;
+        return parseMetadata(msgs.get(6), 0, true);
     }
 
     protected final void puts(String msg)

--- a/src/main/java/zmq/io/mechanism/Mechanisms.java
+++ b/src/main/java/zmq/io/mechanism/Mechanisms.java
@@ -70,5 +70,5 @@ public enum Mechanisms
         byte[] name = name().getBytes(ZMQ.CHARSET);
         byte[] comp = Arrays.copyOf(name, 20);
         return Arrays.equals(dst, comp);
-    };
+    }
 }

--- a/src/main/java/zmq/io/mechanism/NullMechanism.java
+++ b/src/main/java/zmq/io/mechanism/NullMechanism.java
@@ -92,7 +92,7 @@ class NullMechanism extends Mechanism
         }
         int dataSize = msg.size();
 
-        int rc = 0;
+        int rc;
         if (dataSize >= 6 && compare(msg, READY, true)) {
             rc = processReadyCommand(msg);
         }

--- a/src/main/java/zmq/io/mechanism/curve/Curve.java
+++ b/src/main/java/zmq/io/mechanism/curve/Curve.java
@@ -11,7 +11,7 @@ import zmq.util.Z85;
 // wrapper around the wrapper of libsodium (ahem), for shorter names.
 public class Curve
 {
-    static enum Size
+    enum Size
     {
         NONCE {
             @Override

--- a/src/main/java/zmq/io/mechanism/curve/CurveClientMechanism.java
+++ b/src/main/java/zmq/io/mechanism/curve/CurveClientMechanism.java
@@ -78,7 +78,7 @@ public class CurveClientMechanism extends Mechanism
     @Override
     public int nextHandshakeCommand(Msg msg)
     {
-        int rc = 0;
+        int rc;
         switch (state) {
         case SEND_HELLO:
             rc = produceHello(msg);
@@ -103,7 +103,7 @@ public class CurveClientMechanism extends Mechanism
     @Override
     public int processHandshakeCommand(Msg msg)
     {
-        int rc = 0;
+        int rc;
 
         int dataSize = msg.size();
         if (dataSize >= 8 && compare(msg, "WELCOME", true)) {

--- a/src/main/java/zmq/io/mechanism/curve/CurveServerMechanism.java
+++ b/src/main/java/zmq/io/mechanism/curve/CurveServerMechanism.java
@@ -75,7 +75,7 @@ public class CurveServerMechanism extends Mechanism
     @Override
     public int nextHandshakeCommand(Msg msg)
     {
-        int rc = 0;
+        int rc;
         switch (state) {
         case SEND_WELCOME:
             rc = produceWelcome(msg);
@@ -106,7 +106,7 @@ public class CurveServerMechanism extends Mechanism
     @Override
     public int processHandshakeCommand(Msg msg)
     {
-        int rc = 0;
+        int rc;
         switch (state) {
         case EXPECT_HELLO:
             rc = processHello(msg);

--- a/src/main/java/zmq/io/mechanism/plain/PlainClientMechanism.java
+++ b/src/main/java/zmq/io/mechanism/plain/PlainClientMechanism.java
@@ -32,7 +32,7 @@ public class PlainClientMechanism extends Mechanism
     @Override
     public int nextHandshakeCommand(Msg msg)
     {
-        int rc = 0;
+        int rc;
         switch (state) {
         case SENDING_HELLO:
             rc = produceHello(msg);
@@ -57,7 +57,7 @@ public class PlainClientMechanism extends Mechanism
     @Override
     public int processHandshakeCommand(Msg msg)
     {
-        int rc = 0;
+        int rc;
 
         int dataSize = msg.size();
         if (dataSize >= 8 && compare(msg, "WELCOME", true)) {

--- a/src/main/java/zmq/io/mechanism/plain/PlainServerMechanism.java
+++ b/src/main/java/zmq/io/mechanism/plain/PlainServerMechanism.java
@@ -37,7 +37,7 @@ public class PlainServerMechanism extends Mechanism
     @Override
     public int nextHandshakeCommand(Msg msg)
     {
-        int rc = 0;
+        int rc;
         switch (state) {
         case SENDING_WELCOME:
             rc = produceWelcome(msg);
@@ -68,7 +68,7 @@ public class PlainServerMechanism extends Mechanism
     @Override
     public int processHandshakeCommand(Msg msg)
     {
-        int rc = 0;
+        int rc;
         switch (state) {
         case WAITING_FOR_HELLO:
             rc = produceHello(msg);
@@ -156,7 +156,7 @@ public class PlainServerMechanism extends Mechanism
         msg.getBytes(index, tmp, 0, length);
         byte[] password = tmp;
         bytesLeft -= length;
-        index += length;
+        //        index += length;
 
         if (bytesLeft > 0) {
             //  Temporary support for security debugging

--- a/src/main/java/zmq/io/net/Address.java
+++ b/src/main/java/zmq/io/net/Address.java
@@ -20,7 +20,7 @@ public class Address
         SocketAddress address();
 
         SocketAddress sourceAddress();
-    };
+    }
 
     private final NetProtocol protocol;
     private final String      address;

--- a/src/main/java/zmq/io/net/NetProtocol.java
+++ b/src/main/java/zmq/io/net/NetProtocol.java
@@ -18,7 +18,7 @@ public enum NetProtocol
     public final boolean  valid;
     private List<Sockets> compatibles;
 
-    private NetProtocol(boolean implemented, Sockets... compatibles)
+    NetProtocol(boolean implemented, Sockets... compatibles)
     {
         valid = implemented;
         this.compatibles = Arrays.asList(compatibles);

--- a/src/main/java/zmq/io/net/tcp/SocksConnecter.java
+++ b/src/main/java/zmq/io/net/tcp/SocksConnecter.java
@@ -14,7 +14,7 @@ public class SocksConnecter extends TcpConnecter
 
     private Address proxyAddress;
 
-    private static enum Status
+    private enum Status
     {
         UNPLUGGED,
         WAITING_FOR_RECONNECT_TIME,

--- a/src/main/java/zmq/io/net/tcp/TcpConnecter.java
+++ b/src/main/java/zmq/io/net/tcp/TcpConnecter.java
@@ -144,7 +144,7 @@ public class TcpConnecter extends Own implements IPollEvents
         //        socket.setFd(channel);
 
         //  Create the engine object for this connection.
-        StreamEngine engine = null;
+        StreamEngine engine;
         try {
             engine = new StreamEngine(channel, options, addr.toString());
         }
@@ -152,7 +152,6 @@ public class TcpConnecter extends Own implements IPollEvents
             // TODO V4 socket.eventConnectDelayed(addr.toString(), -1);
             return;
         }
-        assert (engine != null);
 
         this.fd = null;
 
@@ -311,7 +310,7 @@ public class TcpConnecter extends Own implements IPollEvents
         }
 
         //  Connect to the remote peer.
-        boolean rc = false;
+        boolean rc;
         try {
             rc = fd.connect(sa);
             if (rc) {

--- a/src/main/java/zmq/io/net/tcp/TcpListener.java
+++ b/src/main/java/zmq/io/net/tcp/TcpListener.java
@@ -22,7 +22,7 @@ public class TcpListener extends Own implements IPollEvents
     private static boolean isWindows;
     static {
         String os = System.getProperty("os.name").toLowerCase();
-        isWindows = os.indexOf("win") >= 0;
+        isWindows = os.contains("win");
     }
 
     //  Address to listen on.
@@ -78,7 +78,7 @@ public class TcpListener extends Own implements IPollEvents
     @Override
     public void acceptEvent()
     {
-        SocketChannel channel = null;
+        SocketChannel channel;
 
         try {
             channel = accept();
@@ -229,7 +229,6 @@ public class TcpListener extends Own implements IPollEvents
                 return null;
             }
         }
-        // TODO V4 Set the IP Type-Of-Service priority for this client socket
         if (options.tos != 0) {
             TcpUtils.setIpTypeOfService(sock, options.tos);
         }

--- a/src/main/java/zmq/pipe/Pipe.java
+++ b/src/main/java/zmq/pipe/Pipe.java
@@ -124,9 +124,9 @@ public class Pipe extends ZObject
         //   Creates two pipe objects. These objects are connected by two ypipes,
         //   each to pass messages in one direction.
 
-        YPipeBase<Msg> upipe1 = conflates[0] ? new YPipeConflate<Msg>()
+        YPipeBase<Msg> upipe1 = conflates[0] ? new YPipeConflate<>()
                 : new YPipe<Msg>(Config.MESSAGE_PIPE_GRANULARITY.getValue());
-        YPipeBase<Msg> upipe2 = conflates[1] ? new YPipeConflate<Msg>()
+        YPipeBase<Msg> upipe2 = conflates[1] ? new YPipeConflate<>()
                 : new YPipe<Msg>(Config.MESSAGE_PIPE_GRANULARITY.getValue());
 
         pipes[0] = new Pipe(parents[0], upipe1, upipe2, hwms[1], hwms[0], conflates[0]);
@@ -332,7 +332,7 @@ public class Pipe extends ZObject
         //  migrated to this thread.
         assert (outpipe != null);
         outpipe.flush();
-        Msg msg = null;
+        Msg msg;
         while ((msg = outpipe.read()) != null) {
             if (!msg.hasMore()) {
                 msgsWritten--;
@@ -562,10 +562,10 @@ public class Pipe extends ZObject
 
         //  Create new inpipe.
         if (conflate) {
-            inpipe = new YPipeConflate<Msg>();
+            inpipe = new YPipeConflate<>();
         }
         else {
-            inpipe = new YPipe<Msg>(Config.MESSAGE_PIPE_GRANULARITY.getValue());
+            inpipe = new YPipe<>(Config.MESSAGE_PIPE_GRANULARITY.getValue());
         }
         inActive = true;
 

--- a/src/main/java/zmq/pipe/YPipe.java
+++ b/src/main/java/zmq/pipe/YPipe.java
@@ -29,7 +29,7 @@ public class YPipe<T> implements YPipeBase<T>
 
     public YPipe(int qsize)
     {
-        queue = new YQueue<T>(qsize);
+        queue = new YQueue<>(qsize);
         int pos = queue.backPos();
         f = pos;
         r = pos;

--- a/src/main/java/zmq/pipe/YQueue.java
+++ b/src/main/java/zmq/pipe/YQueue.java
@@ -20,7 +20,7 @@ class YQueue<T>
                 memoryPtr++;
             }
         }
-    };
+    }
 
     //  Back position may point to invalid memory if the queue is empty,
     //  while begin & end positions are always valid. Begin position is
@@ -44,7 +44,7 @@ class YQueue<T>
     {
         this.size = size;
         memoryPtr = 0;
-        beginChunk = new Chunk<T>(size, memoryPtr);
+        beginChunk = new Chunk<>(size, memoryPtr);
         memoryPtr += size;
         beginPos = 0;
         backPos = 0;
@@ -96,7 +96,7 @@ class YQueue<T>
             sc.prev = endChunk;
         }
         else {
-            endChunk.next = new Chunk<T>(size, memoryPtr);
+            endChunk.next = new Chunk<>(size, memoryPtr);
             memoryPtr += size;
             endChunk.next.prev = endChunk;
         }

--- a/src/main/java/zmq/poll/Poller.java
+++ b/src/main/java/zmq/poll/Poller.java
@@ -192,7 +192,7 @@ public final class Poller extends PollerBase implements Runnable
             //  Execute any due timers.
             long timeout = executeTimers();
 
-            if (retired == true) {
+            if (retired) {
                 retired = false;
                 Iterator<Handle> iter = fdTable.iterator();
                 while (iter.hasNext()) {

--- a/src/main/java/zmq/socket/Pair.java
+++ b/src/main/java/zmq/socket/Pair.java
@@ -88,7 +88,7 @@ public class Pair extends SocketBase
     protected Msg xrecv()
     {
         //  Deallocate old content of the message.
-        Msg msg = null;
+        Msg msg;
         if (pipe == null) {
             //  Initialize the output parameter to be a 0-byte message.
             errno.set(ZError.EAGAIN);

--- a/src/main/java/zmq/socket/Stream.java
+++ b/src/main/java/zmq/socket/Stream.java
@@ -197,7 +197,7 @@ public class Stream extends SocketBase
     @Override
     public Msg xrecv()
     {
-        Msg msg = null;
+        Msg msg;
         if (prefetched) {
             if (!identitySent) {
                 msg = prefetchedId;
@@ -212,7 +212,7 @@ public class Stream extends SocketBase
             return msg;
         }
 
-        ValueReference<Pipe> pipe = new ValueReference<Pipe>();
+        ValueReference<Pipe> pipe = new ValueReference<>();
         prefetchedMsg = fq.recvPipe(errno, pipe);
 
         // TODO DIFF V4 we sometimes need to process the commands to receive data, let's just return and give it another chance
@@ -254,7 +254,7 @@ public class Stream extends SocketBase
 
         //  Try to read the next message.
         //  The message, if read, is kept in the pre-fetch buffer.
-        ValueReference<Pipe> pipe = new ValueReference<Pipe>();
+        ValueReference<Pipe> pipe = new ValueReference<>();
         prefetchedMsg = fq.recvPipe(errno, pipe);
         if (prefetchedMsg == null) {
             return false;
@@ -294,7 +294,7 @@ public class Stream extends SocketBase
     {
         //  Always assign identity for raw-socket
 
-        Blob identity = null;
+        Blob identity;
         if (connectRid != null && !connectRid.isEmpty()) {
             identity = Blob.createBlob(connectRid.getBytes(ZMQ.CHARSET));
             connectRid = null;

--- a/src/main/java/zmq/socket/pubsub/Dist.java
+++ b/src/main/java/zmq/socket/pubsub/Dist.java
@@ -37,7 +37,7 @@ class Dist
         active = 0;
         eligible = 0;
         more = false;
-        pipes = new ArrayList<Pipe>();
+        pipes = new ArrayList<>();
     }
 
     //  Adds the pipe to the distributor object.

--- a/src/main/java/zmq/socket/pubsub/Mtrie.java
+++ b/src/main/java/zmq/socket/pubsub/Mtrie.java
@@ -50,7 +50,7 @@ class Mtrie
         if (size == 0) {
             boolean result = pipes == null;
             if (pipes == null) {
-                pipes = new HashSet<Pipe>();
+                pipes = new HashSet<>();
             }
             pipes.add(pipe);
             return result;

--- a/src/main/java/zmq/socket/pubsub/Trie.java
+++ b/src/main/java/zmq/socket/pubsub/Trie.java
@@ -7,7 +7,7 @@ import zmq.util.Utils;
 
 class Trie
 {
-    public static interface ITrieHandler
+    public interface ITrieHandler
     {
         void added(byte[] data, int size, Pipe arg);
     }

--- a/src/main/java/zmq/socket/pubsub/XPub.java
+++ b/src/main/java/zmq/socket/pubsub/XPub.java
@@ -93,7 +93,7 @@ public class XPub extends SocketBase
     protected void xreadActivated(Pipe pipe)
     {
         //  There are some subscriptions waiting. Let's process them.
-        Msg sub = null;
+        Msg sub;
         while ((sub = pipe.read()) != null) {
             //  Apply the subscription to the trie
             byte[] data = sub.data();

--- a/src/main/java/zmq/socket/pubsub/XSub.java
+++ b/src/main/java/zmq/socket/pubsub/XSub.java
@@ -137,7 +137,7 @@ public class XSub extends SocketBase
     @Override
     protected Msg xrecv()
     {
-        Msg msg = null;
+        Msg msg;
 
         //  If there's already a message prepared by a previous call to zmq_poll,
         //  return it straight ahead.

--- a/src/main/java/zmq/socket/reqrep/Rep.java
+++ b/src/main/java/zmq/socket/reqrep/Rep.java
@@ -38,7 +38,7 @@ public class Rep extends Router
         //  Push message to the reply pipe.
         boolean rc = super.xsend(msg);
         if (!rc) {
-            return rc;
+            return false;
         }
 
         //  If the reply is complete flip the FSM back to request receiving state.
@@ -57,7 +57,7 @@ public class Rep extends Router
             errno.set(ZError.EFSM);
         }
 
-        Msg msg = null;
+        Msg msg;
         //  First thing to do when receiving a request is to copy all the labels
         //  to the reply pipe.
         if (requestBegins) {

--- a/src/main/java/zmq/socket/reqrep/Req.java
+++ b/src/main/java/zmq/socket/reqrep/Req.java
@@ -111,7 +111,7 @@ public class Req extends Dealer
 
         boolean rc = super.xsend(msg);
         if (!rc) {
-            return rc;
+            return false;
         }
 
         //  If the request was fully sent, flip the FSM into reply-receiving state.
@@ -226,7 +226,7 @@ public class Req extends Dealer
     private Msg recvReplyPipe()
     {
         while (true) {
-            ValueReference<Pipe> pipe = new ValueReference<Pipe>();
+            ValueReference<Pipe> pipe = new ValueReference<>();
             Msg msg = super.recvpipe(pipe);
             if (msg == null) {
                 return null;
@@ -244,7 +244,7 @@ public class Req extends Dealer
         {
             BOTTOM,
             BODY
-        };
+        }
 
         private State state;
 

--- a/src/main/java/zmq/socket/reqrep/Router.java
+++ b/src/main/java/zmq/socket/reqrep/Router.java
@@ -51,7 +51,7 @@ public class Router extends SocketBase
             this.pipe = pipe;
             this.active = active;
         }
-    };
+    }
 
     //  We keep a set of pipes that have not been identified yet.
     private final Set<Pipe> anonymousPipes;
@@ -288,7 +288,7 @@ public class Router extends SocketBase
     @Override
     protected Msg xrecv()
     {
-        Msg msg = null;
+        Msg msg;
         if (prefetched) {
             if (!identitySent) {
                 msg = prefetchedId;
@@ -304,7 +304,7 @@ public class Router extends SocketBase
             return msg;
         }
 
-        ValueReference<Pipe> pipe = new ValueReference<Pipe>();
+        ValueReference<Pipe> pipe = new ValueReference<>();
         msg = fq.recvPipe(errno, pipe);
 
         //  It's possible that we receive peer's identity. That happens
@@ -368,7 +368,7 @@ public class Router extends SocketBase
 
         //  Try to read the next message.
         //  The message, if read, is kept in the pre-fetch buffer.
-        ValueReference<Pipe> pipe = new ValueReference<Pipe>();
+        ValueReference<Pipe> pipe = new ValueReference<>();
         prefetchedMsg = fq.recvPipe(errno, pipe);
 
         //  It's possible that we receive peer's identity. That happens


### PR DESCRIPTION
Better styling: removed unnecessary keywords and var assignments
Fixed error in comparison of byte[] in Mechanism
Handled possibility of null received message in ZSocket
Fixed return status of ZMQ#setHWM

Some warnings were about dead branches of code, most critical ones are in Signaler and Mechanism.