### PR TITLE
Avoid using system time to measure elapsed time

### DIFF
--- a/src/main/java/zmq/ZMQ.java
+++ b/src/main/java/zmq/ZMQ.java
@@ -695,7 +695,7 @@ public class ZMQ
                 waitMillis = -1L;
             }
             else {
-                waitMillis = TimeUnit.MICROSECONDS.toMillis(end - now);
+                waitMillis = TimeUnit.NANOSECONDS.toMillis(end - now);
                 if (waitMillis == 0) {
                     waitMillis = 1L;
                 }
@@ -754,8 +754,8 @@ public class ZMQ
             //  first pass have taken negligible time). We also compute the time
             //  when the polling should time out.
             if (firstPass) {
-                now = Clock.nowUS();
-                end = now + TimeUnit.MILLISECONDS.toMicros(timeout);
+                now = Clock.nowNS();
+                end = now + TimeUnit.MILLISECONDS.toNanos(timeout);
                 if (now == end) {
                     break;
                 }
@@ -764,7 +764,7 @@ public class ZMQ
             }
 
             //  Find out whether timeout have expired.
-            now = Clock.nowUS();
+            now = Clock.nowNS();
             if (now >= end) {
                 break;
             }

--- a/src/main/java/zmq/ZMQ.java
+++ b/src/main/java/zmq/ZMQ.java
@@ -695,7 +695,10 @@ public class ZMQ
                 waitMillis = -1L;
             }
             else {
-                waitMillis = end - now;
+                waitMillis = TimeUnit.MICROSECONDS.toMillis(end - now);
+                if (waitMillis == 0) {
+                    waitMillis = 1L;
+                }
             }
 
             //  Wait for events.
@@ -751,8 +754,8 @@ public class ZMQ
             //  first pass have taken negligible time). We also compute the time
             //  when the polling should time out.
             if (firstPass) {
-                now = Clock.nowMS();
-                end = now + timeout;
+                now = Clock.nowUS();
+                end = now + TimeUnit.MILLISECONDS.toMicros(timeout);
                 if (now == end) {
                     break;
                 }
@@ -761,7 +764,7 @@ public class ZMQ
             }
 
             //  Find out whether timeout have expired.
-            now = Clock.nowMS();
+            now = Clock.nowUS();
             if (now >= end) {
                 break;
             }

--- a/src/main/java/zmq/util/Clock.java
+++ b/src/main/java/zmq/util/Clock.java
@@ -14,10 +14,20 @@ public class Clock
     {
     }
 
-    //  High precision timestamp.
+    /**
+     * High precision timestamp in microseconds.
+     */
     public static long nowUS()
     {
         return TimeUnit.MICROSECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
+    }
+
+    /**
+     * High precision timestamp in nanoseconds.
+     */
+    public static long nowNS()
+    {
+        return System.nanoTime();
     }
 
     //  Low precision timestamp. In tight loops generating it can be


### PR DESCRIPTION
I ran into a situation today where Poller#poll was blocked for a long time even though a timeout value of 1 second had been passed to poll. I attached a debugger and captured the state displayed in the attached screenshot. As you can see `waitMillis` has a value of just over an hour even though `timeout` is set to 1000.

This can happen because `poll` uses `currentTimeMillis` values to measure elapsed time without taking into account that the system clock may be changed in the meantime.

To avoid this I've updated `poll` to use `nanoTime` instead. This way elapsed time is measured correctly regardless of system time changes.

![screen shot 2017-12-20 at 12 08 12](https://user-images.githubusercontent.com/225326/34209644-4dc6f0a2-e593-11e7-8796-fe8207acb98f.png)
