### PR TITLE
Added optional jacoco coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,11 @@
       <version>4.11</version>
       <scope>test</scope>
     </dependency>
-	<dependency>
-	  <groupId>org.zeromq</groupId>
-	  <artifactId>jnacl</artifactId>
-	  <version>0.1.0</version>
-	</dependency>
+    <dependency>
+      <groupId>org.zeromq</groupId>
+      <artifactId>jnacl</artifactId>
+      <version>0.1.0</version>
+    </dependency>
   </dependencies>
   <distributionManagement>
     <snapshotRepository>
@@ -180,6 +180,58 @@
     </pluginManagement>
   </build>
   <profiles>
+    <profile>
+      <id>coverage</id>
+        <activation>
+          <activeByDefault>false</activeByDefault>
+        </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.7.9</version>
+            <executions>
+              <execution>
+                <id>default-prepare-agent</id>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>default-report</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>default-check</id>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <!-- implementation is needed only for Maven 2 -->
+                    <rule implementation="org.jacoco.maven.RuleConfiguration">
+                      <element>BUNDLE</element>
+                      <limits>
+                        <!-- implementation is needed only for Maven 2 -->
+                        <limit implementation="org.jacoco.report.check.Limit">
+                          <counter>COMPLEXITY</counter>
+                          <value>COVEREDRATIO</value>
+                          <minimum>0.60</minimum>
+                        </limit>
+                      </limits>
+                    </rule>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>doclint-java8-disable</id>
       <activation>

--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -17,6 +17,7 @@ import zmq.ZError.CtxTerminatedException;
 import zmq.io.coder.IDecoder;
 import zmq.io.coder.IEncoder;
 import zmq.io.mechanism.Mechanisms;
+import zmq.msg.MsgAllocator;
 
 public class ZMQ
 {
@@ -229,9 +230,13 @@ public class ZMQ
      */
     public static final int EVENT_ALL                = zmq.ZMQ.ZMQ_EVENT_ALL;
 
-    public static final byte[] MESSAGE_SEPARATOR = new byte[0];
+    public static final byte[] MESSAGE_SEPARATOR = zmq.ZMQ.MESSAGE_SEPARATOR;
 
-    public static final byte[] SUBSCRIPTION_ALL = new byte[0];
+    public static final byte[] SUBSCRIPTION_ALL = zmq.ZMQ.SUBSCRIPTION_ALL;
+
+    public static final byte[] PROXY_PAUSE     = zmq.ZMQ.PROXY_PAUSE;
+    public static final byte[] PROXY_RESUME    = zmq.ZMQ.PROXY_RESUME;
+    public static final byte[] PROXY_TERMINATE = zmq.ZMQ.PROXY_TERMINATE;
 
     public static final Charset CHARSET = zmq.ZMQ.CHARSET;
 
@@ -1672,6 +1677,16 @@ public class ZMQ
         }
 
         /**
+         * Sets a custom message allocator.
+         * @param allocator the custom allocator.
+         * @return true if the option was set, otherwise false.
+         */
+        public boolean setMsgAllocator(MsgAllocator allocator)
+        {
+            return setSocketOpt(zmq.ZMQ.ZMQ_MSG_ALLOCATOR, allocator);
+        }
+
+        /**
          * The ZMQ_CONNECT_RID option sets the peer id of the next host connected via the connect() call,
          * and immediately readies that connection for data transfer with the named id.
          * This option applies only to the first subsequent call to connect(),
@@ -2305,6 +2320,7 @@ public class ZMQ
             NULL(Mechanisms.NULL),
             PLAIN(Mechanisms.PLAIN),
             CURVE(Mechanisms.CURVE);
+            // TODO add GSSAPI once it is implemented
 
             private final Mechanisms mech;
 

--- a/src/main/java/org/zeromq/ZStar.java
+++ b/src/main/java/org/zeromq/ZStar.java
@@ -269,7 +269,7 @@ public class ZStar implements ZAgent
      */
     public ZStar(Fortune actor, String lock, Object... args)
     {
-        this(null, new VerySimpleSelectorCreator(), actor, lock, args);
+        this(new VerySimpleSelectorCreator(), actor, lock, args);
     }
 
     /**
@@ -321,6 +321,8 @@ public class ZStar implements ZAgent
             // it will be destroyed, so this is the main context
             producer = chef;
         }
+        this.context = chef;
+        assert (this.context != null);
 
         // retrieve the last optional set and entourage given in input
         Set set = null;
@@ -354,6 +356,9 @@ public class ZStar implements ZAgent
         agent = agent(phone, motdelafin);
     }
 
+    // context of the star. never null
+    private final ZContext context;
+
     // communicating agent with the star for the Corbeille side
     private final ZAgent agent;
 
@@ -374,6 +379,14 @@ public class ZStar implements ZAgent
     protected ZAgent agent(Socket phone, String secret)
     {
         return ZAgent.Creator.create(phone, secret);
+    }
+
+    /**
+     * @return the context. Never null. If provided context in constructor was null, returns the auto-generated context for that star.
+     */
+    private ZContext context()
+    {
+        return context;
     }
 
     // the plateau where the acting will take place (stage and backstage), or

--- a/src/main/java/zmq/Proxy.java
+++ b/src/main/java/zmq/Proxy.java
@@ -1,6 +1,7 @@
 package zmq;
 
 import java.nio.channels.Selector;
+import java.util.Arrays;
 
 import zmq.poll.PollItem;
 
@@ -93,19 +94,20 @@ class Proxy
                         return false;
                     }
 
-                    String command = new String(msg.data(), ZMQ.CHARSET);
-                    if ("PAUSE".equals(command)) {
+                    byte[] command = msg.data();
+                    if (Arrays.equals(command, ZMQ.PROXY_PAUSE)) {
                         state = State.PAUSED;
                     }
-                    else if ("RESUME".equals(command)) {
+                    else if (Arrays.equals(command, ZMQ.PROXY_RESUME)) {
                         state = State.ACTIVE;
                     }
-                    else if ("TERMINATE".equals(command)) {
+                    else if (Arrays.equals(command, ZMQ.PROXY_TERMINATE)) {
                         state = State.TERMINATED;
                     }
                     else {
                         //  This is an API error, we should assert
-                        System.out.println("E: invalid command sent to proxy '" + command + "'");
+                        System.out
+                                .printf("E: invalid command sent to proxy '%s'%n", new String(command, ZMQ.CHARSET));
                         assert false;
                     }
                 }

--- a/src/main/java/zmq/SocketBase.java
+++ b/src/main/java/zmq/SocketBase.java
@@ -27,7 +27,7 @@ import zmq.util.MultiMap;
 
 public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeEvents
 {
-    private class EndpointPipe
+    private static class EndpointPipe
     {
         private final Own  endpoint;
         private final Pipe pipe;

--- a/src/main/java/zmq/ZMQ.java
+++ b/src/main/java/zmq/ZMQ.java
@@ -187,6 +187,10 @@ public class ZMQ
 
     public static final Charset CHARSET = Charset.forName("UTF-8");
 
+    public static final byte[] PROXY_PAUSE     = "PAUSE".getBytes(ZMQ.CHARSET);
+    public static final byte[] PROXY_RESUME    = "RESUME".getBytes(ZMQ.CHARSET);
+    public static final byte[] PROXY_TERMINATE = "TERMINATE".getBytes(ZMQ.CHARSET);
+
     public static class Event
     {
         private static final int VALUE_INTEGER = 1;

--- a/src/main/java/zmq/socket/pubsub/XPub.java
+++ b/src/main/java/zmq/socket/pubsub/XPub.java
@@ -81,7 +81,7 @@ public class XPub extends SocketBase
         //  If subscribe_to_all_ is specified, the caller would like to subscribe
         //  to all data on this pipe, implicitly.
         if (subscribeToAll) {
-            subscriptions.add(null, pipe);
+            subscriptions.addOnTop(pipe);
         }
 
         //  The pipe is active when attached. Let's read the subscriptions from
@@ -96,20 +96,19 @@ public class XPub extends SocketBase
         Msg sub;
         while ((sub = pipe.read()) != null) {
             //  Apply the subscription to the trie
-            byte[] data = sub.data();
             int size = sub.size();
-            if (size > 0 && (data[0] == 0 || data[0] == 1)) {
+            if (size > 0 && (sub.get(0) == 0 || sub.get(0) == 1)) {
                 boolean unique;
-                if (data[0] == 0) {
-                    unique = subscriptions.rm(data, size, pipe);
+                if (sub.get(0) == 0) {
+                    unique = subscriptions.rm(sub, pipe);
                 }
                 else {
-                    unique = subscriptions.add(data, size, pipe);
+                    unique = subscriptions.add(sub, pipe);
                 }
 
                 //  If the subscription is not a duplicate, store it so that it can be
                 //  passed to used on next recv call. (Unsubscribe is not verbose.)
-                if (options.type == ZMQ.ZMQ_XPUB && (unique || (data[0] > 0 && verbose))) {
+                if (options.type == ZMQ.ZMQ_XPUB && (unique || (sub.get(0) > 0 && verbose))) {
                     pendingData.add(Blob.createBlob(sub));
                     pendingFlags.add(0);
                 }

--- a/src/main/java/zmq/socket/pubsub/XSub.java
+++ b/src/main/java/zmq/socket/pubsub/XSub.java
@@ -103,20 +103,19 @@ public class XSub extends SocketBase
     protected boolean xsend(Msg msg)
     {
         final int size = msg.size();
-        final byte[] data = msg.data();
 
-        if (size > 0 && data[0] == 1) {
+        if (size > 0 && msg.get(0) == 1) {
             //  Process subscribe message
             //  This used to filter out duplicate subscriptions,
             //  however this is already done on the XPUB side and
             //  doing it here as well breaks ZMQ_XPUB_VERBOSE
             //  when there are forwarding devices involved.
-            subscriptions.add(data, 1, size - 1);
+            subscriptions.add(msg, 1, size - 1);
             return dist.sendToAll(msg);
         }
-        else if (size > 0 && data[0] == 0) {
+        else if (size > 0 && msg.get(0) == 0) {
             //  Process unsubscribe message
-            if (subscriptions.rm(data, 1, size - 1)) {
+            if (subscriptions.rm(msg, 1, size - 1)) {
                 return dist.sendToAll(msg);
             }
         }

--- a/src/test/java/org/zeromq/TestProxy.java
+++ b/src/test/java/org/zeromq/TestProxy.java
@@ -237,7 +237,7 @@ public class TestProxy
         Context ctx = ZMQ.context(1);
         Socket control = ctx.socket(ZMQ.PAIR);
         control.connect(controlEndpoint);
-        control.send("TERMINATE");
+        control.send(ZMQ.PROXY_TERMINATE);
         proxy.join();
         control.close();
         ctx.close();

--- a/src/test/java/org/zeromq/XpubXsubZTest.java
+++ b/src/test/java/org/zeromq/XpubXsubZTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -13,36 +14,17 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
+import org.zeromq.ZMQ.Socket;
+import org.zeromq.ZProxy.Plug;
 
 import zmq.util.Utils;
 
 public class XpubXsubZTest
 {
-    @Test
-    public void testIssue476() throws InterruptedException, IOException, ExecutionException
+    private AtomicReference<Throwable> testIssue476(final int front, final int back, final int max,
+                                                    ExecutorService service, final ZContext ctx)
+            throws InterruptedException, ExecutionException
     {
-        final int front = Utils.findOpenPort();
-        final int back = Utils.findOpenPort();
-
-        final int max = 10;
-
-        ExecutorService service = Executors.newFixedThreadPool(3);
-        final ZContext ctx = new ZContext();
-        service.submit(new Runnable()
-        {
-            @Override
-            public void run()
-            {
-                Thread.currentThread().setName("Proxy");
-                ZMQ.Socket xpub = ctx.createSocket(ZMQ.XPUB);
-                xpub.bind("tcp://*:" + back);
-                ZMQ.Socket xsub = ctx.createSocket(ZMQ.XSUB);
-                xsub.bind("tcp://*:" + front);
-                ZMQ.Socket ctrl = ctx.createSocket(ZMQ.PAIR);
-                ctrl.bind("inproc://ctrl-proxy");
-                ZMQ.proxy(xpub, xsub, null, ctrl);
-            }
-        });
         Future<?> subscriber = service.submit(new Runnable()
         {
             @Override
@@ -93,10 +75,149 @@ public class XpubXsubZTest
         subscriber.get();
 
         ZMQ.msleep(300);
+        return error;
+    }
+
+    @Test
+    public void testIssue476() throws InterruptedException, IOException, ExecutionException
+    {
+        final int front = Utils.findOpenPort();
+        final int back = Utils.findOpenPort();
+
+        final int max = 10;
+
+        ExecutorService service = Executors.newFixedThreadPool(3);
+        final ZContext ctx = new ZContext();
+        service.submit(new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                Thread.currentThread().setName("Proxy");
+                ZMQ.Socket xpub = ctx.createSocket(ZMQ.XPUB);
+                xpub.bind("tcp://*:" + back);
+                ZMQ.Socket xsub = ctx.createSocket(ZMQ.XSUB);
+                xsub.bind("tcp://*:" + front);
+                ZMQ.Socket ctrl = ctx.createSocket(ZMQ.PAIR);
+                ctrl.bind("inproc://ctrl-proxy");
+                ZMQ.proxy(xpub, xsub, null, ctrl);
+            }
+        });
+        final AtomicReference<Throwable> error = testIssue476(front, back, max, service, ctx);
         ZMQ.Socket ctrl = ctx.createSocket(ZMQ.PAIR);
         ctrl.connect("inproc://ctrl-proxy");
-        ctrl.send("TERMINATE");
+        ctrl.send(ZMQ.PROXY_TERMINATE);
         ctrl.close();
+
+        service.shutdown();
+        service.awaitTermination(2, TimeUnit.SECONDS);
+
+        assertThat(error.get(), nullValue());
+
+        ctx.close();
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testIssue476WithZProxy() throws InterruptedException, IOException, ExecutionException
+    {
+        final int front = Utils.findOpenPort();
+        final int back = Utils.findOpenPort();
+
+        final int max = 10;
+
+        ExecutorService service = Executors.newFixedThreadPool(3);
+        final ZContext ctx = new ZContext();
+
+        ZProxy.Proxy actor = new ZProxy.Proxy.SimpleProxy()
+        {
+            @Override
+            public Socket create(ZContext ctx, Plug place, Object... args)
+            {
+                if (place == Plug.FRONT) {
+                    return ctx.createSocket(ZMQ.XSUB);
+                }
+                if (place == Plug.BACK) {
+                    return ctx.createSocket(ZMQ.XPUB);
+                }
+                if (place == Plug.CAPTURE) {
+                    return ctx.createSocket(ZMQ.PUB);
+                }
+                return null;
+            }
+
+            @Override
+            public boolean configure(Socket socket, Plug place, Object... args) throws IOException
+            {
+                if (place == Plug.FRONT) {
+                    return socket.bind("tcp://*:" + front);
+                }
+                if (place == Plug.BACK) {
+                    return socket.bind("tcp://*:" + back);
+                }
+                return true;
+            }
+        };
+        ZProxy proxy = ZProxy.newZProxy(ctx, null, actor, UUID.randomUUID().toString());
+        proxy.start(true);
+        final AtomicReference<Throwable> error = testIssue476(front, back, max, service, ctx);
+
+        proxy.exit(false);
+
+        service.shutdown();
+        service.awaitTermination(2, TimeUnit.SECONDS);
+
+        assertThat(error.get(), nullValue());
+
+        ctx.close();
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testIssue476WithZProxyZmqPump() throws InterruptedException, IOException, ExecutionException
+    {
+        final int front = Utils.findOpenPort();
+        final int back = Utils.findOpenPort();
+
+        final int max = 10;
+
+        ExecutorService service = Executors.newFixedThreadPool(3);
+        final ZContext ctx = new ZContext();
+
+        ZProxy.Proxy actor = new ZProxy.Proxy.SimpleProxy()
+        {
+            @Override
+            public Socket create(ZContext ctx, Plug place, Object... args)
+            {
+                if (place == Plug.FRONT) {
+                    return ctx.createSocket(ZMQ.XSUB);
+                }
+                if (place == Plug.BACK) {
+                    return ctx.createSocket(ZMQ.XPUB);
+                }
+                if (place == Plug.CAPTURE) {
+                    return ctx.createSocket(ZMQ.PUB);
+                }
+                return null;
+            }
+
+            @Override
+            public boolean configure(Socket socket, Plug place, Object... args) throws IOException
+            {
+                if (place == Plug.FRONT) {
+                    return socket.bind("tcp://*:" + front);
+                }
+                if (place == Plug.BACK) {
+                    return socket.bind("tcp://*:" + back);
+                }
+                return true;
+            }
+        };
+        ZProxy proxy = ZProxy.newProxy(ctx, "XPub-XSub", actor, UUID.randomUUID().toString());
+        proxy.start(true);
+
+        final AtomicReference<Throwable> error = testIssue476(front, back, max, service, ctx);
+        proxy.exit(false);
 
         service.shutdown();
         service.awaitTermination(2, TimeUnit.SECONDS);

--- a/src/test/java/org/zeromq/ZMonitorTest.java
+++ b/src/test/java/org/zeromq/ZMonitorTest.java
@@ -1,6 +1,7 @@
 package org.zeromq;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
@@ -13,7 +14,31 @@ import org.zeromq.ZMonitor.ZEvent;
 public class ZMonitorTest
 {
     @Test
-    public void testZMonitor()
+    public void testZMonitorImpossibleWorkflows() throws IOException
+    {
+        final ZContext ctx = new ZContext();
+        final Socket socket = ctx.createSocket(ZMQ.DEALER);
+
+        final ZMonitor monitor = new ZMonitor(ctx, socket);
+
+        // impossible to monitor events before being started
+        ZEvent event = monitor.nextEvent();
+        assertThat(event, nullValue());
+        event = monitor.nextEvent(-1);
+        assertThat(event, nullValue());
+
+        monitor.start();
+
+        // all no-ops commands once ZMonitor is started
+        monitor.add().remove().verbose(false).start();
+
+        socket.close();
+        monitor.close();
+        ctx.close();
+    }
+
+    @Test
+    public void testZMonitor() throws IOException
     {
         final ZContext ctx = new ZContext();
         final Socket client = ctx.createSocket(ZMQ.DEALER);
@@ -21,12 +46,14 @@ public class ZMonitorTest
 
         final ZMonitor clientMonitor = new ZMonitor(ctx, client);
         clientMonitor.verbose(true);
-        clientMonitor.add(Event.LISTENING, Event.CONNECTED, Event.DISCONNECTED);
+        clientMonitor.add(Event.LISTENING, Event.CONNECTED, Event.DISCONNECTED, Event.ACCEPT_FAILED);
+        clientMonitor.remove(Event.ACCEPT_FAILED);
+
         clientMonitor.start();
 
         final ZMonitor serverMonitor = new ZMonitor(ctx, server);
         serverMonitor.verbose(false);
-        serverMonitor.add(Event.LISTENING, Event.ACCEPTED);
+        serverMonitor.add(Event.LISTENING, Event.ACCEPTED, Event.HANDSHAKE_PROTOCOL);
         serverMonitor.start();
 
         //  Check server is now listening
@@ -43,6 +70,18 @@ public class ZMonitorTest
         //  Check server accepted connection
         received = serverMonitor.nextEvent(true);
         assertThat(received.type, is(Event.ACCEPTED));
+
+        System.out.println("server @ tcp://127.0.0.1:" + port + " received " + received.toString());
+
+        //  Check server accepted connection
+        received = serverMonitor.nextEvent(-1); // timeout -1 aka blocking
+        assertThat(received.type, is(Event.HANDSHAKE_PROTOCOL));
+
+        received = serverMonitor.nextEvent(false); // with no blocking
+        assertThat(received, nullValue());
+
+        received = serverMonitor.nextEvent(10); // timeout
+        assertThat(received, nullValue());
 
         client.close();
         clientMonitor.close();

--- a/src/test/java/org/zeromq/auth/ZAuthTest.java
+++ b/src/test/java/org/zeromq/auth/ZAuthTest.java
@@ -22,7 +22,7 @@ import org.zeromq.ZMQ;
  */
 public class ZAuthTest
 {
-    private static final boolean VERBOSE_MODE       = false;
+    private static final boolean VERBOSE_MODE       = true;
     private static final String  PASSWORDS_FILE     = "target/passwords";
     private static final String  CERTIFICATE_FOLDER = "target/curve";
 
@@ -43,6 +43,131 @@ public class ZAuthTest
     }
 
     @Test
+    public void testNull() throws IOException
+    {
+        System.out.println("testNull");
+        //  Create context
+        final ZContext ctx = new ZContext();
+        try {
+            ZAuth auth = new ZAuth(ctx);
+            //  Get some indication of what the authenticator is deciding
+            auth.setVerbose(VERBOSE_MODE);
+            // auth send the replies
+            auth.replies(true);
+
+            //  Create and bind server socket
+            ZMQ.Socket server = ctx.createSocket(ZMQ.PUSH);
+            server.setZapDomain("test");
+            final int port = server.bindToRandomPort("tcp://*");
+
+            //  Create and connect client socket
+            ZMQ.Socket client = ctx.createSocket(ZMQ.PULL);
+            boolean rc = client.connect("tcp://127.0.0.1:" + port);
+            assertThat(rc, is(true));
+
+            //  Send a single message from server to client
+            rc = server.send("Hello");
+            assertThat(rc, is(true));
+
+            ZAuth.ZapReply reply = auth.nextReply();
+            assertThat(reply.statusCode, is(200));
+
+            String message = client.recvStr();
+
+            assertThat(message, is("Hello"));
+
+            auth.close();
+        }
+        finally {
+            ctx.close();
+        }
+    }
+
+    @Test
+    public void testNullAllowed() throws IOException
+    {
+        System.out.println("testNullAllowed");
+        //  Create context
+        final ZContext ctx = new ZContext();
+        try {
+            ZAuth auth = new ZAuth(ctx);
+            //  Get some indication of what the authenticator is deciding
+            auth.setVerbose(VERBOSE_MODE);
+            // auth send the replies
+            auth.replies(true);
+            auth.allow("127.0.0.1");
+
+            //  Create and bind server socket
+            ZMQ.Socket server = ctx.createSocket(ZMQ.PUSH);
+            server.setZapDomain("test");
+            final int port = server.bindToRandomPort("tcp://*");
+
+            //  Create and connect client socket
+            ZMQ.Socket client = ctx.createSocket(ZMQ.PULL);
+            boolean rc = client.connect("tcp://127.0.0.1:" + port);
+            assertThat(rc, is(true));
+
+            //  Send a single message from server to client
+            rc = server.send("Hello");
+            assertThat(rc, is(true));
+
+            ZAuth.ZapReply reply = auth.nextReply();
+            assertThat(reply.statusCode, is(200));
+
+            String message = client.recvStr();
+
+            assertThat(message, is("Hello"));
+
+            auth.close();
+        }
+        finally {
+            ctx.close();
+        }
+    }
+
+    @Test
+    public void testNullWithNoDomain() throws IOException
+    {
+        System.out.println("testNullWithNoDomain");
+        //  Create context
+        final ZContext ctx = new ZContext();
+        try {
+            ZAuth auth = new ZAuth(ctx);
+            //  Get some indication of what the authenticator is deciding
+            auth.setVerbose(VERBOSE_MODE);
+            // auth send the replies
+            auth.replies(true);
+            auth.allow("127.0.0.1");
+
+            //  Create and bind server socket
+            ZMQ.Socket server = ctx.createSocket(ZMQ.PUSH);
+//            server.setZapDomain("test"); // no domain, so no NULL authentication mechanism
+            final int port = server.bindToRandomPort("tcp://*");
+
+            //  Create and connect client socket
+            ZMQ.Socket client = ctx.createSocket(ZMQ.PULL);
+            boolean rc = client.connect("tcp://127.0.0.1:" + port);
+            assertThat(rc, is(true));
+
+            //  Send a single message from server to client
+            rc = server.send("Hello");
+            assertThat(rc, is(true));
+
+            ZAuth.ZapReply reply = auth.nextReply(1000);
+            assertThat(reply, nullValue());
+
+            String message = client.recvStr();
+
+            assertThat(message, is("Hello"));
+
+            auth.close();
+        }
+        finally {
+            ctx.close();
+        }
+    }
+
+    @Test
     public void testPlainWithPassword() throws IOException
     {
         System.out.println("testPlainWithPassword");
@@ -57,8 +182,6 @@ public class ZAuthTest
             auth.setVerbose(VERBOSE_MODE);
             // auth send the replies
             auth.replies(true);
-            //  Whitelist our address; any other address will be rejected
-            auth.allow("127.0.0.1");
             auth.configurePlain("*", PASSWORDS_FILE);
 
             //  Create and bind server socket
@@ -94,6 +217,50 @@ public class ZAuthTest
     }
 
     @Test
+    public void testPlainWithPasswordDenied() throws IOException
+    {
+        System.out.println("testPlainWithPasswordDenied");
+        //  Create context
+        final ZContext ctx = new ZContext();
+        try {
+            //  Start an authentication engine for this context. This engine
+            //  allows or denies incoming connections (talking to the libzmq
+            //  core over a protocol called ZAP).
+            ZAuth auth = new ZAuth(ctx);
+            //  Get some indication of what the authenticator is deciding
+            auth.setVerbose(true);
+            // auth send the replies
+            auth.replies(true);
+            auth.configurePlain("*", PASSWORDS_FILE);
+
+            //  Create and bind server socket
+            ZMQ.Socket server = ctx.createSocket(ZMQ.PUSH);
+            server.setAsServerPlain(true);
+            server.setZapDomain("global".getBytes());
+            final int port = server.bindToRandomPort("tcp://*");
+
+            //  Create and connect client socket
+            ZMQ.Socket client = ctx.createSocket(ZMQ.PULL);
+            client.setPlainUsername("admin".getBytes());
+            client.setPlainPassword("wrong".getBytes());
+            boolean rc = client.connect("tcp://127.0.0.1:" + port);
+            assertThat(rc, is(true));
+
+            //  Send a single message from server to client
+            rc = server.send("Hello");
+            assertThat(rc, is(true));
+
+            ZAuth.ZapReply reply = auth.nextReply();
+            assertThat(reply.statusCode, is(400));
+
+            auth.close();
+        }
+        finally {
+            ctx.close();
+        }
+    }
+
+    @Test
     public void testCurveAnyClient() throws IOException
     {
         System.out.println("testCurveAnyClient");
@@ -109,8 +276,6 @@ public class ZAuthTest
             // auth send the replies
             auth.replies(true);
 
-            //  Whitelist our address; any other address will be rejected
-            auth.allow("127.0.0.1");
             auth.configureCurve(ZAuth.CURVE_ALLOW_ANY);
 
             //  We need two certificates, one for the client and one for
@@ -141,6 +306,8 @@ public class ZAuthTest
             assertThat(reply.statusCode, is(200));
             assertThat(reply.userId, is(""));
 
+            System.out.println("ZAuth replied " + reply.toString());
+
             String message = client.recvStr();
             assertThat(message, is("Hello"));
 
@@ -167,8 +334,6 @@ public class ZAuthTest
             // auth send the replies
             auth.replies(true);
 
-            //  Whitelist our address; any other address will be rejected
-            auth.allow("127.0.0.1");
             //  Tell authenticator to use the certificate store in .curve
             auth.configureCurve(CERTIFICATE_FOLDER);
 
@@ -218,7 +383,178 @@ public class ZAuthTest
             ctx.close();
             TestUtils.cleanupDir(CERTIFICATE_FOLDER);
         }
+    }
 
+    @Test
+    public void testBlacklistDenied() throws IOException
+    {
+        System.out.println("testBlacklistDenied");
+        final ZContext ctx = new ZContext();
+        try {
+            //  Start an authentication engine for this context. This engine
+            //  allows or denies incoming connections (talking to the libzmq
+            //  core over a protocol called ZAP).
+            ZAuth auth = new ZAuth(ctx, new ZCertStore.Timestamper());
+            //  Get some indication of what the authenticator is deciding
+            auth.setVerbose(VERBOSE_MODE);
+            // auth send the replies
+            auth.replies(true);
+
+            //  Blacklist our address
+            auth.deny("127.0.0.1");
+
+            //  Create and bind server socket
+            ZMQ.Socket server = ctx.createSocket(ZMQ.PUSH);
+            server.setZapDomain("global".getBytes());
+            final int port = server.bindToRandomPort("tcp://*");
+
+            //  Create and connect client socket
+            ZMQ.Socket client = ctx.createSocket(ZMQ.PULL);
+            boolean rc = client.connect("tcp://127.0.0.1:" + port);
+            assertThat(rc, is(true));
+
+            //  Send a single message from server to client
+            rc = server.send("Hello");
+            assertThat(rc, is(true));
+
+            ZAuth.ZapReply reply = auth.nextReply(true);
+            assertThat(reply.statusCode, is(400));
+            assertThat(reply.userId, is(""));
+
+            auth.close();
+        }
+        finally {
+            ctx.close();
+        }
+    }
+
+    @Test
+    public void testBlacklistAllowed() throws IOException
+    {
+        System.out.println("testBlacklistAllowed");
+        final ZContext ctx = new ZContext();
+        try {
+            //  Start an authentication engine for this context. This engine
+            //  allows or denies incoming connections (talking to the libzmq
+            //  core over a protocol called ZAP).
+            ZAuth auth = new ZAuth(ctx, new ZCertStore.Hasher());
+            //  Get some indication of what the authenticator is deciding
+            auth.setVerbose(VERBOSE_MODE);
+            // auth send the replies
+            auth.replies(true);
+
+            //  Blacklist another address
+            auth.deny("127.0.0.2");
+
+            //  Create and bind server socket
+            ZMQ.Socket server = ctx.createSocket(ZMQ.PUSH);
+            server.setZapDomain("global".getBytes());
+            final int port = server.bindToRandomPort("tcp://*");
+
+            //  Create and connect client socket
+            ZMQ.Socket client = ctx.createSocket(ZMQ.PULL);
+            boolean rc = client.connect("tcp://127.0.0.1:" + port);
+            assertThat(rc, is(true));
+
+            //  Send a single message from server to client
+            rc = server.send("Hello");
+            assertThat(rc, is(true));
+
+            ZAuth.ZapReply reply = auth.nextReply(true);
+            assertThat(reply.statusCode, is(200));
+            assertThat(reply.userId, is(""));
+
+            auth.close();
+        }
+        finally {
+            ctx.close();
+        }
+    }
+
+    @Test
+    public void testWhitelistDenied() throws IOException
+    {
+        System.out.println("testWhitelistDenied");
+        final ZContext ctx = new ZContext();
+        try {
+            //  Start an authentication engine for this context. This engine
+            //  allows or denies incoming connections (talking to the libzmq
+            //  core over a protocol called ZAP).
+            ZAuth auth = new ZAuth(ctx, new ZCertStore.Hasher());
+            //  Get some indication of what the authenticator is deciding
+            auth.setVerbose(VERBOSE_MODE);
+            // auth send the replies
+            auth.replies(true);
+
+            //  Whitelist another address
+            auth.allow("127.0.0.2");
+
+            //  Create and bind server socket
+            ZMQ.Socket server = ctx.createSocket(ZMQ.PUSH);
+            server.setZapDomain("global".getBytes());
+            final int port = server.bindToRandomPort("tcp://*");
+
+            //  Create and connect client socket
+            ZMQ.Socket client = ctx.createSocket(ZMQ.PULL);
+            boolean rc = client.connect("tcp://127.0.0.1:" + port);
+            assertThat(rc, is(true));
+
+            //  Send a single message from server to client
+            rc = server.send("Hello");
+            assertThat(rc, is(true));
+
+            ZAuth.ZapReply reply = auth.nextReply(true);
+            assertThat(reply.statusCode, is(400));
+            assertThat(reply.userId, is(""));
+
+            auth.close();
+        }
+        finally {
+            ctx.close();
+        }
+    }
+
+    @Test
+    public void testWhitelistAllowed() throws IOException
+    {
+        System.out.println("testWhitelistAllowed");
+        final ZContext ctx = new ZContext();
+        try {
+            //  Start an authentication engine for this context. This engine
+            //  allows or denies incoming connections (talking to the libzmq
+            //  core over a protocol called ZAP).
+            ZAuth auth = new ZAuth(ctx, new ZCertStore.Hasher());
+            //  Get some indication of what the authenticator is deciding
+            auth.setVerbose(VERBOSE_MODE);
+            // auth send the replies
+            auth.replies(true);
+
+            //  Whitelist our address
+            auth.allow("127.0.0.1");
+
+            //  Create and bind server socket
+            ZMQ.Socket server = ctx.createSocket(ZMQ.PUSH);
+            server.setZapDomain("global".getBytes());
+            final int port = server.bindToRandomPort("tcp://*");
+
+            //  Create and connect client socket
+            ZMQ.Socket client = ctx.createSocket(ZMQ.PULL);
+            boolean rc = client.connect("tcp://127.0.0.1:" + port);
+            assertThat(rc, is(true));
+
+            //  Send a single message from server to client
+            rc = server.send("Hello");
+            assertThat(rc, is(true));
+
+            ZAuth.ZapReply reply = auth.nextReply(true);
+            assertThat(reply.statusCode, is(200));
+            assertThat(reply.userId, is(""));
+
+            auth.close();
+        }
+        finally {
+            ctx.close();
+        }
     }
 
     @Test
@@ -228,14 +564,12 @@ public class ZAuthTest
         // this is the same test but here we do not save the client's certificate into the certstore's folder
         final ZContext ctx = new ZContext();
         try {
-            ZAuth auth = new ZAuth(ctx, new ZCertStore.Hasher());
+            ZAuth auth = new ZAuth(ctx, new ZCertStore.Timestamper());
             //  Get some indication of what the authenticator is deciding
             auth.setVerbose(VERBOSE_MODE);
             // auth send the replies
             auth.replies(true);
 
-            //  Whitelist our address; any other address will be rejected
-            auth.allow("127.0.0.1");
             //  Tell authenticator to use the certificate store in .curve
             auth.configureCurve(CERTIFICATE_FOLDER);
 
@@ -287,6 +621,31 @@ public class ZAuthTest
         }
     }
 
+    @Test
+    public void testNoReplies() throws IOException
+    {
+        System.out.println("testNoReplies");
+        final ZContext ctx = new ZContext();
+        try {
+            //  Start an authentication engine for this context. This engine
+            //  allows or denies incoming connections (talking to the libzmq
+            //  core over a protocol called ZAP).
+            ZAuth auth = new ZAuth(ctx, new ZCertStore.Hasher());
+            //  Get some indication of what the authenticator is deciding
+            auth.setVerbose(VERBOSE_MODE);
+            // auth do not send the replies
+            auth.replies(false);
+
+            ZAuth.ZapReply reply = auth.nextReply(true);
+            assertThat(reply, nullValue());
+
+            auth.close();
+        }
+        finally {
+            ctx.close();
+        }
+    }
+
     @After
     public void cleanup()
     {
@@ -294,7 +653,7 @@ public class ZAuthTest
         deletePasswords.delete();
     }
 
-//    @Test
+    //    @Test
     public void testRepeated() throws IOException
     {
         for (int idx = 0; idx < 10000; ++idx) {

--- a/src/test/java/org/zeromq/util/ZDataTest.java
+++ b/src/test/java/org/zeromq/util/ZDataTest.java
@@ -1,0 +1,69 @@
+package org.zeromq.util;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.zeromq.ZMQ;
+
+public class ZDataTest
+{
+    @Test
+    public void testPrint()
+    {
+        byte[] buf = new byte[10];
+        Arrays.fill(buf , (byte) 0xAA);
+        ZData data = new ZData(buf);
+
+        data.print(System.out, "ZData: ");
+    }
+
+    @Test
+    public void testPrintNonPrintable()
+    {
+        byte[] buf = new byte[12];
+        Arrays.fill(buf , (byte) 0x04);
+        ZData data = new ZData(buf);
+
+        data.print(System.out, "ZData: ");
+    }
+
+    @Test
+    public void testToString()
+    {
+        ZData data = new ZData("test".getBytes(ZMQ.CHARSET));
+
+        String string = data.toString();
+        assertThat(string, is("test"));
+    }
+
+    @Test
+    public void testToStringNonPrintable()
+    {
+        byte[] buf = new byte[2];
+        Arrays.fill(buf , (byte) 0x04);
+        ZData data = new ZData(buf);
+
+        String string = data.toString();
+        assertThat(string, is("0404"));
+    }
+
+    @Test
+    public void testStreq()
+    {
+        ZData data = new ZData("test".getBytes(ZMQ.CHARSET));
+
+        assertThat(data.streq("test"), is(true));
+    }
+
+    @Test
+    public void testEquals()
+    {
+        ZData data = new ZData("test".getBytes(ZMQ.CHARSET));
+        ZData other = new ZData("test".getBytes(ZMQ.CHARSET));
+
+        assertThat(data.equals(other), is(true));
+    }
+}

--- a/src/test/java/zmq/proxy/ProxySingleSocketTest.java
+++ b/src/test/java/zmq/proxy/ProxySingleSocketTest.java
@@ -98,7 +98,7 @@ public class ProxySingleSocketTest
         assertThat(msg, notNullValue());
         assertThat(new String(msg.data(), ZMQ.CHARSET), is("msg22"));
 
-        ret = ZMQ.send(control, "TERMINATE", 0);
+        ret = ZMQ.send(control, ZMQ.PROXY_TERMINATE, 0);
         assertThat(ret, is(9));
 
         System.out.println(".");

--- a/src/test/java/zmq/proxy/ProxyTerminateTest.java
+++ b/src/test/java/zmq/proxy/ProxyTerminateTest.java
@@ -107,7 +107,7 @@ public class ProxyTerminateTest
         ret = ZMQ.send(publisher, "This is a test", 0);
         assertThat(ret, is(14));
 
-        ret = ZMQ.send(control, "TERMINATE", 0);
+        ret = ZMQ.send(control, ZMQ.PROXY_TERMINATE, 0);
         assertThat(ret, is(9));
 
         ZMQ.close(publisher);

--- a/src/test/java/zmq/socket/pubsub/MTrieTest.java
+++ b/src/test/java/zmq/socket/pubsub/MTrieTest.java
@@ -3,37 +3,277 @@ package zmq.socket.pubsub;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.Before;
 import org.junit.Test;
 
+import zmq.Msg;
 import zmq.ZObject;
 import zmq.pipe.Pipe;
+import zmq.socket.pubsub.Mtrie.IMtrieHandler;
 
 public class MTrieTest
 {
+    private static final class MtrieHandler implements IMtrieHandler
+    {
+        private final AtomicInteger counter = new AtomicInteger();
+        @Override
+        public void invoke(Pipe pipe, byte[] data, int size, XPub pub)
+        {
+            counter.incrementAndGet();
+        }
+    }
+
     private Pipe pipe;
 
-    private static final byte[] prefix = { 1, 2, 3, 4, 5 };
+    private MtrieHandler handler;
+
+    private static final Msg prefix = new Msg(new byte[] { 1, 2, 3, 4, 5 });
 
     @Before
     public void setUp()
+    {
+        pipe = createPipe();
+        handler = new MtrieHandler();
+    }
+
+    private Pipe createPipe()
     {
         ZObject object = new ZObject(null, 0)
         {
         };
         Pipe[] pair = Pipe.pair(new ZObject[] { object, object }, new int[2], new boolean[2]);
-        pipe = pair[0];
+        return pair[0];
     }
 
     @Test
-    public void testRemoveIssue476()
+    public void testAddRemoveNodeOnTop()
     {
         Mtrie mtrie = new Mtrie();
 
-        boolean rc = mtrie.add(prefix, prefix.length, pipe);
+        boolean rc = mtrie.addOnTop(pipe);
+        assertThat(rc, is(true));
+        rc = mtrie.rm(new Msg(1), pipe);
+        assertThat(rc, is(true));
+    }
+
+    @Test
+    public void testAddRemoveMultiNodesBelowLevel()
+    {
+        Mtrie mtrie = new Mtrie();
+        Pipe other = createPipe();
+        Pipe third = createPipe();
+
+        boolean rc = mtrie.add(prefix, pipe);
+        assertThat(rc, is(true));
+        byte[] abv = Arrays.copyOf(prefix.data(), prefix.size());
+        abv[1] = 0;
+        Msg above = new Msg(abv);
+        rc = mtrie.add(above, other);
         assertThat(rc, is(true));
 
-        rc = mtrie.rm(prefix, prefix.length, pipe);
+        abv[1] = -1;
+        above = new Msg(abv);
+        rc = mtrie.add(above, third);
         assertThat(rc, is(true));
+
+        rc = mtrie.rm(prefix, pipe);
+        assertThat(rc, is(true));
+
+        abv[1] = 0;
+        above = new Msg(abv);
+        rc = mtrie.rm(above, other);
+        assertThat(rc, is(true));
+
+        abv[1] = -1;
+        above = new Msg(abv);
+        rc = mtrie.rm(above, third);
+        assertThat(rc, is(true));
+    }
+
+    @Test
+    public void testAddRemoveMultiNodesAboveLevel()
+    {
+        Mtrie mtrie = new Mtrie();
+        Pipe other = createPipe();
+        Pipe third = createPipe();
+
+        boolean rc = mtrie.add(prefix, pipe);
+        assertThat(rc, is(true));
+        byte[] abv = Arrays.copyOf(prefix.data(), prefix.size());
+        abv[1] = 0;
+        Msg above = new Msg(abv);
+        rc = mtrie.add(above, other);
+        assertThat(rc, is(true));
+
+        abv[1] = 33;
+        above = new Msg(abv);
+        rc = mtrie.add(above, third);
+        assertThat(rc, is(true));
+
+        rc = mtrie.rm(prefix, pipe);
+        assertThat(rc, is(true));
+
+        abv[1] = 0;
+        above = new Msg(abv);
+        rc = mtrie.rm(above, other);
+        assertThat(rc, is(true));
+
+        abv[1] = 33;
+        above = new Msg(abv);
+        rc = mtrie.rm(above, third);
+        assertThat(rc, is(true));
+    }
+
+    @Test
+    public void testAddRemoveMultiNodesSameLevel()
+    {
+        Mtrie mtrie = new Mtrie();
+        Pipe other = createPipe();
+
+        boolean rc = mtrie.add(prefix, pipe);
+        assertThat(rc, is(true));
+        rc = mtrie.add(prefix, other);
+        assertThat(rc, is(false));
+
+        rc = mtrie.rm(prefix, pipe);
+        assertThat(rc, is(false));
+        rc = mtrie.rm(prefix, other);
+        assertThat(rc, is(true));
+    }
+
+    @Test
+    public void testAddRemoveOneNode()
+    {
+        Mtrie mtrie = new Mtrie();
+
+        boolean rc = mtrie.add(prefix, pipe);
+        assertThat(rc, is(true));
+
+        rc = mtrie.rm(prefix, pipe);
+        assertThat(rc, is(true));
+    }
+
+    @Test
+    public void testAddRemoveOneNodeWithFunctionCall()
+    {
+        Mtrie mtrie = new Mtrie();
+
+        boolean rc = mtrie.add(prefix, pipe);
+        assertThat(rc, is(true));
+
+        rc = mtrie.rm(pipe, handler, null);
+        assertThat(rc, is(true));
+        assertThat(handler.counter.get(), is(1));
+    }
+
+    @Test
+    public void testAddRemoveMultiNodesSameLevelWithFunctionCall()
+    {
+        Mtrie mtrie = new Mtrie();
+        Pipe other = createPipe();
+
+        boolean rc = mtrie.add(prefix, pipe);
+        assertThat(rc, is(true));
+        rc = mtrie.add(prefix, other);
+        assertThat(rc, is(false));
+
+        rc = mtrie.rm(pipe, handler, null);
+        assertThat(rc, is(true));
+        assertThat(handler.counter.get(), is(0));
+
+        rc = mtrie.rm(other, handler, null);
+        assertThat(rc, is(true));
+        assertThat(handler.counter.get(), is(1));
+    }
+
+    @Test
+    public void testAddRemoveNodeOnTopWithFunctionCall()
+    {
+        Mtrie mtrie = new Mtrie();
+
+        boolean rc = mtrie.addOnTop(pipe);
+        assertThat(rc, is(true));
+        rc = mtrie.rm(pipe, handler, null);
+        assertThat(rc, is(true));
+        assertThat(handler.counter.get(), is(1));
+    }
+
+    @Test
+    public void testAddRemoveMultiNodesBelowLevelWithFunctionCall()
+    {
+        Mtrie mtrie = new Mtrie();
+        Pipe other = createPipe();
+        Pipe third = createPipe();
+
+        boolean rc = mtrie.add(prefix, pipe);
+        assertThat(rc, is(true));
+        byte[] abv = Arrays.copyOf(prefix.data(), prefix.size());
+
+        abv[1] = 0;
+        Msg above = new Msg(abv);
+        rc = mtrie.add(above, other);
+        assertThat(rc, is(true));
+
+        abv[1] = -1;
+        above = new Msg(abv);
+        rc = mtrie.add(above, third);
+        assertThat(rc, is(true));
+
+        rc = mtrie.rm(pipe, handler, null);
+        assertThat(rc, is(true));
+        assertThat(handler.counter.get(), is(1));
+
+        abv[1] = 0;
+        above = new Msg(abv);
+        rc = mtrie.rm(other, handler, null);
+        assertThat(rc, is(true));
+        assertThat(handler.counter.get(), is(2));
+
+        abv[1] = -1;
+        above = new Msg(abv);
+        rc = mtrie.rm(third, handler, null);
+        assertThat(rc, is(true));
+        assertThat(handler.counter.get(), is(3));
+    }
+
+    @Test
+    public void testAddRemoveMultiNodesAboveLevelWithFunctionCall()
+    {
+        Mtrie mtrie = new Mtrie();
+        Pipe other = createPipe();
+        Pipe third = createPipe();
+
+        boolean rc = mtrie.add(prefix, pipe);
+        assertThat(rc, is(true));
+        byte[] abv = Arrays.copyOf(prefix.data(), prefix.size());
+
+        abv[1] = 3;
+        Msg above = new Msg(abv);
+        rc = mtrie.add(above, other);
+        assertThat(rc, is(true));
+
+        abv[1] = 33;
+        above = new Msg(abv);
+        rc = mtrie.add(above, third);
+        assertThat(rc, is(true));
+
+        rc = mtrie.rm(pipe, handler, null);
+        assertThat(rc, is(true));
+        assertThat(handler.counter.get(), is(1));
+
+        abv[1] = 3;
+        above = new Msg(abv);
+        rc = mtrie.rm(other, handler, null);
+        assertThat(rc, is(true));
+        assertThat(handler.counter.get(), is(2));
+
+        abv[1] = 33;
+        above = new Msg(abv);
+        rc = mtrie.rm(third, handler, null);
+        assertThat(rc, is(true));
+        assertThat(handler.counter.get(), is(3));
     }
 }

--- a/src/test/java/zmq/socket/pubsub/TrieTest.java
+++ b/src/test/java/zmq/socket/pubsub/TrieTest.java
@@ -1,0 +1,118 @@
+package zmq.socket.pubsub;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import zmq.Msg;
+
+public class TrieTest
+{
+    private static final Msg prefix = new Msg(new byte[] { 1, 2, 3, 4, 5 });
+
+    @Test
+    public void testAddRemoveNodeOnTop()
+    {
+        Trie trie = new Trie();
+
+        boolean rc = trie.add(null, 0, 0);
+        assertThat(rc, is(true));
+        rc = trie.rm(null, 0, 0);
+        assertThat(rc, is(true));
+    }
+
+    @Test
+    public void testAddRemoveMultiNodesBelowLevel()
+    {
+        Trie trie = new Trie();
+
+        boolean rc = trie.add(prefix, 0, prefix.size());
+        assertThat(rc, is(true));
+        byte[] abv = Arrays.copyOf(prefix.data(), prefix.size());
+        abv[1] = 0;
+        Msg above = new Msg(abv);
+        rc = trie.add(above, 0, above.size());
+        assertThat(rc, is(true));
+
+        abv[1] = -1;
+        above = new Msg(abv);
+        rc = trie.add(above, 0, above.size());
+        assertThat(rc, is(true));
+
+        rc = trie.rm(prefix, 0, prefix.size());
+        assertThat(rc, is(true));
+
+        abv[1] = 0;
+        above = new Msg(abv);
+        rc = trie.rm(above, 0, above.size());
+        assertThat(rc, is(true));
+
+        abv[1] = -1;
+        above = new Msg(abv);
+        rc = trie.rm(above, 0, above.size());
+        assertThat(rc, is(true));
+    }
+
+    @Test
+    public void testAddRemoveMultiNodesAboveLevel()
+    {
+        Trie trie = new Trie();
+
+        boolean rc = trie.add(prefix, 0, prefix.size());
+        assertThat(rc, is(true));
+        byte[] abv = Arrays.copyOf(prefix.data(), prefix.size());
+        abv[1] = 3;
+        Msg above = new Msg(abv);
+        rc = trie.add(above, 0, above.size());
+        assertThat(rc, is(true));
+
+        abv[1] = 33;
+        above = new Msg(abv);
+        rc = trie.add(above, 0, above.size());
+        assertThat(rc, is(true));
+
+        rc = trie.rm(prefix, 0, prefix.size());
+        assertThat(rc, is(true));
+
+        abv[1] = 3;
+        above = new Msg(abv);
+        rc = trie.rm(above, 0, above.size());
+        assertThat(rc, is(true));
+
+        abv[1] = 33;
+        above = new Msg(abv);
+        rc = trie.rm(above, 0, above.size());
+        assertThat(rc, is(true));
+    }
+
+    @Test
+    public void testAddRemoveMultiNodesSameLevel()
+    {
+        Trie trie = new Trie();
+
+        boolean rc = trie.add(prefix, 0, prefix.size());
+        assertThat(rc, is(true));
+        rc = trie.add(prefix, 0, prefix.size());
+        assertThat(rc, is(false));
+
+        rc = trie.rm(prefix, 0, prefix.size());
+        assertThat(rc, is(false));
+        rc = trie.rm(prefix, 0, prefix.size());
+        assertThat(rc, is(true));
+    }
+
+    @Test
+    public void testAddRemoveOneNode()
+    {
+        Trie trie = new Trie();
+
+        boolean rc = trie.add(prefix, 0, prefix.size());
+        assertThat(rc, is(true));
+
+        rc = trie.rm(prefix, 0, prefix.size());
+        assertThat(rc, is(true));
+    }
+}

--- a/src/test/java/zmq/socket/pubsub/XpubXsubTest.java
+++ b/src/test/java/zmq/socket/pubsub/XpubXsubTest.java
@@ -99,7 +99,7 @@ public class XpubXsubTest
         rc = command.connect("inproc://ctrl-proxy");
         assertThat(rc, is(true));
 
-        command.send(new Msg("TERMINATE".getBytes(ZMQ.CHARSET)), 0);
+        command.send(new Msg(ZMQ.PROXY_TERMINATE), 0);
 
         proxy.get();
         zmq.ZMQ.close(command);

--- a/src/test/java/zmq/socket/pubsub/XpubXsubTest.java
+++ b/src/test/java/zmq/socket/pubsub/XpubXsubTest.java
@@ -2,6 +2,7 @@ package zmq.socket.pubsub;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
@@ -21,13 +22,145 @@ import zmq.util.Utils;
 public class XpubXsubTest
 {
     @Test
+    public void testXpubSub() throws InterruptedException, IOException, ExecutionException
+    {
+        final int port = Utils.findOpenPort();
+
+        final Ctx ctx = zmq.ZMQ.createContext();
+        assertThat(ctx, notNullValue());
+
+        boolean rc;
+
+        SocketBase sub = zmq.ZMQ.socket(ctx, zmq.ZMQ.ZMQ_SUB);
+        rc = zmq.ZMQ.setSocketOption(sub, zmq.ZMQ.ZMQ_SUBSCRIBE, "topic");
+        assertThat(rc, is(true));
+        rc = zmq.ZMQ.setSocketOption(sub, zmq.ZMQ.ZMQ_SUBSCRIBE, "topix");
+        assertThat(rc, is(true));
+
+        rc = zmq.ZMQ.connect(sub, "tcp://127.0.0.1:" + port);
+        assertThat(rc, is(true));
+
+        SocketBase pub = zmq.ZMQ.socket(ctx, zmq.ZMQ.ZMQ_XPUB);
+
+        rc = zmq.ZMQ.bind(pub, "tcp://127.0.0.1:" + port);
+        assertThat(rc, is(true));
+
+        zmq.ZMQ.msleep(1000);
+
+        System.out.print("Send.");
+
+        rc = pub.send(new Msg("topic".getBytes(ZMQ.CHARSET)), ZMQ.ZMQ_SNDMORE);
+        assertThat(rc, is(true));
+
+        rc = pub.send(new Msg("hop".getBytes(ZMQ.CHARSET)), 0);
+        assertThat(rc, is(true));
+
+        System.out.print("Recv.");
+
+        Msg msg = sub.recv(0);
+        assertThat(msg.size(), is(5));
+
+        msg = sub.recv(0);
+        assertThat(msg.size(), is(3));
+
+        rc = zmq.ZMQ.setSocketOption(sub, zmq.ZMQ.ZMQ_UNSUBSCRIBE, "topix");
+        assertThat(rc, is(true));
+
+        rc = pub.send(new Msg("topix".getBytes(ZMQ.CHARSET)), ZMQ.ZMQ_SNDMORE);
+        assertThat(rc, is(true));
+
+        rc = pub.send(new Msg("hop".getBytes(ZMQ.CHARSET)), 0);
+        assertThat(rc, is(true));
+
+        rc = zmq.ZMQ.setSocketOption(sub, zmq.ZMQ.ZMQ_RCVTIMEO, 500);
+        assertThat(rc, is(true));
+
+        msg = sub.recv(0);
+        assertThat(msg, nullValue());
+
+        System.out.print("End.");
+
+        zmq.ZMQ.close(sub);
+
+        for (int idx = 0; idx < 2; ++idx) {
+            rc = pub.send(new Msg("topic abc".getBytes(ZMQ.CHARSET)), 0);
+            assertThat(rc, is(true));
+            ZMQ.msleep(10);
+        }
+        zmq.ZMQ.close(pub);
+
+        zmq.ZMQ.term(ctx);
+        System.out.println("Done.");
+    }
+
+    @Test
+    public void testXpubXSub() throws InterruptedException, IOException, ExecutionException
+    {
+        final int port = Utils.findOpenPort();
+
+        final Ctx ctx = zmq.ZMQ.createContext();
+        assertThat(ctx, notNullValue());
+
+        boolean rc;
+        Msg msg;
+
+        SocketBase sub = zmq.ZMQ.socket(ctx, zmq.ZMQ.ZMQ_XSUB);
+
+        rc = zmq.ZMQ.connect(sub, "tcp://127.0.0.1:" + port);
+        assertThat(rc, is(true));
+
+        SocketBase pub = zmq.ZMQ.socket(ctx, zmq.ZMQ.ZMQ_XPUB);
+
+        rc = zmq.ZMQ.bind(pub, "tcp://127.0.0.1:" + port);
+        assertThat(rc, is(true));
+
+        zmq.ZMQ.msleep(300);
+
+        System.out.print("Send.");
+
+        rc = sub.send(new Msg("\1topic".getBytes(ZMQ.CHARSET)), 0);
+        assertThat(rc, is(true));
+
+        zmq.ZMQ.msleep(300);
+
+        rc = pub.send(new Msg("topic".getBytes(ZMQ.CHARSET)), 0);
+        assertThat(rc, is(true));
+
+        System.out.print("Recv.");
+
+//        msg = sub.recv(0);
+//        assertThat(msg.size(), is(5));
+//
+//        msg = sub.recv(0);
+//        assertThat(msg.size(), is(3));
+//
+        rc = sub.send(new Msg("\0topic".getBytes(ZMQ.CHARSET)), 0);
+        assertThat(rc, is(true));
+
+//        rc = pub.send(new Msg("topix".getBytes(ZMQ.CHARSET)), ZMQ.ZMQ_SNDMORE);
+//        assertThat(rc, is(true));
+//
+//        rc = pub.send(new Msg("hop".getBytes(ZMQ.CHARSET)), 0);
+//        assertThat(rc, is(true));
+//
+//        rc = zmq.ZMQ.setSocketOption(sub, zmq.ZMQ.ZMQ_RCVTIMEO, 500);
+//        assertThat(rc, is(true));
+//
+//        msg = sub.recv(0);
+//        assertThat(msg, nullValue());
+
+        zmq.ZMQ.close(sub);
+        zmq.ZMQ.close(pub);
+        zmq.ZMQ.term(ctx);
+    }
+
+    @Test
     public void testIssue476() throws InterruptedException, IOException, ExecutionException
     {
         final int front = Utils.findOpenPort();
         final int back = Utils.findOpenPort();
 
         final Ctx ctx = zmq.ZMQ.createContext();
-        ZMQ.setContextOption(ctx, ZMQ.ZMQ_IO_THREADS, 4);
         assertThat(ctx, notNullValue());
 
         boolean rc;


### PR DESCRIPTION
Coverage can be activated with given profile, aka mvn clean package -Pcoverage.

This leads to other changes, to improve code coverage.

In particular, Mtrie and Trie are now with 87 and 92% coverage.
Method signatures have also been changed to avoid extra copy of array when dispatching message from XPUB and XSUB.

Final changes: org.zeromq.ZMQ constants are referring to zmq ones, and handy constants for messages to controlled proxy were introduced.