### PR TITLE
Fix #534: If timer is cancelled, it should not be executed again without being readded

### DIFF
--- a/src/main/java/zmq/poll/PollerBase.java
+++ b/src/main/java/zmq/poll/PollerBase.java
@@ -167,11 +167,11 @@ abstract class PollerBase implements Runnable
                 return key - current;
             }
 
-            //  Trigger the timer.
-            timerInfo.sink.timerEvent(timerInfo.id);
-
             //  Remove it from the list of active timers.
             timers.remove(key, timerInfo);
+
+            //  Trigger the timer.
+            timerInfo.sink.timerEvent(timerInfo.id);
         }
 
         if (changed) {

--- a/src/main/java/zmq/util/MultiMap.java
+++ b/src/main/java/zmq/util/MultiMap.java
@@ -93,11 +93,15 @@ public final class MultiMap<K extends Comparable<? super K>, V>
     {
         K old = inverse.get(value);
         if (old != null) {
-            removeData(old, value);
+            boolean rc = removeData(old, value);
+            assert rc;
         }
         boolean inserted = getValues(key).add(value);
         if (inserted) {
             inverse.put(value, key);
+        }
+        else {
+            inverse.remove(value);
         }
         return inserted;
     }

--- a/src/test/java/zmq/socket/pair/TestPairIpc.java
+++ b/src/test/java/zmq/socket/pair/TestPairIpc.java
@@ -25,15 +25,15 @@ public class TestPairIpc
         SocketBase pairBind = ZMQ.socket(ctx, ZMQ.ZMQ_PAIR);
         assertThat(pairBind, notNullValue());
 
-        UUID random = UUID.randomUUID();
-
-        boolean brc = ZMQ.bind(pairBind, "ipc:///tmp/tester/" + random.toString());
-        assertThat(brc, is(true));
+        UUID random;
+        do {
+            random = UUID.randomUUID();
+        } while (!ZMQ.bind(pairBind, "ipc:///tmp/tester/" + random.toString()));
 
         SocketBase pairConnect = ZMQ.socket(ctx, ZMQ.ZMQ_PAIR);
         assertThat(pairConnect, notNullValue());
 
-        brc = ZMQ.connect(pairConnect, "ipc:///tmp/tester/" + random.toString());
+        boolean brc = ZMQ.connect(pairConnect, "ipc:///tmp/tester/" + random.toString());
         assertThat(brc, is(true));
 
         Helper.bounce(pairBind, pairConnect);


### PR DESCRIPTION
Please have a look at the tests to assess if the described behaviour is as expected.