### PR TITLE
Added option to configure datagram socket blocking behaviour

### DIFF
--- a/src/main/java/org/zeromq/ZBeacon.java
+++ b/src/main/java/org/zeromq/ZBeacon.java
@@ -38,6 +38,11 @@ public class ZBeacon
 
     public ZBeacon(String host, int port, byte[] beacon, boolean ignoreLocalAddress)
     {
+        this(host, port, beacon, ignoreLocalAddress, false);
+    }
+
+    public ZBeacon(String host, int port, byte[] beacon, boolean ignoreLocalAddress, boolean blocking)
+    {
         this.port = port;
         this.beacon = beacon;
         try {
@@ -47,7 +52,7 @@ public class ZBeacon
             throw new RuntimeException(unknownHostException);
         }
 
-        broadcastServer = new BroadcastServer(ignoreLocalAddress);
+        broadcastServer = new BroadcastServer(ignoreLocalAddress, blocking);
         broadcastServer.setDaemon(true);
         broadcastClient = new BroadcastClient();
         broadcastClient.setDaemon(true);
@@ -165,13 +170,13 @@ public class ZBeacon
         private DatagramChannel handle;            // Socket for send/recv
         private final boolean   ignoreLocalAddress;
 
-        public BroadcastServer(boolean ignoreLocalAddress)
+        public BroadcastServer(boolean ignoreLocalAddress, boolean blocking)
         {
             this.ignoreLocalAddress = ignoreLocalAddress;
             try {
                 // Create UDP socket
                 handle = DatagramChannel.open();
-                handle.configureBlocking(false);
+                handle.configureBlocking(blocking);
                 DatagramSocket sock = handle.socket();
                 sock.setReuseAddress(true);
                 sock.bind(new InetSocketAddress(InetAddress.getByAddress(new byte[] { 0, 0, 0, 0 }), port));

--- a/src/test/java/org/zeromq/ZBeaconTest.java
+++ b/src/test/java/org/zeromq/ZBeaconTest.java
@@ -1,19 +1,22 @@
 package org.zeromq;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.zeromq.ZBeacon.Listener;
 
 public class ZBeaconTest
 {
     @Test
-    public void test() throws InterruptedException, IOException
+    public void testReceiveOwnBeacons() throws InterruptedException, IOException
     {
         final CountDownLatch latch = new CountDownLatch(1);
         byte[] beacon = new byte[] { 'H', 'Y', 'D', 'R', 'A', 0x01, 0x12, 0x34 };
@@ -32,7 +35,101 @@ public class ZBeaconTest
 
         zbeacon.start();
         latch.await(20, TimeUnit.SECONDS);
-        assertEquals(latch.getCount(), 0);
+        assertThat(latch.getCount(), is(0L));
         zbeacon.stop();
+    }
+
+    @Test
+    @Ignore
+    public void testIgnoreOwnBeacon() throws IOException, InterruptedException
+    {
+        final int port = Utils.findOpenPort();
+
+        final byte[] beacon = new byte[] { 'Z', 'R', 'E', 0x01, 0x2 };
+        final byte[] prefix = new byte[] { 'Z', 'R', 'E', 0x01 };
+        final ZBeacon zbeacon = new ZBeacon(ZBeacon.DEFAULT_BROADCAST_HOST, port, beacon, true);
+        zbeacon.setPrefix(prefix);
+
+        final AtomicLong counter = new AtomicLong();
+
+        zbeacon.setListener(new Listener()
+        {
+            @Override
+            public void onBeacon(InetAddress sender, byte[] beacon)
+            {
+                counter.incrementAndGet();
+                System.out.println(sender.toString());
+                try {
+                    System.out.println(InetAddress.getLocalHost().getHostAddress());
+                }
+                catch (Exception e) {
+                }
+                System.out.println(new String(beacon));
+            }
+        });
+        zbeacon.start();
+        zmq.ZMQ.sleep(1);
+        zbeacon.stop();
+
+        assertThat(counter.get(), is(0L));
+    }
+
+    @Test
+    public void testReceiveOwnBeaconsBlocking() throws InterruptedException, IOException
+    {
+        final CountDownLatch latch = new CountDownLatch(1);
+        byte[] beacon = new byte[] { 'H', 'Y', 'D', 'R', 'A', 0x01, 0x12, 0x34 };
+        byte[] prefix = new byte[] { 'H', 'Y', 'D', 'R', 'A', 0x01 };
+        int port = Utils.findOpenPort();
+        ZBeacon zbeacon = new ZBeacon("255.255.255.255", port, beacon, false, true);
+        zbeacon.setPrefix(prefix);
+        zbeacon.setListener(new Listener()
+        {
+            @Override
+            public void onBeacon(InetAddress sender, byte[] beacon)
+            {
+                latch.countDown();
+            }
+        });
+
+        zbeacon.start();
+        latch.await(20, TimeUnit.SECONDS);
+        assertThat(latch.getCount(), is(0L));
+        zbeacon.stop();
+    }
+
+    @Test
+    @Ignore
+    public void testIgnoreOwnBeaconBlocking() throws IOException, InterruptedException
+    {
+        final int port = Utils.findOpenPort();
+
+        final byte[] beacon = new byte[] { 'Z', 'R', 'E', 0x01, 0x2 };
+        final byte[] prefix = new byte[] { 'Z', 'R', 'E', 0x01 };
+        final ZBeacon zbeacon = new ZBeacon(ZBeacon.DEFAULT_BROADCAST_HOST, port, beacon, true, true);
+        zbeacon.setPrefix(prefix);
+
+        final AtomicLong counter = new AtomicLong();
+
+        zbeacon.setListener(new Listener()
+        {
+            @Override
+            public void onBeacon(InetAddress sender, byte[] beacon)
+            {
+                counter.incrementAndGet();
+                System.out.println(sender.toString());
+                try {
+                    System.out.println(InetAddress.getLocalHost().getHostAddress());
+                }
+                catch (Exception e) {
+                }
+                System.out.println(new String(beacon));
+            }
+        });
+        zbeacon.start();
+        zmq.ZMQ.sleep(1);
+        zbeacon.stop();
+
+        assertThat(counter.get(), is(0L));
     }
 }


### PR DESCRIPTION
Added test for ignoring own beacons in ZBeacon regarding #296 , but disabled as they fail in Travis.

Added boolean parameter in ZBeacon to allow configure blocking behaviour of Datagram Socket, to provide reporters of #318 an handy way to solve their situation.

