### PR TITLE
Remove link to issue #4 in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,6 @@
 
 This project uses the [C4 process](http://rfc.zeromq.org/spec:16) for all code changes. "Everyone, without distinction or discrimination, SHALL have an equal right to become a Contributor under the terms of this contract."
 
-If you are interested in contributing to JeroMQ, leave us a comment on [this issue](https://github.com/zeromq/jeromq/issues/4) and let us know that you have read and understand the C4 process.
-
 ## General Information
 
 These [slides](http://www.slideshare.net/dongminyu/zeromq-jeromq) (a visualization of the [Internal Architecture of libzmq](http://zeromq.org/whitepapers:architecture) page) may be helpful if you are interesting in contributing to JeroMQ.


### PR DESCRIPTION
See my comment at the end of issue #4, which I took the liberty of closing.

To summarize, I don't think it is necessary for new contributors to leave a comment on issue #4 stating that they have read and understand the C4 process. Case in point, the vast majority of contributors have not done this, and it hasn't been a problem. Of course I'm not arguing that we shouldn't follow the C4 process, it just seems silly to ask people to state that they are going to adhere to it.

I believe it is sufficient that we have detailed information about the contribution process, and we trust that contributors follow the process.