### PR TITLE
Problem: No communication with libzmq 2.2.0

### DIFF
--- a/src/main/java/zmq/io/coder/DecoderBase.java
+++ b/src/main/java/zmq/io/coder/DecoderBase.java
@@ -100,10 +100,10 @@ public abstract class DecoderBase implements IDecoder
         while (processed.get() < size) {
             //  Copy the data from buffer to the message.
             int toCopy = Math.min(toRead, size - processed.get());
-            int limit = buf.limit();
-            buf.limit(buf.position() + toCopy);
-            readPos.put(buf);
-            buf.limit(limit);
+            int limit = data.limit();
+            data.limit(data.position() + toCopy);
+            readPos.put(data);
+            data.limit(limit);
             toRead -= toCopy;
             processed.set(processed.get() + toCopy);
 

--- a/src/test/java/zmq/io/AbstractProtocolVersion.java
+++ b/src/test/java/zmq/io/AbstractProtocolVersion.java
@@ -1,0 +1,131 @@
+package zmq.io;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import zmq.Ctx;
+import zmq.Msg;
+import zmq.SocketBase;
+import zmq.ZError;
+import zmq.ZMQ;
+import zmq.util.Utils;
+
+public abstract class AbstractProtocolVersion
+{
+    static class SocketMonitor extends Thread
+    {
+        private final Ctx             ctx;
+        private final String          monitorAddr;
+        private final List<ZMQ.Event> events = new ArrayList<>();
+
+        public SocketMonitor(Ctx ctx, String monitorAddr)
+        {
+            this.ctx = ctx;
+            this.monitorAddr = monitorAddr;
+        }
+
+        @Override
+        public void run()
+        {
+            SocketBase s = ZMQ.socket(ctx, ZMQ.ZMQ_PAIR);
+            boolean rc = s.connect(monitorAddr);
+            assertThat(rc, is(true));
+            // Only some of the exceptional events could fire
+            while (true) {
+                ZMQ.Event event = ZMQ.Event.read(s);
+                if (event == null && s.errno() == ZError.ETERM) {
+                    break;
+                }
+                assertThat(event, notNullValue());
+
+                events.add(event);
+            }
+            s.close();
+        }
+    }
+
+    protected byte[] assertProtocolVersion(int version, List<ByteBuffer> raws, String payload)
+            throws IOException, InterruptedException
+    {
+        int port = Utils.findOpenPort();
+        String host = "tcp://localhost:" + port;
+
+        Ctx ctx = ZMQ.init(1);
+        assertThat(ctx, notNullValue());
+
+        SocketBase receiver = ZMQ.socket(ctx, ZMQ.ZMQ_PULL);
+        assertThat(receiver, notNullValue());
+
+        boolean rc = ZMQ.setSocketOption(receiver, ZMQ.ZMQ_LINGER, 0);
+        assertThat(rc, is(true));
+
+        SocketMonitor monitor = new SocketMonitor(ctx, "inproc://monitor");
+        monitor.start();
+        rc = ZMQ.monitorSocket(receiver, "inproc://monitor", ZMQ.ZMQ_EVENT_HANDSHAKE_PROTOCOL);
+        assertThat(rc, is(true));
+
+        rc = ZMQ.bind(receiver, host);
+        assertThat(rc, is(true));
+
+        Socket sender = new Socket("127.0.0.1", port);
+        OutputStream out = sender.getOutputStream();
+        for (ByteBuffer raw : raws) {
+            out.write(raw.array());
+            ZMQ.msleep(100);
+        }
+
+        Msg msg = ZMQ.recv(receiver, 0);
+        assertThat(msg, notNullValue());
+        assertThat(new String(msg.data(), ZMQ.CHARSET), is(payload));
+
+        ZMQ.msleep(500);
+        assertThat(monitor.events.size(), is(1));
+        assertThat(monitor.events.get(0).event, is(ZMQ.ZMQ_EVENT_HANDSHAKE_PROTOCOL));
+        assertThat((Integer) monitor.events.get(0).arg, is(version));
+
+        InputStream in = sender.getInputStream();
+        byte[] data = new byte[255];
+        int read = in.read(data);
+
+        sender.close();
+
+        ZMQ.close(receiver);
+        ZMQ.term(ctx);
+
+        return Arrays.copyOf(data, read);
+    }
+
+    protected List<ByteBuffer> raws(int revision)
+    {
+        List<ByteBuffer> raws = new ArrayList<>();
+        ByteBuffer raw = ByteBuffer.allocate(12);
+        // send V1 header
+        raw.put((byte) 0xff).put(new byte[8]).put((byte) 0x1);
+        // protocol revision
+        raw.put((byte) revision);
+        // socket type
+        raw.put((byte) ZMQ.ZMQ_PUSH);
+
+        raws.add(raw);
+        return raws;
+    }
+
+    protected ByteBuffer identity()
+    {
+        return ByteBuffer.allocate(2)
+                // size
+                .put((byte) 1)
+                // flags
+                .put((byte) 0);
+    }
+}

--- a/src/test/java/zmq/io/V0ProtocolTest.java
+++ b/src/test/java/zmq/io/V0ProtocolTest.java
@@ -1,0 +1,51 @@
+package zmq.io;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import zmq.ZMQ;
+
+public class V0ProtocolTest extends AbstractProtocolVersion
+{
+    @Test(timeout = 2000)
+    public void testProtocolVersion0short() throws IOException, InterruptedException
+    {
+        ByteBuffer raw = ByteBuffer.allocate(11)
+                // send unversioned identity message
+                // size
+                .put((byte) 0x01)
+                // flags
+                .put((byte) 0);
+        // and payload
+        raw.put((byte) 8).put((byte) 0).put("abcdefg".getBytes(ZMQ.CHARSET));
+        assertProtocolVersion(0, raw, "abcdefg");
+    }
+
+    @Test(timeout = 2000)
+    public void testProtocolVersion0long() throws IOException, InterruptedException
+    {
+        ByteBuffer raw = ByteBuffer.allocate(35)
+                // send unversioned identity message
+                // large message indicator
+                .put((byte) 0xff)
+                // size
+                .put(new byte[7]).put((byte) 9)
+                // flags
+                .put((byte) 0)
+                // identity
+                .put("identity".getBytes(ZMQ.CHARSET));
+
+        // and payload
+        raw.put((byte) 0xff).put(new byte[7]).put((byte) 8).put((byte) 0).put("abcdefg".getBytes(ZMQ.CHARSET));
+        assertProtocolVersion(0, raw, "abcdefg");
+    }
+
+    private byte[] assertProtocolVersion(int version, ByteBuffer raw, String payload)
+            throws IOException, InterruptedException
+    {
+        return assertProtocolVersion(version, Collections.singletonList(raw), payload);
+    }
+}

--- a/src/test/java/zmq/io/V1ProtocolTest.java
+++ b/src/test/java/zmq/io/V1ProtocolTest.java
@@ -1,0 +1,42 @@
+package zmq.io;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import org.junit.Test;
+
+import zmq.ZMQ;
+
+public class V1ProtocolTest extends AbstractProtocolVersion
+{
+    @Test(timeout = 2000)
+    public void testProtocolVersion1short() throws IOException, InterruptedException
+    {
+        List<ByteBuffer> raws = raws(0);
+
+        raws.add(identity());
+
+        // payload
+        ByteBuffer raw = ByteBuffer.allocate(9);
+        raw.put((byte) 8).put((byte) 0).put("abcdefg".getBytes(ZMQ.CHARSET));
+        raws.add(raw);
+
+        assertProtocolVersion(1, raws, "abcdefg");
+    }
+
+    @Test(timeout = 2000)
+    public void testProtocolVersion1long() throws IOException, InterruptedException
+    {
+        List<ByteBuffer> raws = raws(0);
+
+        raws.add(identity());
+
+        // payload
+        ByteBuffer raw = ByteBuffer.allocate(17);
+        raw.put((byte) 0xff).put(new byte[7]).put((byte) 8).put((byte) 0).put("abcdefg".getBytes(ZMQ.CHARSET));
+        raws.add(raw);
+
+        assertProtocolVersion(1, raws, "abcdefg");
+    }
+}

--- a/src/test/java/zmq/io/V2ProtocolTest.java
+++ b/src/test/java/zmq/io/V2ProtocolTest.java
@@ -1,0 +1,57 @@
+package zmq.io;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import org.junit.Test;
+
+import zmq.ZMQ;
+import zmq.util.Wire;
+
+public class V2ProtocolTest extends AbstractProtocolVersion
+{
+    @Override
+    protected ByteBuffer identity()
+    {
+        return ByteBuffer.allocate(2)
+                // flag
+                .put((byte) 0)
+                // length
+                .put((byte) 0);
+    }
+
+    @Test(timeout = 2000)
+    public void testProtocolVersion2short() throws IOException, InterruptedException
+    {
+        List<ByteBuffer> raws = raws(1);
+        raws.add(identity());
+
+        ByteBuffer raw = ByteBuffer.allocate(9)
+                // flag
+                .put((byte) 0)
+                // length
+                .put((byte) 7)
+                // payload
+                .put("abcdefg".getBytes(ZMQ.CHARSET));
+        raws.add(raw);
+        assertProtocolVersion(2, raws, "abcdefg");
+    }
+
+    @Test(timeout = 2000)
+    public void testProtocolVersion2long() throws IOException, InterruptedException
+    {
+        List<ByteBuffer> raws = raws(1);
+        raws.add(identity());
+
+        ByteBuffer raw = ByteBuffer.allocate(17);
+        // flag
+        raw.put((byte) 2);
+        // length
+        Wire.putUInt64(raw, 8);
+        // payload
+        raw.put("abcdefgh".getBytes(ZMQ.CHARSET));
+        raws.add(raw);
+        assertProtocolVersion(2, raws, "abcdefgh");
+    }
+}


### PR DESCRIPTION
Fix #497.

I added some tests (obviously) for protocols except V3 (which is now used in every other test). May you make a review of the tests messages format?