### PR TITLE
Bugfix: prevent corrupted buffer of encoder base on zero-copy encode

### DIFF
--- a/src/main/java/zmq/io/StreamEngine.java
+++ b/src/main/java/zmq/io/StreamEngine.java
@@ -577,6 +577,7 @@ public class StreamEngine implements IEngine, IPollEvents
                 buf.flip();
             }
         }
+        assert (outsize == outpos.get().remaining());
 
         //  If there are any data to write in write buffer, write as much as
         //  possible to the socket. Note that amount of data to write can be

--- a/src/main/java/zmq/io/coder/EncoderBase.java
+++ b/src/main/java/zmq/io/coder/EncoderBase.java
@@ -92,7 +92,13 @@ public abstract class EncoderBase implements IEncoder
             //  As a consequence, large messages being sent won't block
             //  other engines running in the same I/O thread for excessive
             //  amounts of time.
-            if (pos == 0 && data.get() == null && toWrite >= bufferSize) {
+            //  Note: Since writeBuf must not be flipped before sending,
+            //  but StreamEngine flips the data buffer if its size is less
+            //  or equals OUT_BATCH_SIZE we must allow zero-copy encode
+            //  only if toWrite is greater (and not equals) OUT_BATCH_SIZE.
+            //  Since StreamEngine initializes bufferSize with
+            //  OUT_BATCH_SIZE, it follows toWrite > bufferSize.
+            if (pos == 0 && data.get() == null && toWrite > bufferSize) {
                 writeBuf.limit(writeBuf.capacity());
                 data.set(writeBuf);
                 pos = toWrite;


### PR DESCRIPTION
This PR is an attempt to fix a problem of potentially corrupted byte buffers that can cause io threads to loop on the same out event infinitely and, consequently, to block/deadlock applications. For details, see issue https://github.com/zeromq/jeromq/issues/520 