### PR TITLE
Add a (failing) test for issue #198

### DIFF
--- a/src/test/java/org/zeromq/TestRapidOpenCloseSocket.java
+++ b/src/test/java/org/zeromq/TestRapidOpenCloseSocket.java
@@ -10,7 +10,7 @@ import org.zeromq.ZMQ.Socket;
 // For issue: https://github.com/zeromq/jeromq/issues/198
 public class TestRapidOpenCloseSocket
 {
-  @Test
+  @Test(timeout = 10000)
   public void testRapidOpenCloseSocket() throws Exception
   {
     for (int i = 0; i < 50; i++) {

--- a/src/test/java/org/zeromq/TestRapidOpenCloseSocket.java
+++ b/src/test/java/org/zeromq/TestRapidOpenCloseSocket.java
@@ -3,6 +3,7 @@ package org.zeromq;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.zeromq.ZMQ.Socket;
@@ -10,7 +11,8 @@ import org.zeromq.ZMQ.Socket;
 // For issue: https://github.com/zeromq/jeromq/issues/198
 public class TestRapidOpenCloseSocket
 {
-  @Test(timeout = 10000)
+  @Test
+  @Ignore
   public void testRapidOpenCloseSocket() throws Exception
   {
     for (int i = 0; i < 50; i++) {

--- a/src/test/java/org/zeromq/TestRapidOpenCloseSocket.java
+++ b/src/test/java/org/zeromq/TestRapidOpenCloseSocket.java
@@ -1,0 +1,75 @@
+package org.zeromq;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.zeromq.ZMQ.Socket;
+
+// For issue: https://github.com/zeromq/jeromq/issues/198
+public class TestRapidOpenCloseSocket
+{
+  @Test
+  public void testRapidOpenCloseSocket() throws Exception
+  {
+    for (int i = 0; i < 50; i++) {
+      performTest();
+    }
+  }
+
+  private void performTest() throws Exception
+  {
+    ZContext ctx = new ZContext();
+
+    Socket recvMsgSock = ctx.createSocket(ZMQ.PULL);
+    recvMsgSock.bind("tcp://*:" + Utils.findOpenPort());
+    Socket processMsgSock = ctx.createSocket(ZMQ.PUSH);
+    processMsgSock.bind("inproc://process-msg");
+
+    List<Socket> workerSocks = new ArrayList<Socket>();
+    for (int i = 0; i < 5; i++) {
+      Socket workerSock = ctx.createSocket(ZMQ.PULL);
+      workerSock.connect("inproc://process-msg");
+      workerSocks.add(workerSock);
+    }
+
+    ZMQQueue queue = new ZMQQueue(ctx.getContext(), recvMsgSock, processMsgSock);
+    Thread proxyThr = new Thread(queue);
+    proxyThr.setName("Proxy thr");
+    proxyThr.start();
+
+    for (final Socket workerSock : workerSocks) {
+      Thread workerThr = new Thread(new Runnable()
+      {
+        @Override
+        public void run()
+        {
+          try {
+            while (true) {
+              byte[] msg = workerSock.recv();
+              // Process the msg!
+            }
+          }
+          catch (Exception e) {
+          }
+        }
+      });
+      workerThr.setName("A worker thread");
+      workerThr.start();
+    }
+
+    try {
+      Thread.sleep(100);
+    }
+    catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
+
+    System.out.println("Closing now");
+
+    ctx.destroy();
+    System.out.println("Successfully closed");
+  }
+}


### PR DESCRIPTION
In the interest of working toward a solution to #198, I copied @augustl's code into a new test file and patched it up a little bit to work with the current state of JeroMQ.

I basically just replaced the `ZMQ.context(1)` with a `new ZContext()` and replaced the context methods with the corresponding methods from ZContext (e.g. `ctx.socket` became `ctx.createSocket`, `ctx.term` became `ctx.destroy`).

I also removed the lines near the end that manually close the sockets, as this is something that the ZContext does for you when it is terminated.

Rather than use the same port every time, I used `Utils.findOpenPort` to use a new available port on every run, so we can at least conclude that the issue isn't something to do with reusing the same port.

I was able to reproduce the issue easily -- depending on the test run, the process would hang on termination of the context either on the first run, or it would get a little farther than that and hang around the third run.