### PR TITLE
Add Coveralls Maven plugin and Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ language: java
 jdk:
   - openjdk7
   - oraclejdk8
-
+after_success:
+  - mvn clean test jacoco:report coveralls:report -P coverage

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Pure Java implementation of libzmq (http://zeromq.org).
 
 [![Build Status](https://travis-ci.org/zeromq/jeromq.png)](https://travis-ci.org/zeromq/jeromq)
+[![Coverage Status](https://coveralls.io/repos/github/zeromq/jeromq/badge.svg?branch=master)](https://coveralls.io/github/zeromq/jeromq?branch=master)
 [![Maven Central](https://img.shields.io/maven-central/v/org.zeromq/jeromq.svg)](https://maven-badges.herokuapp.com/maven-central/org.zeromq/jeromq)
 [![Javadocs](http://www.javadoc.io/badge/org.zeromq/jeromq.svg)](http://www.javadoc.io/doc/org.zeromq/jeromq)
 

--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,11 @@
               </execution>
             </executions>
           </plugin>
+        <plugin>
+          <groupId>org.eluder.coveralls</groupId>
+          <artifactId>coveralls-maven-plugin</artifactId>
+          <version>4.3.0</version>
+        </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
For #472.

I tried running `mvn clean test jacoco:report coveralls:report -P coverage` locally and it works except for the Coveralls part. I did some reading on this, and it looks like if we ever want to run the Coveralls submit task locally, we need to include `-DrepoToken=coverallsrepotokengoeshere`, per the Coveralls Maven plugin README.

I wasn't able to test that part because I don't have admin access to the JeroMQ repo, therefore I cannot see the repo token in the Coveralls UI, [as noted here](https://github.com/lemurheavy/coveralls-public/issues/152#issuecomment-33510656).

On the other hand, Travis should be able to start submitting coverage reports to Coveralls out-of-the-box, from what I've read, so hopefully this will just work™ when this PR is merged and Travis runs on the master branch.

It may or may not work when Travis runs it as part of this PR, as I think Coveralls is set up to not run in PRs, otherwise anybody could alter our published coverage percentage based on the content of their PR.