### PR TITLE
Update zguide examples to use ZContext in a try-with-resources block

### DIFF
--- a/scripts/run-example
+++ b/scripts/run-example
@@ -12,4 +12,4 @@ if [[ ! -f $filename ]]; then
   exit 1
 fi
 
-mvn exec:java -Dexec.mainClass=guide.$example -Dexec.classpathScope=test
+mvn test-compile exec:java -Dexec.mainClass=guide.$example -Dexec.classpathScope=test

--- a/src/test/java/guide/bstarcli.java
+++ b/src/test/java/guide/bstarcli.java
@@ -14,66 +14,68 @@ public class bstarcli
 
     public static void main(String[] argv) throws Exception
     {
-        ZContext ctx = new ZContext();
-        String[] server = { "tcp://localhost:5001", "tcp://localhost:5002" };
-        int serverNbr = 0;
+        try (ZContext ctx = new ZContext()) {
+            String[] server = { "tcp://localhost:5001",
+                                "tcp://localhost:5002" };
+            int serverNbr = 0;
 
-        System.out.printf("I: connecting to server at %s...\n", server[serverNbr]);
-        Socket client = ctx.createSocket(ZMQ.REQ);
-        client.connect(server[serverNbr]);
+            System.out.printf("I: connecting to server at %s...\n",
+                              server[serverNbr]);
 
-        Poller poller = ctx.createPoller(1);
-        poller.register(client, ZMQ.Poller.POLLIN);
+            Socket client = ctx.createSocket(ZMQ.REQ);
+            client.connect(server[serverNbr]);
 
-        int sequence = 0;
-        while (!Thread.currentThread().isInterrupted()) {
-            //  We send a request, then we work to get a reply
-            String request = String.format("%d", ++sequence);
-            client.send(request);
+            Poller poller = ctx.createPoller(1);
+            poller.register(client, ZMQ.Poller.POLLIN);
 
-            boolean expectReply = true;
-            while (expectReply) {
-                //  Poll socket for a reply, with timeout
-                int rc = poller.poll(REQUEST_TIMEOUT);
-                if (rc == -1)
-                    break; //  Interrupted
+            int sequence = 0;
+            while (!Thread.currentThread().isInterrupted()) {
+                //  We send a request, then we work to get a reply
+                String request = String.format("%d", ++sequence);
+                client.send(request);
 
-                //  .split main body of client
-                //  We use a Lazy Pirate strategy in the client. If there's no
-                //  reply within our timeout, we close the socket and try again.
-                //  In Binary Star, it's the client vote that decides which
-                //  server is primary; the client must therefore try to connect
-                //  to each server in turn:
+                boolean expectReply = true;
+                while (expectReply) {
+                    //  Poll socket for a reply, with timeout
+                    int rc = poller.poll(REQUEST_TIMEOUT);
+                    if (rc == -1)
+                        break; //  Interrupted
 
-                if (poller.pollin(0)) {
-                    //  We got a reply from the server, must match getSequence
-                    String reply = client.recvStr();
-                    if (Integer.parseInt(reply) == sequence) {
-                        System.out.printf("I: server replied OK (%s)\n", reply);
-                        expectReply = false;
-                        Thread.sleep(1000); //  One request per second
+                    //  .split main body of client
+                    //  We use a Lazy Pirate strategy in the client. If there's
+                    //  no reply within our timeout, we close the socket and try
+                    //  again.  In Binary Star, it's the client vote that
+                    //  decides which server is primary; the client must
+                    //  therefore try to connect to each server in turn:
+
+                    if (poller.pollin(0)) {
+                        //  We got a reply from the server, must match getSequence
+                        String reply = client.recvStr();
+                        if (Integer.parseInt(reply) == sequence) {
+                            System.out.printf("I: server replied OK (%s)\n", reply);
+                            expectReply = false;
+                            Thread.sleep(1000); //  One request per second
+                        }
+                        else System.out.printf("E: bad reply from server: %s\n", reply);
                     }
-                    else System.out.printf("E: bad reply from server: %s\n", reply);
-                }
-                else {
-                    System.out.printf("W: no response from server, failing over\n");
+                    else {
+                        System.out.printf("W: no response from server, failing over\n");
 
-                    //  Old socket is confused; close it and open a new one
-                    poller.unregister(client);
-                    ctx.destroySocket(client);
-                    serverNbr = (serverNbr + 1) % 2;
-                    Thread.sleep(SETTLE_DELAY);
-                    System.out.printf("I: connecting to server at %s...\n", server[serverNbr]);
-                    client = ctx.createSocket(ZMQ.REQ);
-                    client.connect(server[serverNbr]);
-                    poller.register(client, ZMQ.Poller.POLLIN);
+                        //  Old socket is confused; close it and open a new one
+                        poller.unregister(client);
+                        ctx.destroySocket(client);
+                        serverNbr = (serverNbr + 1) % 2;
+                        Thread.sleep(SETTLE_DELAY);
+                        System.out.printf("I: connecting to server at %s...\n", server[serverNbr]);
+                        client = ctx.createSocket(ZMQ.REQ);
+                        client.connect(server[serverNbr]);
+                        poller.register(client, ZMQ.Poller.POLLIN);
 
-                    //  Send request again, on new socket
-                    client.send(request);
+                        //  Send request again, on new socket
+                        client.send(request);
+                    }
                 }
             }
         }
-        ctx.close();
-
     }
 }

--- a/src/test/java/guide/clonecli1.java
+++ b/src/test/java/guide/clonecli1.java
@@ -20,21 +20,21 @@ public class clonecli1
 
     public void run()
     {
-        ZContext ctx = new ZContext();
-        Socket subscriber = ctx.createSocket(ZMQ.SUB);
-        subscriber.connect("tcp://localhost:5556");
-        subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
+        try (ZContext ctx = new ZContext()) {
+            Socket subscriber = ctx.createSocket(ZMQ.SUB);
+            subscriber.connect("tcp://localhost:5556");
+            subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
 
-        while (true) {
-            kvsimple kvMsg = kvsimple.recv(subscriber);
-            if (kvMsg == null)
-                break;
+            while (true) {
+                kvsimple kvMsg = kvsimple.recv(subscriber);
+                if (kvMsg == null)
+                    break;
 
-            clonecli1.kvMap.put(kvMsg.getKey(), kvMsg);
-            System.out.println("receiving " + kvMsg);
-            sequence.incrementAndGet();
+                clonecli1.kvMap.put(kvMsg.getKey(), kvMsg);
+                System.out.println("receiving " + kvMsg);
+                sequence.incrementAndGet();
+            }
         }
-        ctx.close();
     }
 
     public static void main(String[] args)

--- a/src/test/java/guide/clonecli3.java
+++ b/src/test/java/guide/clonecli3.java
@@ -21,71 +21,75 @@ public class clonecli3
 
     public void run()
     {
-        ZContext ctx = new ZContext();
-        Socket snapshot = ctx.createSocket(ZMQ.DEALER);
-        snapshot.connect("tcp://localhost:5556");
+        try (ZContext ctx = new ZContext()) {
+            Socket snapshot = ctx.createSocket(ZMQ.DEALER);
+            snapshot.connect("tcp://localhost:5556");
 
-        Socket subscriber = ctx.createSocket(ZMQ.SUB);
-        subscriber.connect("tcp://localhost:5557");
-        subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
+            Socket subscriber = ctx.createSocket(ZMQ.SUB);
+            subscriber.connect("tcp://localhost:5557");
+            subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
 
-        Socket push = ctx.createSocket(ZMQ.PUSH);
-        push.connect("tcp://localhost:5558");
+            Socket push = ctx.createSocket(ZMQ.PUSH);
+            push.connect("tcp://localhost:5558");
 
-        // get state snapshot
-        long sequence = 0;
-        snapshot.send("ICANHAZ?".getBytes(ZMQ.CHARSET), 0);
-        while (true) {
-            kvsimple kvMsg = kvsimple.recv(snapshot);
-            if (kvMsg == null)
-                break; //  Interrupted
-
-            sequence = kvMsg.getSequence();
-            if ("KTHXBAI".equalsIgnoreCase(kvMsg.getKey())) {
-                System.out.println("Received snapshot = " + kvMsg.getSequence());
-                break; // done
-            }
-
-            System.out.println("receiving " + kvMsg.getSequence());
-            clonecli3.kvMap.put(kvMsg.getKey(), kvMsg);
-        }
-
-        Poller poller = ctx.createPoller(1);
-        poller.register(subscriber);
-
-        Random random = new Random();
-
-        // now apply pending updates, discard out-of-getSequence messages
-        long alarm = System.currentTimeMillis() + 5000;
-        while (true) {
-            int rc = poller.poll(Math.max(0, alarm - System.currentTimeMillis()));
-            if (rc == -1)
-                break; //  Context has been shut down
-
-            if (poller.pollin(0)) {
-                kvsimple kvMsg = kvsimple.recv(subscriber);
+            // get state snapshot
+            long sequence = 0;
+            snapshot.send("ICANHAZ?".getBytes(ZMQ.CHARSET), 0);
+            while (true) {
+                kvsimple kvMsg = kvsimple.recv(snapshot);
                 if (kvMsg == null)
                     break; //  Interrupted
-                if (kvMsg.getSequence() > sequence) {
-                    sequence = kvMsg.getSequence();
-                    System.out.println("receiving " + sequence);
-                    clonecli3.kvMap.put(kvMsg.getKey(), kvMsg);
+
+                sequence = kvMsg.getSequence();
+                if ("KTHXBAI".equalsIgnoreCase(kvMsg.getKey())) {
+                    System.out.println(
+                        "Received snapshot = " + kvMsg.getSequence()
+                    );
+                    break; // done
+                }
+
+                System.out.println("receiving " + kvMsg.getSequence());
+                clonecli3.kvMap.put(kvMsg.getKey(), kvMsg);
+            }
+
+            Poller poller = ctx.createPoller(1);
+            poller.register(subscriber);
+
+            Random random = new Random();
+
+            // now apply pending updates, discard out-of-getSequence messages
+            long alarm = System.currentTimeMillis() + 5000;
+            while (true) {
+                int rc = poller.poll(
+                    Math.max(0, alarm - System.currentTimeMillis())
+                );
+                if (rc == -1)
+                    break; //  Context has been shut down
+
+                if (poller.pollin(0)) {
+                    kvsimple kvMsg = kvsimple.recv(subscriber);
+                    if (kvMsg == null)
+                        break; //  Interrupted
+                    if (kvMsg.getSequence() > sequence) {
+                        sequence = kvMsg.getSequence();
+                        System.out.println("receiving " + sequence);
+                        clonecli3.kvMap.put(kvMsg.getKey(), kvMsg);
+                    }
+                }
+
+                if (System.currentTimeMillis() >= alarm) {
+                    int key = random.nextInt(10000);
+                    int body = random.nextInt(1000000);
+
+                    ByteBuffer b = ByteBuffer.allocate(4);
+                    b.asIntBuffer().put(body);
+
+                    kvsimple kvUpdateMsg = new kvsimple(key + "", 0, b.array());
+                    kvUpdateMsg.send(push);
+                    alarm = System.currentTimeMillis() + 1000;
                 }
             }
-
-            if (System.currentTimeMillis() >= alarm) {
-                int key = random.nextInt(10000);
-                int body = random.nextInt(1000000);
-
-                ByteBuffer b = ByteBuffer.allocate(4);
-                b.asIntBuffer().put(body);
-
-                kvsimple kvUpdateMsg = new kvsimple(key + "", 0, b.array());
-                kvUpdateMsg.send(push);
-                alarm = System.currentTimeMillis() + 1000;
-            }
         }
-        ctx.close();
     }
 
     public static void main(String[] args)

--- a/src/test/java/guide/clonecli4.java
+++ b/src/test/java/guide/clonecli4.java
@@ -24,73 +24,79 @@ public class clonecli4
 
     public void run()
     {
-        ZContext ctx = new ZContext();
-        Socket snapshot = ctx.createSocket(ZMQ.DEALER);
-        snapshot.connect("tcp://localhost:5556");
+        try (ZContext ctx = new ZContext()) {
+            Socket snapshot = ctx.createSocket(ZMQ.DEALER);
+            snapshot.connect("tcp://localhost:5556");
 
-        Socket subscriber = ctx.createSocket(ZMQ.SUB);
-        subscriber.connect("tcp://localhost:5557");
-        subscriber.subscribe(SUBTREE.getBytes(ZMQ.CHARSET));
+            Socket subscriber = ctx.createSocket(ZMQ.SUB);
+            subscriber.connect("tcp://localhost:5557");
+            subscriber.subscribe(SUBTREE.getBytes(ZMQ.CHARSET));
 
-        Socket push = ctx.createSocket(ZMQ.PUSH);
-        push.connect("tcp://localhost:5558");
+            Socket push = ctx.createSocket(ZMQ.PUSH);
+            push.connect("tcp://localhost:5558");
 
-        // get state snapshot
-        snapshot.sendMore("ICANHAZ?");
-        snapshot.send(SUBTREE);
-        long sequence = 0;
+            // get state snapshot
+            snapshot.sendMore("ICANHAZ?");
+            snapshot.send(SUBTREE);
+            long sequence = 0;
 
-        while (true) {
-            kvsimple kvMsg = kvsimple.recv(snapshot);
-            if (kvMsg == null)
-                break; //  Interrupted
-
-            sequence = kvMsg.getSequence();
-            if ("KTHXBAI".equalsIgnoreCase(kvMsg.getKey())) {
-                System.out.println("Received snapshot = " + kvMsg.getSequence());
-                break; // done
-            }
-
-            System.out.println("receiving " + kvMsg.getSequence());
-            clonecli4.kvMap.put(kvMsg.getKey(), kvMsg);
-        }
-
-        Poller poller = ctx.createPoller(1);
-        poller.register(subscriber);
-
-        Random random = new Random();
-
-        // now apply pending updates, discard out-of-getSequence messages
-        long alarm = System.currentTimeMillis() + 5000;
-        while (true) {
-            int rc = poller.poll(Math.max(0, alarm - System.currentTimeMillis()));
-            if (rc == -1)
-                break; //  Context has been shut down
-
-            if (poller.pollin(0)) {
-                kvsimple kvMsg = kvsimple.recv(subscriber);
+            while (true) {
+                kvsimple kvMsg = kvsimple.recv(snapshot);
                 if (kvMsg == null)
                     break; //  Interrupted
-                if (kvMsg.getSequence() > sequence) {
-                    sequence = kvMsg.getSequence();
-                    System.out.println("receiving " + sequence);
-                    clonecli4.kvMap.put(kvMsg.getKey(), kvMsg);
+
+                sequence = kvMsg.getSequence();
+                if ("KTHXBAI".equalsIgnoreCase(kvMsg.getKey())) {
+                    System.out.println(
+                        "Received snapshot = " + kvMsg.getSequence()
+                    );
+                    break; // done
+                }
+
+                System.out.println("receiving " + kvMsg.getSequence());
+                clonecli4.kvMap.put(kvMsg.getKey(), kvMsg);
+            }
+
+            Poller poller = ctx.createPoller(1);
+            poller.register(subscriber);
+
+            Random random = new Random();
+
+            // now apply pending updates, discard out-of-getSequence messages
+            long alarm = System.currentTimeMillis() + 5000;
+            while (true) {
+                int rc = poller.poll(
+                    Math.max(0, alarm - System.currentTimeMillis())
+                );
+                if (rc == -1)
+                    break; //  Context has been shut down
+
+                if (poller.pollin(0)) {
+                    kvsimple kvMsg = kvsimple.recv(subscriber);
+                    if (kvMsg == null)
+                        break; //  Interrupted
+                    if (kvMsg.getSequence() > sequence) {
+                        sequence = kvMsg.getSequence();
+                        System.out.println("receiving " + sequence);
+                        clonecli4.kvMap.put(kvMsg.getKey(), kvMsg);
+                    }
+                }
+
+                if (System.currentTimeMillis() >= alarm) {
+                    String key = String.format(
+                        "%s%d", SUBTREE, random.nextInt(10000)
+                    );
+                    int body = random.nextInt(1000000);
+
+                    ByteBuffer b = ByteBuffer.allocate(4);
+                    b.asIntBuffer().put(body);
+
+                    kvsimple kvUpdateMsg = new kvsimple(key, 0, b.array());
+                    kvUpdateMsg.send(push);
+                    alarm = System.currentTimeMillis() + 1000;
                 }
             }
-
-            if (System.currentTimeMillis() >= alarm) {
-                String key = String.format("%s%d", SUBTREE, random.nextInt(10000));
-                int body = random.nextInt(1000000);
-
-                ByteBuffer b = ByteBuffer.allocate(4);
-                b.asIntBuffer().put(body);
-
-                kvsimple kvUpdateMsg = new kvsimple(key, 0, b.array());
-                kvUpdateMsg.send(push);
-                alarm = System.currentTimeMillis() + 1000;
-            }
         }
-        ctx.close();
     }
 
     public static void main(String[] args)

--- a/src/test/java/guide/clonecli5.java
+++ b/src/test/java/guide/clonecli5.java
@@ -21,77 +21,81 @@ public class clonecli5
 
     public void run()
     {
-        ZContext ctx = new ZContext();
-        Socket snapshot = ctx.createSocket(ZMQ.DEALER);
-        snapshot.connect("tcp://localhost:5556");
+        try (ZContext ctx = new ZContext()) {
+            Socket snapshot = ctx.createSocket(ZMQ.DEALER);
+            snapshot.connect("tcp://localhost:5556");
 
-        Socket subscriber = ctx.createSocket(ZMQ.SUB);
-        subscriber.connect("tcp://localhost:5557");
-        subscriber.subscribe(SUBTREE.getBytes(ZMQ.CHARSET));
+            Socket subscriber = ctx.createSocket(ZMQ.SUB);
+            subscriber.connect("tcp://localhost:5557");
+            subscriber.subscribe(SUBTREE.getBytes(ZMQ.CHARSET));
 
-        Socket publisher = ctx.createSocket(ZMQ.PUSH);
-        publisher.connect("tcp://localhost:5558");
+            Socket publisher = ctx.createSocket(ZMQ.PUSH);
+            publisher.connect("tcp://localhost:5558");
 
-        Map<String, kvmsg> kvMap = new HashMap<String, kvmsg>();
+            Map<String, kvmsg> kvMap = new HashMap<String, kvmsg>();
 
-        // get state snapshot
-        snapshot.sendMore("ICANHAZ?");
-        snapshot.send(SUBTREE);
-        long sequence = 0;
+            // get state snapshot
+            snapshot.sendMore("ICANHAZ?");
+            snapshot.send(SUBTREE);
+            long sequence = 0;
 
-        while (true) {
-            kvmsg kvMsg = kvmsg.recv(snapshot);
-            if (kvMsg == null)
-                break; //  Interrupted
-
-            sequence = kvMsg.getSequence();
-            if ("KTHXBAI".equalsIgnoreCase(kvMsg.getKey())) {
-                System.out.println("Received snapshot = " + kvMsg.getSequence());
-                kvMsg.destroy();
-                break; // done
-            }
-
-            System.out.println("receiving " + kvMsg.getSequence());
-            kvMsg.store(kvMap);
-        }
-
-        Poller poller = ctx.createPoller(1);
-        poller.register(subscriber);
-
-        Random random = new Random();
-
-        // now apply pending updates, discard out-of-getSequence messages
-        long alarm = System.currentTimeMillis() + 5000;
-        while (true) {
-            int rc = poller.poll(Math.max(0, alarm - System.currentTimeMillis()));
-            if (rc == -1)
-                break; //  Context has been shut down
-
-            if (poller.pollin(0)) {
-                kvmsg kvMsg = kvmsg.recv(subscriber);
+            while (true) {
+                kvmsg kvMsg = kvmsg.recv(snapshot);
                 if (kvMsg == null)
                     break; //  Interrupted
 
-                if (kvMsg.getSequence() > sequence) {
-                    sequence = kvMsg.getSequence();
-                    System.out.println("receiving " + sequence);
-                    kvMsg.store(kvMap);
+                sequence = kvMsg.getSequence();
+                if ("KTHXBAI".equalsIgnoreCase(kvMsg.getKey())) {
+                    System.out.println(
+                        "Received snapshot = " + kvMsg.getSequence()
+                    );
+                    kvMsg.destroy();
+                    break; // done
                 }
-                else kvMsg.destroy();
+
+                System.out.println("receiving " + kvMsg.getSequence());
+                kvMsg.store(kvMap);
             }
 
-            if (System.currentTimeMillis() >= alarm) {
-                kvmsg kvMsg = new kvmsg(0);
-                kvMsg.fmtKey("%s%d", SUBTREE, random.nextInt(10000));
-                kvMsg.fmtBody("%d", random.nextInt(1000000));
-                kvMsg.setProp("ttl", "%d", random.nextInt(30));
-                kvMsg.send(publisher);
-                kvMsg.destroy();
+            Poller poller = ctx.createPoller(1);
+            poller.register(subscriber);
 
-                alarm = System.currentTimeMillis() + 1000;
+            Random random = new Random();
+
+            // now apply pending updates, discard out-of-getSequence messages
+            long alarm = System.currentTimeMillis() + 5000;
+            while (true) {
+                int rc = poller.poll(
+                    Math.max(0, alarm - System.currentTimeMillis())
+                );
+                if (rc == -1)
+                    break; //  Context has been shut down
+
+                if (poller.pollin(0)) {
+                    kvmsg kvMsg = kvmsg.recv(subscriber);
+                    if (kvMsg == null)
+                        break; //  Interrupted
+
+                    if (kvMsg.getSequence() > sequence) {
+                        sequence = kvMsg.getSequence();
+                        System.out.println("receiving " + sequence);
+                        kvMsg.store(kvMap);
+                    }
+                    else kvMsg.destroy();
+                }
+
+                if (System.currentTimeMillis() >= alarm) {
+                    kvmsg kvMsg = new kvmsg(0);
+                    kvMsg.fmtKey("%s%d", SUBTREE, random.nextInt(10000));
+                    kvMsg.fmtBody("%d", random.nextInt(1000000));
+                    kvMsg.setProp("ttl", "%d", random.nextInt(30));
+                    kvMsg.send(publisher);
+                    kvMsg.destroy();
+
+                    alarm = System.currentTimeMillis() + 1000;
+                }
             }
         }
-        ctx.close();
     }
 
     public static void main(String[] args)

--- a/src/test/java/guide/clonesrv1.java
+++ b/src/test/java/guide/clonesrv1.java
@@ -5,8 +5,8 @@ import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.zeromq.ZMQ;
-import org.zeromq.ZMQ.Context;
 import org.zeromq.ZMQ.Socket;
+import org.zeromq.ZContext;
 
 /**
  * 
@@ -20,31 +20,33 @@ public class clonesrv1
 
     public void run()
     {
-        Context ctx = ZMQ.context(1);
-        Socket publisher = ctx.socket(ZMQ.PUB);
-        publisher.bind("tcp://*:5556");
+        try (ZContext ctx = new ZContext()) {
+            Socket publisher = ctx.createSocket(ZMQ.PUB);
+            publisher.bind("tcp://*:5556");
 
-        try {
-            Thread.sleep(200);
-        }
-        catch (InterruptedException e) {
-            e.printStackTrace();
-        }
+            try {
+                Thread.sleep(200);
+            }
+            catch (InterruptedException e) {
+                e.printStackTrace();
+            }
 
-        Random random = new Random();
+            Random random = new Random();
 
-        while (true) {
-            long currentSequenceNumber = sequence.incrementAndGet();
-            int key = random.nextInt(10000);
-            int body = random.nextInt(1000000);
+            while (true) {
+                long currentSequenceNumber = sequence.incrementAndGet();
+                int key = random.nextInt(10000);
+                int body = random.nextInt(1000000);
 
-            ByteBuffer b = ByteBuffer.allocate(4);
-            b.asIntBuffer().put(body);
+                ByteBuffer b = ByteBuffer.allocate(4);
+                b.asIntBuffer().put(body);
 
-            kvsimple kvMsg = new kvsimple(key + "", currentSequenceNumber, b.array());
-            kvMsg.send(publisher);
-            System.out.println("sending " + kvMsg);
-
+                kvsimple kvMsg = new kvsimple(
+                    key + "", currentSequenceNumber, b.array()
+                );
+                kvMsg.send(publisher);
+                System.out.println("sending " + kvMsg);
+            }
         }
     }
 

--- a/src/test/java/guide/clonesrv3.java
+++ b/src/test/java/guide/clonesrv3.java
@@ -21,67 +21,71 @@ public class clonesrv3
 
     public void run()
     {
+        try (ZContext ctx = new ZContext()) {
+            Socket snapshot = ctx.createSocket(ZMQ.ROUTER);
+            snapshot.bind("tcp://*:5556");
 
-        ZContext ctx = new ZContext();
+            Socket publisher = ctx.createSocket(ZMQ.PUB);
+            publisher.bind("tcp://*:5557");
 
-        Socket snapshot = ctx.createSocket(ZMQ.ROUTER);
-        snapshot.bind("tcp://*:5556");
+            Socket collector = ctx.createSocket(ZMQ.PULL);
+            collector.bind("tcp://*:5558");
 
-        Socket publisher = ctx.createSocket(ZMQ.PUB);
-        publisher.bind("tcp://*:5557");
+            Poller poller = ctx.createPoller(2);
+            poller.register(collector, Poller.POLLIN);
+            poller.register(snapshot, Poller.POLLIN);
 
-        Socket collector = ctx.createSocket(ZMQ.PULL);
-        collector.bind("tcp://*:5558");
+            long sequence = 0;
+            while (!Thread.currentThread().isInterrupted()) {
+                if (poller.poll(1000) < 0)
+                    break; //  Context has been shut down
 
-        Poller poller = ctx.createPoller(2);
-        poller.register(collector, Poller.POLLIN);
-        poller.register(snapshot, Poller.POLLIN);
-
-        long sequence = 0;
-        while (!Thread.currentThread().isInterrupted()) {
-            if (poller.poll(1000) < 0)
-                break; //  Context has been shut down
-
-            // apply state updates from main thread
-            if (poller.pollin(0)) {
-                kvsimple kvMsg = kvsimple.recv(collector);
-                if (kvMsg == null) //  Interrupted
-                    break;
-                kvMsg.setSequence(++sequence);
-                kvMsg.send(publisher);
-                clonesrv3.kvMap.put(kvMsg.getKey(), kvMsg);
-                System.out.printf("I: publishing update %5d\n", sequence);
-            }
-
-            // execute state snapshot request
-            if (poller.pollin(1)) {
-                byte[] identity = snapshot.recv(0);
-                if (identity == null)
-                    break; //  Interrupted
-                String request = snapshot.recvStr();
-
-                if (!request.equals("ICANHAZ?")) {
-                    System.out.println("E: bad request, aborting");
-                    break;
+                // apply state updates from main thread
+                if (poller.pollin(0)) {
+                    kvsimple kvMsg = kvsimple.recv(collector);
+                    if (kvMsg == null) //  Interrupted
+                        break;
+                    kvMsg.setSequence(++sequence);
+                    kvMsg.send(publisher);
+                    clonesrv3.kvMap.put(kvMsg.getKey(), kvMsg);
+                    System.out.printf("I: publishing update %5d\n", sequence);
                 }
 
-                Iterator<Entry<String, kvsimple>> iter = kvMap.entrySet().iterator();
-                while (iter.hasNext()) {
-                    Entry<String, kvsimple> entry = iter.next();
-                    kvsimple msg = entry.getValue();
-                    System.out.println("Sending message " + entry.getValue().getSequence());
-                    this.sendMessage(msg, identity, snapshot);
-                }
+                // execute state snapshot request
+                if (poller.pollin(1)) {
+                    byte[] identity = snapshot.recv(0);
+                    if (identity == null)
+                        break; //  Interrupted
+                    String request = snapshot.recvStr();
 
-                // now send end message with getSequence number
-                System.out.println("Sending state snapshot = " + sequence);
-                snapshot.send(identity, ZMQ.SNDMORE);
-                kvsimple message = new kvsimple("KTHXBAI", sequence, ZMQ.SUBSCRIPTION_ALL);
-                message.send(snapshot);
+                    if (!request.equals("ICANHAZ?")) {
+                        System.out.println("E: bad request, aborting");
+                        break;
+                    }
+
+                    Iterator<Entry<String, kvsimple>> iter = kvMap.entrySet()
+                                                                  .iterator();
+                    while (iter.hasNext()) {
+                        Entry<String, kvsimple> entry = iter.next();
+                        kvsimple msg = entry.getValue();
+                        System.out.println(
+                            "Sending message " + entry.getValue().getSequence()
+                        );
+                        this.sendMessage(msg, identity, snapshot);
+                    }
+
+                    // now send end message with getSequence number
+                    System.out.println("Sending state snapshot = " + sequence);
+                    snapshot.send(identity, ZMQ.SNDMORE);
+                    kvsimple message = new kvsimple(
+                        "KTHXBAI", sequence, ZMQ.SUBSCRIPTION_ALL
+                    );
+                    message.send(snapshot);
+                }
             }
+
+            System.out.printf(" Interrupted\n%d messages handled\n", sequence);
         }
-        System.out.printf(" Interrupted\n%d messages handled\n", sequence);
-        ctx.close();
     }
 
     private void sendMessage(kvsimple msg, byte[] identity, Socket snapshot)

--- a/src/test/java/guide/clonesrv4.java
+++ b/src/test/java/guide/clonesrv4.java
@@ -19,72 +19,76 @@ public class clonesrv4
 
     public void run()
     {
+        try (ZContext ctx = new ZContext()) {
+            Socket snapshot = ctx.createSocket(ZMQ.ROUTER);
+            snapshot.bind("tcp://*:5556");
 
-        ZContext ctx = new ZContext();
+            Socket publisher = ctx.createSocket(ZMQ.PUB);
+            publisher.bind("tcp://*:5557");
 
-        Socket snapshot = ctx.createSocket(ZMQ.ROUTER);
-        snapshot.bind("tcp://*:5556");
+            Socket collector = ctx.createSocket(ZMQ.PULL);
+            collector.bind("tcp://*:5558");
 
-        Socket publisher = ctx.createSocket(ZMQ.PUB);
-        publisher.bind("tcp://*:5557");
+            Poller poller = ctx.createPoller(2);
+            poller.register(collector, Poller.POLLIN);
+            poller.register(snapshot, Poller.POLLIN);
 
-        Socket collector = ctx.createSocket(ZMQ.PULL);
-        collector.bind("tcp://*:5558");
+            long sequence = 0;
+            while (!Thread.currentThread().isInterrupted()) {
+                if (poller.poll(1000) < 0)
+                    break; //  Context has been shut down
 
-        Poller poller = ctx.createPoller(2);
-        poller.register(collector, Poller.POLLIN);
-        poller.register(snapshot, Poller.POLLIN);
-
-        long sequence = 0;
-        while (!Thread.currentThread().isInterrupted()) {
-            if (poller.poll(1000) < 0)
-                break; //  Context has been shut down
-
-            // apply state updates from main thread
-            if (poller.pollin(0)) {
-                kvsimple kvMsg = kvsimple.recv(collector);
-                if (kvMsg == null) //  Interrupted
-                    break;
-                kvMsg.setSequence(++sequence);
-                kvMsg.send(publisher);
-                clonesrv4.kvMap.put(kvMsg.getKey(), kvMsg);
-                System.out.printf("I: publishing update %5d\n", sequence);
-            }
-
-            // execute state snapshot request
-            if (poller.pollin(1)) {
-                byte[] identity = snapshot.recv(0);
-                if (identity == null)
-                    break; //  Interrupted
-
-                //  .until
-                //  Request is in second frame of message
-                String request = snapshot.recvStr();
-
-                if (!request.equals("ICANHAZ?")) {
-                    System.out.println("E: bad request, aborting");
-                    break;
+                // apply state updates from main thread
+                if (poller.pollin(0)) {
+                    kvsimple kvMsg = kvsimple.recv(collector);
+                    if (kvMsg == null) //  Interrupted
+                        break;
+                    kvMsg.setSequence(++sequence);
+                    kvMsg.send(publisher);
+                    clonesrv4.kvMap.put(kvMsg.getKey(), kvMsg);
+                    System.out.printf("I: publishing update %5d\n", sequence);
                 }
 
-                String subtree = snapshot.recvStr();
+                // execute state snapshot request
+                if (poller.pollin(1)) {
+                    byte[] identity = snapshot.recv(0);
+                    if (identity == null)
+                        break; //  Interrupted
 
-                Iterator<Entry<String, kvsimple>> iter = kvMap.entrySet().iterator();
-                while (iter.hasNext()) {
-                    Entry<String, kvsimple> entry = iter.next();
-                    kvsimple msg = entry.getValue();
-                    System.out.println("Sending message " + entry.getValue().getSequence());
-                    this.sendMessage(msg, identity, subtree, snapshot);
+                    //  .until
+                    //  Request is in second frame of message
+                    String request = snapshot.recvStr();
+
+                    if (!request.equals("ICANHAZ?")) {
+                        System.out.println("E: bad request, aborting");
+                        break;
+                    }
+
+                    String subtree = snapshot.recvStr();
+
+                    Iterator<Entry<String, kvsimple>> iter = kvMap.entrySet()
+                                                                  .iterator();
+                    while (iter.hasNext()) {
+                        Entry<String, kvsimple> entry = iter.next();
+                        kvsimple msg = entry.getValue();
+                        System.out.println(
+                            "Sending message " + entry.getValue().getSequence()
+                        );
+                        this.sendMessage(msg, identity, subtree, snapshot);
+                    }
+
+                    // now send end message with getSequence number
+                    System.out.println("Sending state snapshot = " + sequence);
+                    snapshot.send(identity, ZMQ.SNDMORE);
+                    kvsimple message = new kvsimple(
+                        "KTHXBAI", sequence, ZMQ.SUBSCRIPTION_ALL
+                    );
+                    message.send(snapshot);
                 }
-
-                // now send end message with getSequence number
-                System.out.println("Sending state snapshot = " + sequence);
-                snapshot.send(identity, ZMQ.SNDMORE);
-                kvsimple message = new kvsimple("KTHXBAI", sequence, ZMQ.SUBSCRIPTION_ALL);
-                message.send(snapshot);
             }
+
+            System.out.printf(" Interrupted\n%d messages handled\n", sequence);
         }
-        System.out.printf(" Interrupted\n%d messages handled\n", sequence);
-        ctx.close();
     }
 
     private void sendMessage(kvsimple msg, byte[] identity, String subtree, Socket snapshot)

--- a/src/test/java/guide/espresso.java
+++ b/src/test/java/guide/espresso.java
@@ -88,20 +88,21 @@ public class espresso
     //  itself up as a listening proxy. The listener runs as a child thread:
     public static void main(String[] argv)
     {
-        //  Start child threads
-        ZContext ctx = new ZContext();
-        ZThread.fork(ctx, new Publisher());
-        ZThread.fork(ctx, new Subscriber());
+        try (ZContext ctx = new ZContext()) {
+            //  Start child threads
+            ZThread.fork(ctx, new Publisher());
+            ZThread.fork(ctx, new Subscriber());
 
-        Socket subscriber = ctx.createSocket(ZMQ.XSUB);
-        subscriber.connect("tcp://localhost:6000");
-        Socket publisher = ctx.createSocket(ZMQ.XPUB);
-        publisher.bind("tcp://*:6001");
-        Socket listener = ZThread.fork(ctx, new Listener());
-        ZMQ.proxy(subscriber, publisher, listener);
+            Socket subscriber = ctx.createSocket(ZMQ.XSUB);
+            subscriber.connect("tcp://localhost:6000");
+            Socket publisher = ctx.createSocket(ZMQ.XPUB);
+            publisher.bind("tcp://*:6001");
+            Socket listener = ZThread.fork(ctx, new Listener());
+            ZMQ.proxy(subscriber, publisher, listener);
 
-        System.out.println(" interrupted");
-        //  Tell attached threads to exit
-        ctx.destroy();
+            System.out.println(" interrupted");
+
+            // NB: child threads exit here when the context is closed
+        }
     }
 }

--- a/src/test/java/guide/flclient1.java
+++ b/src/test/java/guide/flclient1.java
@@ -44,43 +44,44 @@ public class flclient1
 
     public static void main(String[] argv)
     {
-        ZContext ctx = new ZContext();
-        ZMsg request = new ZMsg();
-        request.add("Hello world");
-        ZMsg reply = null;
+        try (ZContext ctx = new ZContext()) {
+            ZMsg request = new ZMsg();
+            request.add("Hello world");
+            ZMsg reply = null;
 
-        int endpoints = argv.length;
-        if (endpoints == 0)
-            System.out.printf("I: syntax: flclient1 <endpoint> ...\n");
-        else if (endpoints == 1) {
-            //  For one endpoint, we retry N times
-            int retries;
-            for (retries = 0; retries < MAX_RETRIES; retries++) {
-                String endpoint = argv[0];
-                reply = tryRequest(ctx, endpoint, request);
-                if (reply != null)
-                    break; //  Successful
-                System.out.printf("W: no response from %s, retrying...\n", endpoint);
+            int endpoints = argv.length;
+            if (endpoints == 0)
+                System.out.printf("I: syntax: flclient1 <endpoint> ...\n");
+            else if (endpoints == 1) {
+                //  For one endpoint, we retry N times
+                int retries;
+                for (retries = 0; retries < MAX_RETRIES; retries++) {
+                    String endpoint = argv[0];
+                    reply = tryRequest(ctx, endpoint, request);
+                    if (reply != null)
+                        break; //  Successful
+                    System.out.printf(
+                        "W: no response from %s, retrying...\n", endpoint
+                    );
+                }
             }
-        }
-        else {
-            //  For multiple endpoints, try each at most once
-            int endpointNbr;
-            for (endpointNbr = 0; endpointNbr < endpoints; endpointNbr++) {
-                String endpoint = argv[endpointNbr];
-                reply = tryRequest(ctx, endpoint, request);
-                if (reply != null)
-                    break; //  Successful
-                System.out.printf("W: no response from %s\n", endpoint);
+            else {
+                //  For multiple endpoints, try each at most once
+                int endpointNbr;
+                for (endpointNbr = 0; endpointNbr < endpoints; endpointNbr++) {
+                    String endpoint = argv[endpointNbr];
+                    reply = tryRequest(ctx, endpoint, request);
+                    if (reply != null)
+                        break; //  Successful
+                    System.out.printf("W: no response from %s\n", endpoint);
+                }
             }
+            if (reply != null) {
+                System.out.printf("Service is running OK\n");
+                reply.destroy();
+            }
+            request.destroy();
         }
-        if (reply != null) {
-            System.out.printf("Service is running OK\n");
-            reply.destroy();
-        }
-        request.destroy();
-        ;
-        ctx.destroy();
     }
 
 }

--- a/src/test/java/guide/flserver1.java
+++ b/src/test/java/guide/flserver1.java
@@ -15,20 +15,22 @@ public class flserver1
             System.out.printf("I: syntax: flserver1 <endpoint>\n");
             System.exit(0);
         }
-        ZContext ctx = new ZContext();
-        Socket server = ctx.createSocket(ZMQ.REP);
-        server.bind(args[0]);
 
-        System.out.printf("I: echo service is ready at %s\n", args[0]);
-        while (true) {
-            ZMsg msg = ZMsg.recvMsg(server);
-            if (msg == null)
-                break; //  Interrupted
-            msg.send(server);
+        try (ZContext ctx = new ZContext()) {
+            Socket server = ctx.createSocket(ZMQ.REP);
+            server.bind(args[0]);
+
+            System.out.printf("I: echo service is ready at %s\n", args[0]);
+
+            while (true) {
+                ZMsg msg = ZMsg.recvMsg(server);
+                if (msg == null)
+                    break; //  Interrupted
+                msg.send(server);
+            }
+
+            if (Thread.currentThread().isInterrupted())
+                System.out.printf("W: interrupted\n");
         }
-        if (Thread.currentThread().isInterrupted())
-            System.out.printf("W: interrupted\n");
-
-        ctx.close();
     }
 }

--- a/src/test/java/guide/hwclient.java
+++ b/src/test/java/guide/hwclient.java
@@ -7,30 +7,30 @@ package guide;
 //
 
 import org.zeromq.ZMQ;
+import org.zeromq.ZContext;
 
 public class hwclient
 {
-
     public static void main(String[] args)
     {
-        ZMQ.Context context = ZMQ.context(1);
+        try (ZContext context = new ZContext()) {
+            //  Socket to talk to server
+            System.out.println("Connecting to hello world server");
 
-        //  Socket to talk to server
-        System.out.println("Connecting to hello world server");
+            ZMQ.Socket socket = context.createSocket(ZMQ.REQ);
+            socket.connect("tcp://localhost:5555");
 
-        ZMQ.Socket socket = context.socket(ZMQ.REQ);
-        socket.connect("tcp://localhost:5555");
+            for (int requestNbr = 0; requestNbr != 10; requestNbr++) {
+                String request = "Hello";
+                System.out.println("Sending Hello " + requestNbr);
+                socket.send(request.getBytes(ZMQ.CHARSET), 0);
 
-        for (int requestNbr = 0; requestNbr != 10; requestNbr++) {
-            String request = "Hello";
-            System.out.println("Sending Hello " + requestNbr);
-            socket.send(request.getBytes(ZMQ.CHARSET), 0);
-
-            byte[] reply = socket.recv(0);
-            System.out.println("Received " + new String(reply, ZMQ.CHARSET) + " " + requestNbr);
+                byte[] reply = socket.recv(0);
+                System.out.println(
+                    "Received " + new String(reply, ZMQ.CHARSET) + " " +
+                    requestNbr
+                );
+            }
         }
-
-        socket.close();
-        context.term();
     }
 }

--- a/src/test/java/guide/hwserver.java
+++ b/src/test/java/guide/hwserver.java
@@ -7,33 +7,30 @@ package guide;
 //
 
 import org.zeromq.ZMQ;
+import org.zeromq.ZContext;
 
 public class hwserver
 {
-
     public static void main(String[] args) throws Exception
     {
-        ZMQ.Context context = ZMQ.context(1);
+        try (ZContext context = new ZContext()) {
+            //  Socket to talk to clients
+            ZMQ.Socket socket = context.createSocket(ZMQ.REP);
+            socket.bind("tcp://*:5555");
 
-        //  Socket to talk to clients
-        ZMQ.Socket socket = context.socket(ZMQ.REP);
+            while (!Thread.currentThread().isInterrupted()) {
+                byte[] reply = socket.recv(0);
+                System.out.println(
+                    "Received " + ": [" + new String(reply, ZMQ.CHARSET) + "]"
+                );
 
-        socket.bind("tcp://*:5555");
+                //  Create a "Hello" message.
+                String request = "world";
+                // Send the message
+                socket.send(request.getBytes(ZMQ.CHARSET), 0);
 
-        while (!Thread.currentThread().isInterrupted()) {
-
-            byte[] reply = socket.recv(0);
-            System.out.println("Received " + ": [" + new String(reply, ZMQ.CHARSET) + "]");
-
-            //  Create a "Hello" message.
-            String request = "world";
-            // Send the message
-            socket.send(request.getBytes(ZMQ.CHARSET), 0);
-
-            Thread.sleep(1000); //  Do some 'work'
+                Thread.sleep(1000); //  Do some 'work'
+            }
         }
-
-        socket.close();
-        context.term();
     }
 }

--- a/src/test/java/guide/identity.java
+++ b/src/test/java/guide/identity.java
@@ -1,40 +1,33 @@
 package guide;
 
 import org.zeromq.ZMQ;
-import org.zeromq.ZMQ.Context;
 import org.zeromq.ZMQ.Socket;
+import org.zeromq.ZContext;
 
 /**
  * Demonstrate identities as used by the request-reply pattern.
  */
 public class identity
 {
-
     public static void main(String[] args) throws InterruptedException
     {
+        try (ZContext context = new ZContext()) {
+            Socket sink = context.createSocket(ZMQ.ROUTER);
+            sink.bind("inproc://example");
 
-        Context context = ZMQ.context(1);
-        Socket sink = context.socket(ZMQ.ROUTER);
-        sink.bind("inproc://example");
+            //  First allow 0MQ to set the identity, [00] + random 4byte
+            Socket anonymous = context.createSocket(ZMQ.REQ);
 
-        //  First allow 0MQ to set the identity, [00] + random 4byte
-        Socket anonymous = context.socket(ZMQ.REQ);
+            anonymous.connect("inproc://example");
+            anonymous.send("ROUTER uses a generated UUID", 0);
+            ZHelper.dump(sink);
 
-        anonymous.connect("inproc://example");
-        anonymous.send("ROUTER uses a generated UUID", 0);
-        ZHelper.dump(sink);
-
-        //  Then set the identity ourself
-        Socket identified = context.socket(ZMQ.REQ);
-        identified.setIdentity("Hello".getBytes(ZMQ.CHARSET));
-        identified.connect("inproc://example");
-        identified.send("ROUTER socket uses REQ's socket identity", 0);
-        ZHelper.dump(sink);
-
-        sink.close();
-        anonymous.close();
-        identified.close();
-        context.term();
-
+            //  Then set the identity ourself
+            Socket identified = context.createSocket(ZMQ.REQ);
+            identified.setIdentity("Hello".getBytes(ZMQ.CHARSET));
+            identified.connect("inproc://example");
+            identified.send("ROUTER socket uses REQ's socket identity", 0);
+            ZHelper.dump(sink);
+        }
     }
 }

--- a/src/test/java/guide/interrupt.java
+++ b/src/test/java/guide/interrupt.java
@@ -8,20 +8,21 @@ package guide;
 
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQException;
+import org.zeromq.ZContext;
 
 public class interrupt
 {
     public static void main(String[] args)
     {
         //  Prepare our context and socket
-        final ZMQ.Context context = ZMQ.context(1);
+        final ZContext context = new ZContext();
 
         final Thread zmqThread = new Thread()
         {
             @Override
             public void run()
             {
-                ZMQ.Socket socket = context.socket(ZMQ.REP);
+                ZMQ.Socket socket = context.createSocket(ZMQ.REP);
                 socket.bind("tcp://*:5555");
 
                 while (!Thread.currentThread().isInterrupted()) {
@@ -46,7 +47,7 @@ public class interrupt
             public void run()
             {
                 System.out.println("W: interrupt received, killing server...");
-                context.term();
+                context.close();
                 try {
                     zmqThread.interrupt();
                     zmqThread.join();

--- a/src/test/java/guide/kvmsg.java
+++ b/src/test/java/guide/kvmsg.java
@@ -327,58 +327,54 @@ public class kvmsg
         System.out.printf(" * kvmsg: ");
 
         //  Prepare our context and sockets
-        ZContext ctx = new ZContext();
-        Socket output = ctx.createSocket(ZMQ.DEALER);
-        output.bind("ipc://kvmsg_selftest.ipc");
-        Socket input = ctx.createSocket(ZMQ.DEALER);
-        input.connect("ipc://kvmsg_selftest.ipc");
+        try (ZContext ctx = new ZContext()) {
+            Socket output = ctx.createSocket(ZMQ.DEALER);
+            output.bind("ipc://kvmsg_selftest.ipc");
+            Socket input = ctx.createSocket(ZMQ.DEALER);
+            input.connect("ipc://kvmsg_selftest.ipc");
 
-        Map<String, kvmsg> kvmap = new HashMap<String, kvmsg>();
+            Map<String, kvmsg> kvmap = new HashMap<String, kvmsg>();
 
-        //  .until
-        //  Test send and receive of simple message
-        kvmsg kvmsg = new kvmsg(1);
-        kvmsg.setKey("getKey");
-        kvmsg.setUUID();
-        kvmsg.setBody("body".getBytes(ZMQ.CHARSET));
-        if (verbose)
-            kvmsg.dump();
-        kvmsg.send(output);
-        kvmsg.store(kvmap);
+            //  .until
+            //  Test send and receive of simple message
+            kvmsg kvmsg = new kvmsg(1);
+            kvmsg.setKey("getKey");
+            kvmsg.setUUID();
+            kvmsg.setBody("body".getBytes(ZMQ.CHARSET));
+            if (verbose)
+                kvmsg.dump();
+            kvmsg.send(output);
+            kvmsg.store(kvmap);
 
-        kvmsg = guide.kvmsg.recv(input);
-        if (verbose)
-            kvmsg.dump();
-        assert (kvmsg.getKey().equals("getKey"));
-        kvmsg.store(kvmap);
+            kvmsg = guide.kvmsg.recv(input);
+            if (verbose)
+                kvmsg.dump();
+            assert (kvmsg.getKey().equals("getKey"));
+            kvmsg.store(kvmap);
 
-        //  Test send and receive of message with properties
-        kvmsg = new kvmsg(2);
-        kvmsg.setProp("prop1", "value1");
-        kvmsg.setProp("prop2", "value1");
-        kvmsg.setProp("prop2", "value2");
-        kvmsg.setKey("getKey");
-        kvmsg.setUUID();
-        kvmsg.setBody("body".getBytes(ZMQ.CHARSET));
-        assert (kvmsg.getProp("prop2").equals("value2"));
-        if (verbose)
-            kvmsg.dump();
-        kvmsg.send(output);
-        kvmsg.destroy();
+            //  Test send and receive of message with properties
+            kvmsg = new kvmsg(2);
+            kvmsg.setProp("prop1", "value1");
+            kvmsg.setProp("prop2", "value1");
+            kvmsg.setProp("prop2", "value2");
+            kvmsg.setKey("getKey");
+            kvmsg.setUUID();
+            kvmsg.setBody("body".getBytes(ZMQ.CHARSET));
+            assert (kvmsg.getProp("prop2").equals("value2"));
+            if (verbose)
+                kvmsg.dump();
+            kvmsg.send(output);
+            kvmsg.destroy();
 
-        kvmsg = guide.kvmsg.recv(input);
-        if (verbose)
-            kvmsg.dump();
-        assert (kvmsg.key.equals("getKey"));
-        assert (kvmsg.getProp("prop2").equals("value2"));
-        kvmsg.destroy();
-
-        //  .skip
-        //  Shutdown and destroy all objects
-        ctx.close();
+            kvmsg = guide.kvmsg.recv(input);
+            if (verbose)
+                kvmsg.dump();
+            assert (kvmsg.key.equals("getKey"));
+            assert (kvmsg.getProp("prop2").equals("value2"));
+            kvmsg.destroy();
+        }
 
         System.out.printf("OK\n");
-
     }
     //  .until
 }

--- a/src/test/java/guide/lbbroker.java
+++ b/src/test/java/guide/lbbroker.java
@@ -4,13 +4,12 @@ import java.util.LinkedList;
 import java.util.Queue;
 
 import org.zeromq.ZMQ;
-import org.zeromq.ZMQ.Context;
 import org.zeromq.ZMQ.Poller;
 import org.zeromq.ZMQ.Socket;
+import org.zeromq.ZContext;
 
 public class lbbroker
 {
-
     private static final int NBR_CLIENTS = 10;
     private static final int NBR_WORKERS = 3;
 
@@ -22,21 +21,18 @@ public class lbbroker
         @Override
         public void run()
         {
-            Context context = ZMQ.context(1);
-
             //  Prepare our context and sockets
-            Socket client = context.socket(ZMQ.REQ);
-            ZHelper.setId(client); //  Set a printable identity
+            try (ZContext context = new ZContext()) {
+                Socket client = context.createSocket(ZMQ.REQ);
+                ZHelper.setId(client); //  Set a printable identity
 
-            client.connect("ipc://frontend.ipc");
+                client.connect("ipc://frontend.ipc");
 
-            //  Send request, get reply
-            client.send("HELLO");
-            String reply = client.recvStr();
-            System.out.println("Client: " + reply);
-
-            client.close();
-            context.term();
+                //  Send request, get reply
+                client.send("HELLO");
+                String reply = client.recvStr();
+                System.out.println("Client: " + reply);
+            }
         }
     }
 
@@ -51,31 +47,30 @@ public class lbbroker
         @Override
         public void run()
         {
-            Context context = ZMQ.context(1);
             //  Prepare our context and sockets
-            Socket worker = context.socket(ZMQ.REQ);
-            ZHelper.setId(worker); //  Set a printable identity
+            try (ZContext context = new ZContext()) {
+                Socket worker = context.createSocket(ZMQ.REQ);
+                ZHelper.setId(worker); //  Set a printable identity
 
-            worker.connect("ipc://backend.ipc");
+                worker.connect("ipc://backend.ipc");
 
-            //  Tell backend we're ready for work
-            worker.send("READY");
+                //  Tell backend we're ready for work
+                worker.send("READY");
 
-            while (!Thread.currentThread().isInterrupted()) {
-                String address = worker.recvStr();
-                String empty = worker.recvStr();
-                assert (empty.length() == 0);
+                while (!Thread.currentThread().isInterrupted()) {
+                    String address = worker.recvStr();
+                    String empty = worker.recvStr();
+                    assert (empty.length() == 0);
 
-                //  Get request, send reply
-                String request = worker.recvStr();
-                System.out.println("Worker: " + request);
+                    //  Get request, send reply
+                    String request = worker.recvStr();
+                    System.out.println("Worker: " + request);
 
-                worker.sendMore(address);
-                worker.sendMore("");
-                worker.send("OK");
+                    worker.sendMore(address);
+                    worker.sendMore("");
+                    worker.send("OK");
+                }
             }
-            worker.close();
-            context.term();
         }
     }
 
@@ -88,104 +83,96 @@ public class lbbroker
      */
     public static void main(String[] args)
     {
-        Context context = ZMQ.context(1);
         //  Prepare our context and sockets
-        Socket frontend = context.socket(ZMQ.ROUTER);
-        Socket backend = context.socket(ZMQ.ROUTER);
-        frontend.bind("ipc://frontend.ipc");
-        backend.bind("ipc://backend.ipc");
+        try (ZContext context = new ZContext()) {
+            Socket frontend = context.createSocket(ZMQ.ROUTER);
+            Socket backend = context.createSocket(ZMQ.ROUTER);
+            frontend.bind("ipc://frontend.ipc");
+            backend.bind("ipc://backend.ipc");
 
-        int clientNbr;
-        for (clientNbr = 0; clientNbr < NBR_CLIENTS; clientNbr++)
-            new ClientTask().start();
+            int clientNbr;
+            for (clientNbr = 0; clientNbr < NBR_CLIENTS; clientNbr++)
+                new ClientTask().start();
 
-        for (int workerNbr = 0; workerNbr < NBR_WORKERS; workerNbr++)
-            new WorkerTask().start();
+            for (int workerNbr = 0; workerNbr < NBR_WORKERS; workerNbr++)
+                new WorkerTask().start();
 
-        //  Here is the main loop for the least-recently-used queue. It has two
-        //  sockets; a frontend for clients and a backend for workers. It polls
-        //  the backend in all cases, and polls the frontend only when there are
-        //  one or more workers ready. This is a neat way to use 0MQ's own queues
-        //  to hold messages we're not ready to process yet. When we get a client
-        //  reply, we pop the next available worker, and send the request to it,
-        //  including the originating client identity. When a worker replies, we
-        //  re-queue that worker, and we forward the reply to the original client,
-        //  using the reply envelope.
+            //  Here is the main loop for the least-recently-used queue. It has
+            //  two sockets; a frontend for clients and a backend for workers.
+            //  It polls the backend in all cases, and polls the frontend only
+            //  when there are one or more workers ready. This is a neat way to
+            //  use 0MQ's own queues to hold messages we're not ready to process
+            //  yet. When we get a client reply, we pop the next available
+            //  worker, and send the request to it, including the originating
+            //  client identity. When a worker replies, we re-queue that worker,
+            //  and we forward the reply to the original client, using the reply
+            //  envelope.
 
-        //  Queue of available workers
-        Queue<String> workerQueue = new LinkedList<String>();
+            //  Queue of available workers
+            Queue<String> workerQueue = new LinkedList<String>();
 
-        while (!Thread.currentThread().isInterrupted()) {
+            while (!Thread.currentThread().isInterrupted()) {
+                //  Initialize poll set
+                Poller items = context.createPoller(2);
 
-            //  Initialize poll set
-            Poller items = context.poller(2);
+                //  Always poll for worker activity on backend
+                items.register(backend, Poller.POLLIN);
 
-            //  Always poll for worker activity on backend
-            items.register(backend, Poller.POLLIN);
+                //  Poll front-end only if we have available workers
+                if (workerQueue.size() > 0)
+                    items.register(frontend, Poller.POLLIN);
 
-            //  Poll front-end only if we have available workers
-            if (workerQueue.size() > 0)
-                items.register(frontend, Poller.POLLIN);
+                if (items.poll() < 0)
+                    break; //  Interrupted
 
-            if (items.poll() < 0)
-                break; //  Interrupted
+                //  Handle worker activity on backend
+                if (items.pollin(0)) {
 
-            //  Handle worker activity on backend
-            if (items.pollin(0)) {
+                    //  Queue worker address for LRU routing
+                    workerQueue.add(backend.recvStr());
 
-                //  Queue worker address for LRU routing
-                workerQueue.add(backend.recvStr());
-
-                //  Second frame is empty
-                String empty = backend.recvStr();
-                assert (empty.length() == 0);
-
-                //  Third frame is READY or else a client reply address
-                String clientAddr = backend.recvStr();
-
-                //  If client reply, send rest back to frontend
-                if (!clientAddr.equals("READY")) {
-
-                    empty = backend.recvStr();
+                    //  Second frame is empty
+                    String empty = backend.recvStr();
                     assert (empty.length() == 0);
 
-                    String reply = backend.recvStr();
-                    frontend.sendMore(clientAddr);
-                    frontend.sendMore("");
-                    frontend.send(reply);
+                    //  Third frame is READY or else a client reply address
+                    String clientAddr = backend.recvStr();
 
-                    if (--clientNbr == 0)
-                        break;
+                    //  If client reply, send rest back to frontend
+                    if (!clientAddr.equals("READY")) {
+
+                        empty = backend.recvStr();
+                        assert (empty.length() == 0);
+
+                        String reply = backend.recvStr();
+                        frontend.sendMore(clientAddr);
+                        frontend.sendMore("");
+                        frontend.send(reply);
+
+                        if (--clientNbr == 0)
+                            break;
+                    }
                 }
 
+                if (items.pollin(1)) {
+                    //  Now get next client request, route to LRU worker
+                    //  Client request is [address][empty][request]
+                    String clientAddr = frontend.recvStr();
+
+                    String empty = frontend.recvStr();
+                    assert (empty.length() == 0);
+
+                    String request = frontend.recvStr();
+
+                    String workerAddr = workerQueue.poll();
+
+                    backend.sendMore(workerAddr);
+                    backend.sendMore("");
+                    backend.sendMore(clientAddr);
+                    backend.sendMore("");
+                    backend.send(request);
+                }
             }
-
-            if (items.pollin(1)) {
-                //  Now get next client request, route to LRU worker
-                //  Client request is [address][empty][request]
-                String clientAddr = frontend.recvStr();
-
-                String empty = frontend.recvStr();
-                assert (empty.length() == 0);
-
-                String request = frontend.recvStr();
-
-                String workerAddr = workerQueue.poll();
-
-                backend.sendMore(workerAddr);
-                backend.sendMore("");
-                backend.sendMore(clientAddr);
-                backend.sendMore("");
-                backend.send(request);
-
-            }
-            items.close();
         }
-
-        frontend.close();
-        backend.close();
-        context.term();
-
     }
-
 }

--- a/src/test/java/guide/lpserver.java
+++ b/src/test/java/guide/lpserver.java
@@ -3,8 +3,8 @@ package guide;
 import java.util.Random;
 
 import org.zeromq.ZMQ;
-import org.zeromq.ZMQ.Context;
 import org.zeromq.ZMQ.Socket;
+import org.zeromq.ZContext;
 
 //
 // Lazy Pirate server
@@ -20,29 +20,28 @@ public class lpserver
     {
         Random rand = new Random(System.nanoTime());
 
-        Context context = ZMQ.context(1);
-        Socket server = context.socket(ZMQ.REP);
-        server.bind("tcp://*:5555");
+        try (ZContext context = new ZContext()) {
+            Socket server = context.createSocket(ZMQ.REP);
+            server.bind("tcp://*:5555");
 
-        int cycles = 0;
-        while (true) {
-            String request = server.recvStr();
-            cycles++;
+            int cycles = 0;
+            while (true) {
+                String request = server.recvStr();
+                cycles++;
 
-            //  Simulate various problems, after a few cycles
-            if (cycles > 3 && rand.nextInt(3) == 0) {
-                System.out.println("I: simulating a crash");
-                break;
+                //  Simulate various problems, after a few cycles
+                if (cycles > 3 && rand.nextInt(3) == 0) {
+                    System.out.println("I: simulating a crash");
+                    break;
+                }
+                else if (cycles > 3 && rand.nextInt(3) == 0) {
+                    System.out.println("I: simulating CPU overload");
+                    Thread.sleep(2000);
+                }
+                System.out.printf("I: normal request (%s)\n", request);
+                Thread.sleep(1000); //  Do some heavy work
+                server.send(request);
             }
-            else if (cycles > 3 && rand.nextInt(3) == 0) {
-                System.out.println("I: simulating CPU overload");
-                Thread.sleep(2000);
-            }
-            System.out.printf("I: normal request (%s)\n", request);
-            Thread.sleep(1000); //  Do some heavy work
-            server.send(request);
         }
-        server.close();
-        context.term();
     }
 }

--- a/src/test/java/guide/lvcache.java
+++ b/src/test/java/guide/lvcache.java
@@ -15,61 +15,60 @@ public class lvcache
 {
     public static void main(String[] args)
     {
-        ZContext context = new ZContext();
-        Socket frontend = context.createSocket(ZMQ.SUB);
-        frontend.bind("tcp://*:5557");
-        Socket backend = context.createSocket(ZMQ.XPUB);
-        backend.bind("tcp://*:5558");
+        try (ZContext context = new ZContext()) {
+            Socket frontend = context.createSocket(ZMQ.SUB);
+            frontend.bind("tcp://*:5557");
+            Socket backend = context.createSocket(ZMQ.XPUB);
+            backend.bind("tcp://*:5558");
 
-        //  Subscribe to every single topic from publisher
-        frontend.subscribe(ZMQ.SUBSCRIPTION_ALL);
+            //  Subscribe to every single topic from publisher
+            frontend.subscribe(ZMQ.SUBSCRIPTION_ALL);
 
-        //  Store last instance of each topic in a cache
-        Map<String, String> cache = new HashMap<String, String>();
+            //  Store last instance of each topic in a cache
+            Map<String, String> cache = new HashMap<String, String>();
 
-        Poller poller = context.createPoller(2);
-        poller.register(frontend, Poller.POLLIN);
-        poller.register(backend, Poller.POLLIN);
+            Poller poller = context.createPoller(2);
+            poller.register(frontend, Poller.POLLIN);
+            poller.register(backend, Poller.POLLIN);
 
-        //  .split main poll loop
-        //  We route topic updates from frontend to backend, and
-        //  we handle subscriptions by sending whatever we cached,
-        //  if anything:
-        while (true) {
-            if (poller.poll(1000) == -1)
-                break; //  Interrupted
+            //  .split main poll loop
+            //  We route topic updates from frontend to backend, and we handle
+            //  subscriptions by sending whatever we cached, if anything:
+            while (true) {
+                if (poller.poll(1000) == -1)
+                    break; //  Interrupted
 
-            //  Any new topic data we cache and then forward
-            if (poller.pollin(0)) {
-                String topic = frontend.recvStr();
-                String current = frontend.recvStr();
+                //  Any new topic data we cache and then forward
+                if (poller.pollin(0)) {
+                    String topic = frontend.recvStr();
+                    String current = frontend.recvStr();
 
-                if (topic == null)
-                    break;
-                cache.put(topic, current);
-                backend.sendMore(topic);
-                backend.send(current);
-            }
-            //  .split handle subscriptions
-            //  When we get a new subscription, we pull data from the cache:
-            if (poller.pollin(1)) {
-                ZFrame frame = ZFrame.recvFrame(backend);
-                if (frame == null)
-                    break;
-                //  Event is one byte 0=unsub or 1=sub, followed by topic
-                byte[] event = frame.getData();
-                if (event[0] == 1) {
-                    String topic = new String(event, 1, event.length - 1, ZMQ.CHARSET);
-                    System.out.printf("Sending cached topic %s\n", topic);
-                    String previous = cache.get(topic);
-                    if (previous != null) {
-                        backend.sendMore(topic);
-                        backend.send(previous);
-                    }
+                    if (topic == null)
+                        break;
+                    cache.put(topic, current);
+                    backend.sendMore(topic);
+                    backend.send(current);
                 }
-                frame.destroy();
+                //  .split handle subscriptions
+                //  When we get a new subscription, we pull data from the cache:
+                if (poller.pollin(1)) {
+                    ZFrame frame = ZFrame.recvFrame(backend);
+                    if (frame == null)
+                        break;
+                    //  Event is one byte 0=unsub or 1=sub, followed by topic
+                    byte[] event = frame.getData();
+                    if (event[0] == 1) {
+                        String topic = new String(event, 1, event.length - 1, ZMQ.CHARSET);
+                        System.out.printf("Sending cached topic %s\n", topic);
+                        String previous = cache.get(topic);
+                        if (previous != null) {
+                            backend.sendMore(topic);
+                            backend.send(previous);
+                        }
+                    }
+                    frame.destroy();
+                }
             }
         }
-        context.close();
     }
 }

--- a/src/test/java/guide/mspoller.java
+++ b/src/test/java/guide/mspoller.java
@@ -1,6 +1,7 @@
 package guide;
 
 import org.zeromq.ZMQ;
+import org.zeromq.ZContext;
 
 //
 //  Reading from multiple sockets in Java
@@ -11,37 +12,34 @@ public class mspoller
 
     public static void main(String[] args)
     {
-        ZMQ.Context context = ZMQ.context(1);
+        try (ZContext context = new ZContext()) {
+            // Connect to task ventilator
+            ZMQ.Socket receiver = context.createSocket(ZMQ.PULL);
+            receiver.connect("tcp://localhost:5557");
 
-        // Connect to task ventilator
-        ZMQ.Socket receiver = context.socket(ZMQ.PULL);
-        receiver.connect("tcp://localhost:5557");
+            //  Connect to weather server
+            ZMQ.Socket subscriber = context.createSocket(ZMQ.SUB);
+            subscriber.connect("tcp://localhost:5556");
+            subscriber.subscribe("10001 ".getBytes(ZMQ.CHARSET));
 
-        //  Connect to weather server
-        ZMQ.Socket subscriber = context.socket(ZMQ.SUB);
-        subscriber.connect("tcp://localhost:5556");
-        subscriber.subscribe("10001 ".getBytes(ZMQ.CHARSET));
+            //  Initialize poll set
+            ZMQ.Poller items = context.createPoller(2);
+            items.register(receiver, ZMQ.Poller.POLLIN);
+            items.register(subscriber, ZMQ.Poller.POLLIN);
 
-        //  Initialize poll set
-        ZMQ.Poller items = context.poller(2);
-        items.register(receiver, ZMQ.Poller.POLLIN);
-        items.register(subscriber, ZMQ.Poller.POLLIN);
-
-        //  Process messages from both sockets
-        while (!Thread.currentThread().isInterrupted()) {
-            byte[] message;
-            items.poll();
-            if (items.pollin(0)) {
-                message = receiver.recv(0);
-                System.out.println("Process task");
-            }
-            if (items.pollin(1)) {
-                message = subscriber.recv(0);
-                System.out.println("Process weather update");
+            //  Process messages from both sockets
+            while (!Thread.currentThread().isInterrupted()) {
+                byte[] message;
+                items.poll();
+                if (items.pollin(0)) {
+                    message = receiver.recv(0);
+                    System.out.println("Process task");
+                }
+                if (items.pollin(1)) {
+                    message = subscriber.recv(0);
+                    System.out.println("Process weather update");
+                }
             }
         }
-        items.close();
-        receiver.close();
-        context.term();
     }
 }

--- a/src/test/java/guide/msreader.java
+++ b/src/test/java/guide/msreader.java
@@ -1,6 +1,7 @@
 package guide;
 
 import org.zeromq.ZMQ;
+import org.zeromq.ZContext;
 
 //
 //  Reading from multiple sockets in Java
@@ -12,35 +13,32 @@ public class msreader
     public static void main(String[] args) throws Exception
     {
         //  Prepare our context and sockets
-        ZMQ.Context context = ZMQ.context(1);
+        try (ZContext context = new ZContext()) {
+            // Connect to task ventilator
+            ZMQ.Socket receiver = context.createSocket(ZMQ.PULL);
+            receiver.connect("tcp://localhost:5557");
 
-        // Connect to task ventilator
-        ZMQ.Socket receiver = context.socket(ZMQ.PULL);
-        receiver.connect("tcp://localhost:5557");
+            //  Connect to weather server
+            ZMQ.Socket subscriber = context.createSocket(ZMQ.SUB);
+            subscriber.connect("tcp://localhost:5556");
+            subscriber.subscribe("10001 ".getBytes(ZMQ.CHARSET));
 
-        //  Connect to weather server
-        ZMQ.Socket subscriber = context.socket(ZMQ.SUB);
-        subscriber.connect("tcp://localhost:5556");
-        subscriber.subscribe("10001 ".getBytes(ZMQ.CHARSET));
-
-        //  Process messages from both sockets
-        //  We prioritize traffic from the task ventilator
-        while (!Thread.currentThread().isInterrupted()) {
-            //  Process any waiting tasks
-            byte[] task;
-            while ((task = receiver.recv(ZMQ.DONTWAIT)) != null) {
-                System.out.println("process task");
+            //  Process messages from both sockets
+            //  We prioritize traffic from the task ventilator
+            while (!Thread.currentThread().isInterrupted()) {
+                //  Process any waiting tasks
+                byte[] task;
+                while ((task = receiver.recv(ZMQ.DONTWAIT)) != null) {
+                    System.out.println("process task");
+                }
+                //  Process any waiting weather updates
+                byte[] update;
+                while ((update = subscriber.recv(ZMQ.DONTWAIT)) != null) {
+                    System.out.println("process weather update");
+                }
+                //  No activity, so sleep for 1 msec
+                Thread.sleep(1000);
             }
-            //  Process any waiting weather updates
-            byte[] update;
-            while ((update = subscriber.recv(ZMQ.DONTWAIT)) != null) {
-                System.out.println("process weather update");
-            }
-            //  No activity, so sleep for 1 msec
-            Thread.sleep(1000);
         }
-        receiver.close();
-        subscriber.close();
-        context.term();
     }
 }

--- a/src/test/java/guide/pathopub.java
+++ b/src/test/java/guide/pathopub.java
@@ -12,28 +12,30 @@ public class pathopub
 {
     public static void main(String[] args) throws Exception
     {
-        ZContext context = new ZContext();
-        Socket publisher = context.createSocket(ZMQ.PUB);
-        if (args.length == 1)
-            publisher.connect(args[0]);
-        else publisher.bind("tcp://*:5556");
+        try (ZContext context = new ZContext()) {
+            Socket publisher = context.createSocket(ZMQ.PUB);
+            if (args.length == 1)
+                publisher.connect(args[0]);
+            else publisher.bind("tcp://*:5556");
 
-        //  Ensure subscriber connection has time to complete
-        Thread.sleep(1000);
-
-        //  Send out all 1,000 topic messages
-        int topicNbr;
-        for (topicNbr = 0; topicNbr < 1000; topicNbr++) {
-            publisher.send(String.format("%03d", topicNbr), ZMQ.SNDMORE);
-            publisher.send("Save Roger");
-        }
-        //  Send one random update per second
-        Random rand = new Random(System.currentTimeMillis());
-        while (!Thread.currentThread().isInterrupted()) {
+            //  Ensure subscriber connection has time to complete
             Thread.sleep(1000);
-            publisher.send(String.format("%03d", rand.nextInt(1000)), ZMQ.SNDMORE);
-            publisher.send("Off with his head!");
+
+            //  Send out all 1,000 topic messages
+            int topicNbr;
+            for (topicNbr = 0; topicNbr < 1000; topicNbr++) {
+                publisher.send(String.format("%03d", topicNbr), ZMQ.SNDMORE);
+                publisher.send("Save Roger");
+            }
+            //  Send one random update per second
+            Random rand = new Random(System.currentTimeMillis());
+            while (!Thread.currentThread().isInterrupted()) {
+                Thread.sleep(1000);
+                publisher.send(
+                    String.format("%03d", rand.nextInt(1000)), ZMQ.SNDMORE
+                );
+                publisher.send("Off with his head!");
+            }
         }
-        context.close();
     }
 }

--- a/src/test/java/guide/pathosub.java
+++ b/src/test/java/guide/pathosub.java
@@ -12,24 +12,24 @@ public class pathosub
 {
     public static void main(String[] args)
     {
-        ZContext context = new ZContext();
-        Socket subscriber = context.createSocket(ZMQ.SUB);
-        if (args.length == 1)
-            subscriber.connect(args[0]);
-        else subscriber.connect("tcp://localhost:5556");
+        try (ZContext context = new ZContext()) {
+            Socket subscriber = context.createSocket(ZMQ.SUB);
+            if (args.length == 1)
+                subscriber.connect(args[0]);
+            else subscriber.connect("tcp://localhost:5556");
 
-        Random rand = new Random(System.currentTimeMillis());
-        String subscription = String.format("%03d", rand.nextInt(1000));
-        subscriber.subscribe(subscription.getBytes(ZMQ.CHARSET));
+            Random rand = new Random(System.currentTimeMillis());
+            String subscription = String.format("%03d", rand.nextInt(1000));
+            subscriber.subscribe(subscription.getBytes(ZMQ.CHARSET));
 
-        while (true) {
-            String topic = subscriber.recvStr();
-            if (topic == null)
-                break;
-            String data = subscriber.recvStr();
-            assert (topic.equals(subscription));
-            System.out.println(data);
+            while (true) {
+                String topic = subscriber.recvStr();
+                if (topic == null)
+                    break;
+                String data = subscriber.recvStr();
+                assert (topic.equals(subscription));
+                System.out.println(data);
+            }
         }
-        context.close();
     }
 }

--- a/src/test/java/guide/peering1.java
+++ b/src/test/java/guide/peering1.java
@@ -26,45 +26,48 @@ public class peering1
         System.out.println(String.format("I: preparing broker at %s\n", self));
         Random rand = new Random(System.nanoTime());
 
-        ZContext ctx = new ZContext();
+        try (ZContext ctx = new ZContext()) {
+            //  Bind state backend to endpoint
+            Socket statebe = ctx.createSocket(ZMQ.PUB);
+            statebe.bind(String.format("ipc://%s-state.ipc", self));
 
-        //  Bind state backend to endpoint
-        Socket statebe = ctx.createSocket(ZMQ.PUB);
-        statebe.bind(String.format("ipc://%s-state.ipc", self));
-
-        //  Connect statefe to all peers
-        Socket statefe = ctx.createSocket(ZMQ.SUB);
-        statefe.subscribe(ZMQ.SUBSCRIPTION_ALL);
-        int argn;
-        for (argn = 1; argn < argv.length; argn++) {
-            String peer = argv[argn];
-            System.out.printf("I: connecting to state backend at '%s'\n", peer);
-            statefe.connect(String.format("ipc://%s-state.ipc", peer));
-        }
-        //  The main loop sends out status messages to peers, and collects
-        //  status messages back from peers. The zmq_poll timeout defines
-        //  our own heartbeat.
-        Poller poller = ctx.createPoller(1);
-        poller.register(statefe, Poller.POLLIN);
-
-        while (true) {
-            //  Poll for activity, or 1 second timeout
-            int rc = poller.poll(1000);
-            if (rc == -1)
-                break; //  Interrupted
-
-            //  Handle incoming status messages
-            if (poller.pollin(0)) {
-                String peer_name = new String(statefe.recv(0), ZMQ.CHARSET);
-                String available = new String(statefe.recv(0), ZMQ.CHARSET);
-                System.out.printf("%s - %s workers free\n", peer_name, available);
+            //  Connect statefe to all peers
+            Socket statefe = ctx.createSocket(ZMQ.SUB);
+            statefe.subscribe(ZMQ.SUBSCRIPTION_ALL);
+            int argn;
+            for (argn = 1; argn < argv.length; argn++) {
+                String peer = argv[argn];
+                System.out.printf(
+                    "I: connecting to state backend at '%s'\n", peer
+                );
+                statefe.connect(String.format("ipc://%s-state.ipc", peer));
             }
-            else {
-                //  Send random values for worker availability
-                statebe.send(self, ZMQ.SNDMORE);
-                statebe.send(String.format("%d", rand.nextInt(10)), 0);
+            //  The main loop sends out status messages to peers, and collects
+            //  status messages back from peers. The zmq_poll timeout defines
+            //  our own heartbeat.
+            Poller poller = ctx.createPoller(1);
+            poller.register(statefe, Poller.POLLIN);
+
+            while (true) {
+                //  Poll for activity, or 1 second timeout
+                int rc = poller.poll(1000);
+                if (rc == -1)
+                    break; //  Interrupted
+
+                //  Handle incoming status messages
+                if (poller.pollin(0)) {
+                    String peer_name = new String(statefe.recv(0), ZMQ.CHARSET);
+                    String available = new String(statefe.recv(0), ZMQ.CHARSET);
+                    System.out.printf(
+                        "%s - %s workers free\n", peer_name, available
+                    );
+                }
+                else {
+                    //  Send random values for worker availability
+                    statebe.send(self, ZMQ.SNDMORE);
+                    statebe.send(String.format("%d", rand.nextInt(10)), 0);
+                }
             }
         }
-        ctx.close();
     }
 }

--- a/src/test/java/guide/peering2.java
+++ b/src/test/java/guide/peering2.java
@@ -31,24 +31,24 @@ public class peering2
         @Override
         public void run()
         {
-            ZContext ctx = new ZContext();
-            Socket client = ctx.createSocket(ZMQ.REQ);
-            client.connect(String.format("ipc://%s-localfe.ipc", self));
+            try (ZContext ctx = new ZContext()) {
+                Socket client = ctx.createSocket(ZMQ.REQ);
+                client.connect(String.format("ipc://%s-localfe.ipc", self));
 
-            while (true) {
-                //  Send request, get reply
-                client.send("HELLO", 0);
-                String reply = client.recvStr(0);
-                if (reply == null)
-                    break; //  Interrupted
-                System.out.printf("Client: %s\n", reply);
-                try {
-                    Thread.sleep(1000);
-                }
-                catch (InterruptedException e) {
+                while (true) {
+                    //  Send request, get reply
+                    client.send("HELLO", 0);
+                    String reply = client.recvStr(0);
+                    if (reply == null)
+                        break; //  Interrupted
+                    System.out.printf("Client: %s\n", reply);
+                    try {
+                        Thread.sleep(1000);
+                    }
+                    catch (InterruptedException e) {
+                    }
                 }
             }
-            ctx.close();
         }
     }
 
@@ -60,25 +60,25 @@ public class peering2
         @Override
         public void run()
         {
-            ZContext ctx = new ZContext();
-            Socket worker = ctx.createSocket(ZMQ.REQ);
-            worker.connect(String.format("ipc://%s-localbe.ipc", self));
+            try (ZContext ctx = new ZContext()) {
+                Socket worker = ctx.createSocket(ZMQ.REQ);
+                worker.connect(String.format("ipc://%s-localbe.ipc", self));
 
-            //  Tell broker we're ready for work
-            ZFrame frame = new ZFrame(WORKER_READY);
-            frame.send(worker, 0);
+                //  Tell broker we're ready for work
+                ZFrame frame = new ZFrame(WORKER_READY);
+                frame.send(worker, 0);
 
-            while (true) {
-                //  Send request, get reply
-                ZMsg msg = ZMsg.recvMsg(worker, 0);
-                if (msg == null)
-                    break; //  Interrupted
-                msg.getLast().print("Worker: ");
-                msg.getLast().reset("OK");
-                msg.send(worker);
+                while (true) {
+                    //  Send request, get reply
+                    ZMsg msg = ZMsg.recvMsg(worker, 0);
+                    if (msg == null)
+                        break; //  Interrupted
+                    msg.getLast().print("Worker: ");
+                    msg.getLast().reset("OK");
+                    msg.send(worker);
 
+                }
             }
-            ctx.close();
         }
     }
 
@@ -97,153 +97,155 @@ public class peering2
         System.out.printf("I: preparing broker at %s\n", self);
         Random rand = new Random(System.nanoTime());
 
-        ZContext ctx = new ZContext();
+        try (ZContext ctx = new ZContext()) {
+            //  Bind cloud frontend to endpoint
+            Socket cloudfe = ctx.createSocket(ZMQ.ROUTER);
+            cloudfe.setIdentity(self.getBytes(ZMQ.CHARSET));
+            cloudfe.bind(String.format("ipc://%s-cloud.ipc", self));
 
-        //  Bind cloud frontend to endpoint
-        Socket cloudfe = ctx.createSocket(ZMQ.ROUTER);
-        cloudfe.setIdentity(self.getBytes(ZMQ.CHARSET));
-        cloudfe.bind(String.format("ipc://%s-cloud.ipc", self));
+            //  Connect cloud backend to all peers
+            Socket cloudbe = ctx.createSocket(ZMQ.ROUTER);
+            cloudbe.setIdentity(self.getBytes(ZMQ.CHARSET));
+            int argn;
+            for (argn = 1; argn < argv.length; argn++) {
+                String peer = argv[argn];
+                System.out.printf(
+                    "I: connecting to cloud forintend at '%s'\n", peer
+                );
+                cloudbe.connect(String.format("ipc://%s-cloud.ipc", peer));
+            }
 
-        //  Connect cloud backend to all peers
-        Socket cloudbe = ctx.createSocket(ZMQ.ROUTER);
-        cloudbe.setIdentity(self.getBytes(ZMQ.CHARSET));
-        int argn;
-        for (argn = 1; argn < argv.length; argn++) {
-            String peer = argv[argn];
-            System.out.printf("I: connecting to cloud forintend at '%s'\n", peer);
-            cloudbe.connect(String.format("ipc://%s-cloud.ipc", peer));
-        }
+            //  Prepare local frontend and backend
+            Socket localfe = ctx.createSocket(ZMQ.ROUTER);
+            localfe.bind(String.format("ipc://%s-localfe.ipc", self));
+            Socket localbe = ctx.createSocket(ZMQ.ROUTER);
+            localbe.bind(String.format("ipc://%s-localbe.ipc", self));
 
-        //  Prepare local frontend and backend
-        Socket localfe = ctx.createSocket(ZMQ.ROUTER);
-        localfe.bind(String.format("ipc://%s-localfe.ipc", self));
-        Socket localbe = ctx.createSocket(ZMQ.ROUTER);
-        localbe.bind(String.format("ipc://%s-localbe.ipc", self));
+            //  Get user to tell us when we can start
+            System.out.println("Press Enter when all brokers are started: ");
+            try {
+                System.in.read();
+            }
+            catch (IOException e) {
+                e.printStackTrace();
+            }
 
-        //  Get user to tell us when we can start
-        System.out.println("Press Enter when all brokers are started: ");
-        try {
-            System.in.read();
-        }
-        catch (IOException e) {
-            e.printStackTrace();
-        }
+            //  Start local workers
+            int worker_nbr;
+            for (worker_nbr = 0; worker_nbr < NBR_WORKERS; worker_nbr++)
+                new worker_task().start();
 
-        //  Start local workers
-        int worker_nbr;
-        for (worker_nbr = 0; worker_nbr < NBR_WORKERS; worker_nbr++)
-            new worker_task().start();
+            //  Start local clients
+            int client_nbr;
+            for (client_nbr = 0; client_nbr < NBR_CLIENTS; client_nbr++)
+                new client_task().start();
 
-        //  Start local clients
-        int client_nbr;
-        for (client_nbr = 0; client_nbr < NBR_CLIENTS; client_nbr++)
-            new client_task().start();
+            //  Here we handle the request-reply flow. We're using the LRU
+            //  approach to poll workers at all times, and clients only when
+            //  there are one or more workers available.
 
-        //  Here we handle the request-reply flow. We're using the LRU approach
-        //  to poll workers at all times, and clients only when there are one or
-        //  more workers available.
+            //  Least recently used queue of available workers
+            int capacity = 0;
+            ArrayList<ZFrame> workers = new ArrayList<ZFrame>();
 
-        //  Least recently used queue of available workers
-        int capacity = 0;
-        ArrayList<ZFrame> workers = new ArrayList<ZFrame>();
+            Poller backends = ctx.createPoller(2);
+            backends.register(localbe, Poller.POLLIN);
+            backends.register(cloudbe, Poller.POLLIN);
 
-        Poller backends = ctx.createPoller(2);
-        backends.register(localbe, Poller.POLLIN);
-        backends.register(cloudbe, Poller.POLLIN);
+            Poller frontends = ctx.createPoller(2);
+            frontends.register(localfe, Poller.POLLIN);
+            frontends.register(cloudfe, Poller.POLLIN);
 
-        Poller frontends = ctx.createPoller(2);
-        frontends.register(localfe, Poller.POLLIN);
-        frontends.register(cloudfe, Poller.POLLIN);
+            while (true) {
+                //  First, route any waiting replies from workers
 
-        while (true) {
-            //  First, route any waiting replies from workers
-
-            //  If we have no workers anyhow, wait indefinitely
-            int rc = backends.poll(capacity > 0 ? 1000 : -1);
-            if (rc == -1)
-                break; //  Interrupted
-            //  Handle reply from local worker
-            ZMsg msg = null;
-            if (backends.pollin(0)) {
-                msg = ZMsg.recvMsg(localbe);
-                if (msg == null)
+                //  If we have no workers anyhow, wait indefinitely
+                int rc = backends.poll(capacity > 0 ? 1000 : -1);
+                if (rc == -1)
                     break; //  Interrupted
-                ZFrame address = msg.unwrap();
-                workers.add(address);
-                capacity++;
+                //  Handle reply from local worker
+                ZMsg msg = null;
+                if (backends.pollin(0)) {
+                    msg = ZMsg.recvMsg(localbe);
+                    if (msg == null)
+                        break; //  Interrupted
+                    ZFrame address = msg.unwrap();
+                    workers.add(address);
+                    capacity++;
 
-                //  If it's READY, don't route the message any further
-                ZFrame frame = msg.getFirst();
-                if (new String(frame.getData(), ZMQ.CHARSET).equals(WORKER_READY)) {
-                    msg.destroy();
-                    msg = null;
+                    //  If it's READY, don't route the message any further
+                    ZFrame frame = msg.getFirst();
+                    String frameData = new String(frame.getData(), ZMQ.CHARSET);
+                    if (frameData.equals(WORKER_READY)) {
+                        msg.destroy();
+                        msg = null;
+                    }
+                }
+                //  Or handle reply from peer broker
+                else if (backends.pollin(1)) {
+                    msg = ZMsg.recvMsg(cloudbe);
+                    if (msg == null)
+                        break; //  Interrupted
+                    //  We don't use peer broker address for anything
+                    ZFrame address = msg.unwrap();
+                    address.destroy();
+                }
+                //  Route reply to cloud if it's addressed to a broker
+                for (argn = 1; msg != null && argn < argv.length; argn++) {
+                    byte[] data = msg.getFirst().getData();
+                    if (argv[argn].equals(new String(data, ZMQ.CHARSET))) {
+                        msg.send(cloudfe);
+                        msg = null;
+                    }
+                }
+                //  Route reply to client if we still need to
+                if (msg != null)
+                    msg.send(localfe);
+
+                //  Now we route as many client requests as we have worker
+                //  capacity for. We may reroute requests from our local
+                //  frontend, but not from // the cloud frontend. We reroute
+                //  randomly now, just to test things out. In the next version
+                //  we'll do this properly by calculating cloud capacity://
+
+                while (capacity > 0) {
+                    rc = frontends.poll(0);
+                    assert (rc >= 0);
+                    int reroutable = 0;
+                    //  We'll do peer brokers first, to prevent starvation
+                    if (frontends.pollin(1)) {
+                        msg = ZMsg.recvMsg(cloudfe);
+                        reroutable = 0;
+                    }
+                    else if (frontends.pollin(0)) {
+                        msg = ZMsg.recvMsg(localfe);
+                        reroutable = 1;
+                    }
+                    else break; //  No work, go back to backends
+
+                    //  If reroutable, send to cloud 20% of the time
+                    //  Here we'd normally use cloud status information
+                    if (reroutable != 0 &&
+                        argv.length > 1 &&
+                        rand.nextInt(5) == 0) {
+                        //  Route to random broker peer
+                        int random_peer = rand.nextInt(argv.length - 1) + 1;
+                        msg.push(argv[random_peer]);
+                        msg.send(cloudbe);
+                    }
+                    else {
+                        ZFrame frame = workers.remove(0);
+                        msg.wrap(frame);
+                        msg.send(localbe);
+                        capacity--;
+                    }
                 }
             }
-            //  Or handle reply from peer broker
-            else if (backends.pollin(1)) {
-                msg = ZMsg.recvMsg(cloudbe);
-                if (msg == null)
-                    break; //  Interrupted
-                //  We don't use peer broker address for anything
-                ZFrame address = msg.unwrap();
-                address.destroy();
-            }
-            //  Route reply to cloud if it's addressed to a broker
-            for (argn = 1; msg != null && argn < argv.length; argn++) {
-                byte[] data = msg.getFirst().getData();
-                if (argv[argn].equals(new String(data, ZMQ.CHARSET))) {
-                    msg.send(cloudfe);
-                    msg = null;
-                }
-            }
-            //  Route reply to client if we still need to
-            if (msg != null)
-                msg.send(localfe);
-
-            //  Now we route as many client requests as we have worker capacity
-            //  for. We may reroute requests from our local frontend, but not from //
-            //  the cloud frontend. We reroute randomly now, just to test things
-            //  out. In the next version we'll do this properly by calculating
-            //  cloud capacity://
-
-            while (capacity > 0) {
-                rc = frontends.poll(0);
-                assert (rc >= 0);
-                int reroutable = 0;
-                //  We'll do peer brokers first, to prevent starvation
-                if (frontends.pollin(1)) {
-                    msg = ZMsg.recvMsg(cloudfe);
-                    reroutable = 0;
-                }
-                else if (frontends.pollin(0)) {
-                    msg = ZMsg.recvMsg(localfe);
-                    reroutable = 1;
-                }
-                else break; //  No work, go back to backends
-
-                //  If reroutable, send to cloud 20% of the time
-                //  Here we'd normally use cloud status information
-                //
-                if (reroutable != 0 && argv.length > 1 && rand.nextInt(5) == 0) {
-                    //  Route to random broker peer
-                    int random_peer = rand.nextInt(argv.length - 1) + 1;
-                    msg.push(argv[random_peer]);
-                    msg.send(cloudbe);
-                }
-                else {
-                    ZFrame frame = workers.remove(0);
-                    msg.wrap(frame);
-                    msg.send(localbe);
-                    capacity--;
-                }
+            //  When we're done, clean up properly
+            while (workers.size() > 0) {
+                ZFrame frame = workers.remove(0);
+                frame.destroy();
             }
         }
-        //  When we're done, clean up properly
-        while (workers.size() > 0) {
-            ZFrame frame = workers.remove(0);
-            frame.destroy();
-        }
-
-        ctx.close();
     }
 }

--- a/src/test/java/guide/peering3.java
+++ b/src/test/java/guide/peering3.java
@@ -18,64 +18,72 @@ public class peering3
 
     private static final int    NBR_CLIENTS  = 10;
     private static final int    NBR_WORKERS  = 5;
-    private static final String WORKER_READY = "\001"; //  Signals worker is ready
+    // Signals worker is ready
+    private static final String WORKER_READY = "\001";
 
     //  Our own name; in practice this would be configured per node
     private static String self;
 
-    //  This is the client task. It issues a burst of requests and then
-    //  sleeps for a few seconds. This simulates sporadic activity; when
-    //  a number of clients are active at once, the local workers should
-    //  be overloaded. The client uses a REQ socket for requests and also
-    //  pushes statistics to the monitor socket:
+    //  This is the client task. It issues a burst of requests and then sleeps
+    //  for a few seconds. This simulates sporadic activity; when a number of
+    //  clients are active at once, the local workers should be overloaded. The
+    //  client uses a REQ socket for requests and also pushes statistics to the
+    //  monitor socket:
     private static class client_task extends Thread
     {
         @Override
         public void run()
         {
-            ZContext ctx = new ZContext();
-            Socket client = ctx.createSocket(ZMQ.REQ);
-            client.connect(String.format("ipc://%s-localfe.ipc", self));
-            Socket monitor = ctx.createSocket(ZMQ.PUSH);
-            monitor.connect(String.format("ipc://%s-monitor.ipc", self));
-            Random rand = new Random(System.nanoTime());
+            try (ZContext ctx = new ZContext()) {
+                Socket client = ctx.createSocket(ZMQ.REQ);
+                client.connect(String.format("ipc://%s-localfe.ipc", self));
+                Socket monitor = ctx.createSocket(ZMQ.PUSH);
+                monitor.connect(String.format("ipc://%s-monitor.ipc", self));
+                Random rand = new Random(System.nanoTime());
 
-            Poller poller = ctx.createPoller(1);
-            poller.register(client, Poller.POLLIN);
+                Poller poller = ctx.createPoller(1);
+                poller.register(client, Poller.POLLIN);
 
-            while (true) {
+                boolean done = false;
+                while (!done) {
+                    try {
+                        Thread.sleep(rand.nextInt(5) * 1000);
+                    }
+                    catch (InterruptedException e1) {
+                    }
+                    int burst = rand.nextInt(15);
 
-                try {
-                    Thread.sleep(rand.nextInt(5) * 1000);
-                }
-                catch (InterruptedException e1) {
-                }
-                int burst = rand.nextInt(15);
+                    while (burst > 0) {
+                        String taskId = String.format(
+                            "%04X", rand.nextInt(10000)
+                        );
+                        //  Send request, get reply
+                        client.send(taskId, 0);
 
-                while (burst > 0) {
-                    String taskId = String.format("%04X", rand.nextInt(10000));
-                    //  Send request, get reply
-                    client.send(taskId, 0);
-
-                    //  Wait max ten seconds for a reply, then complain
-                    int rc = poller.poll(10 * 1000);
-                    if (rc == -1)
-                        break; //  Interrupted
-
-                    if (poller.pollin(0)) {
-                        String reply = client.recvStr(0);
-                        if (reply == null)
+                        //  Wait max ten seconds for a reply, then complain
+                        int rc = poller.poll(10 * 1000);
+                        if (rc == -1)
                             break; //  Interrupted
-                        //  Worker is supposed to answer us with our task id
-                        assert (reply.equals(taskId));
-                        monitor.send(String.format("%s", reply), 0);
+
+                        if (poller.pollin(0)) {
+                            String reply = client.recvStr(0);
+                            if (reply == null)
+                                break; //  Interrupted
+                            //  Worker is supposed to answer us with our task id
+                            assert (reply.equals(taskId));
+                            monitor.send(String.format("%s", reply), 0);
+                        }
+                        else {
+                            monitor.send(
+                                String.format(
+                                    "E: CLIENT EXIT - lost task %s", taskId
+                                ),
+                            0);
+                            done = true;
+                            break;
+                        }
+                        burst--;
                     }
-                    else {
-                        monitor.send(String.format("E: CLIENT EXIT - lost task %s", taskId), 0);
-                        ctx.close();
-                        return;
-                    }
-                    burst--;
                 }
             }
         }
@@ -90,31 +98,30 @@ public class peering3
         public void run()
         {
             Random rand = new Random(System.nanoTime());
-            ZContext ctx = new ZContext();
-            Socket worker = ctx.createSocket(ZMQ.REQ);
-            worker.connect(String.format("ipc://%s-localbe.ipc", self));
+            try (ZContext ctx = new ZContext()) {
+                Socket worker = ctx.createSocket(ZMQ.REQ);
+                worker.connect(String.format("ipc://%s-localbe.ipc", self));
 
-            //  Tell broker we're ready for work
-            ZFrame frame = new ZFrame(WORKER_READY);
-            frame.send(worker, 0);
+                //  Tell broker we're ready for work
+                ZFrame frame = new ZFrame(WORKER_READY);
+                frame.send(worker, 0);
 
-            while (true) {
-                //  Send request, get reply
-                ZMsg msg = ZMsg.recvMsg(worker, 0);
-                if (msg == null)
-                    break; //  Interrupted
+                while (true) {
+                    //  Send request, get reply
+                    ZMsg msg = ZMsg.recvMsg(worker, 0);
+                    if (msg == null)
+                        break; //  Interrupted
 
-                //  Workers are busy for 0/1 seconds
-                try {
-                    Thread.sleep(rand.nextInt(2) * 1000);
+                    //  Workers are busy for 0/1 seconds
+                    try {
+                        Thread.sleep(rand.nextInt(2) * 1000);
+                    }
+                    catch (InterruptedException e) {
+                    }
+
+                    msg.send(worker);
                 }
-                catch (InterruptedException e) {
-                }
-
-                msg.send(worker);
-
             }
-            ctx.close();
         }
     }
 
@@ -138,187 +145,189 @@ public class peering3
         System.out.printf("I: preparing broker at %s\n", self);
         Random rand = new Random(System.nanoTime());
 
-        ZContext ctx = new ZContext();
+        try (ZContext ctx = new ZContext()) {
+            //  Prepare local frontend and backend
+            Socket localfe = ctx.createSocket(ZMQ.ROUTER);
+            localfe.bind(String.format("ipc://%s-localfe.ipc", self));
+            Socket localbe = ctx.createSocket(ZMQ.ROUTER);
+            localbe.bind(String.format("ipc://%s-localbe.ipc", self));
 
-        //  Prepare local frontend and backend
-        Socket localfe = ctx.createSocket(ZMQ.ROUTER);
-        localfe.bind(String.format("ipc://%s-localfe.ipc", self));
-        Socket localbe = ctx.createSocket(ZMQ.ROUTER);
-        localbe.bind(String.format("ipc://%s-localbe.ipc", self));
+            //  Bind cloud frontend to endpoint
+            Socket cloudfe = ctx.createSocket(ZMQ.ROUTER);
+            cloudfe.setIdentity(self.getBytes(ZMQ.CHARSET));
+            cloudfe.bind(String.format("ipc://%s-cloud.ipc", self));
 
-        //  Bind cloud frontend to endpoint
-        Socket cloudfe = ctx.createSocket(ZMQ.ROUTER);
-        cloudfe.setIdentity(self.getBytes(ZMQ.CHARSET));
-        cloudfe.bind(String.format("ipc://%s-cloud.ipc", self));
+            //  Connect cloud backend to all peers
+            Socket cloudbe = ctx.createSocket(ZMQ.ROUTER);
+            cloudbe.setIdentity(self.getBytes(ZMQ.CHARSET));
+            int argn;
+            for (argn = 1; argn < argv.length; argn++) {
+                String peer = argv[argn];
+                System.out.printf(
+                    "I: connecting to cloud forintend at '%s'\n", peer
+                );
+                cloudbe.connect(String.format("ipc://%s-cloud.ipc", peer));
+            }
 
-        //  Connect cloud backend to all peers
-        Socket cloudbe = ctx.createSocket(ZMQ.ROUTER);
-        cloudbe.setIdentity(self.getBytes(ZMQ.CHARSET));
-        int argn;
-        for (argn = 1; argn < argv.length; argn++) {
-            String peer = argv[argn];
-            System.out.printf("I: connecting to cloud forintend at '%s'\n", peer);
-            cloudbe.connect(String.format("ipc://%s-cloud.ipc", peer));
-        }
+            //  Bind state backend to endpoint
+            Socket statebe = ctx.createSocket(ZMQ.PUB);
+            statebe.bind(String.format("ipc://%s-state.ipc", self));
 
-        //  Bind state backend to endpoint
-        Socket statebe = ctx.createSocket(ZMQ.PUB);
-        statebe.bind(String.format("ipc://%s-state.ipc", self));
+            //  Connect statefe to all peers
+            Socket statefe = ctx.createSocket(ZMQ.SUB);
+            statefe.subscribe(ZMQ.SUBSCRIPTION_ALL);
+            for (argn = 1; argn < argv.length; argn++) {
+                String peer = argv[argn];
+                System.out.printf(
+                    "I: connecting to state backend at '%s'\n", peer
+                );
+                statefe.connect(String.format("ipc://%s-state.ipc", peer));
+            }
 
-        //  Connect statefe to all peers
-        Socket statefe = ctx.createSocket(ZMQ.SUB);
-        statefe.subscribe(ZMQ.SUBSCRIPTION_ALL);
-        for (argn = 1; argn < argv.length; argn++) {
-            String peer = argv[argn];
-            System.out.printf("I: connecting to state backend at '%s'\n", peer);
-            statefe.connect(String.format("ipc://%s-state.ipc", peer));
-        }
+            //  Prepare monitor socket
+            Socket monitor = ctx.createSocket(ZMQ.PULL);
+            monitor.bind(String.format("ipc://%s-monitor.ipc", self));
 
-        //  Prepare monitor socket
-        Socket monitor = ctx.createSocket(ZMQ.PULL);
-        monitor.bind(String.format("ipc://%s-monitor.ipc", self));
+            //  Start local workers
+            int worker_nbr;
+            for (worker_nbr = 0; worker_nbr < NBR_WORKERS; worker_nbr++)
+                new worker_task().start();
 
-        //  Start local workers
-        int worker_nbr;
-        for (worker_nbr = 0; worker_nbr < NBR_WORKERS; worker_nbr++)
-            new worker_task().start();
+            //  Start local clients
+            int client_nbr;
+            for (client_nbr = 0; client_nbr < NBR_CLIENTS; client_nbr++)
+                new client_task().start();
 
-        //  Start local clients
-        int client_nbr;
-        for (client_nbr = 0; client_nbr < NBR_CLIENTS; client_nbr++)
-            new client_task().start();
+            //  Queue of available workers
+            int localCapacity = 0;
+            int cloudCapacity = 0;
+            ArrayList<ZFrame> workers = new ArrayList<ZFrame>();
 
-        //  Queue of available workers
-        int localCapacity = 0;
-        int cloudCapacity = 0;
-        ArrayList<ZFrame> workers = new ArrayList<ZFrame>();
+            //  The main loop has two parts. First we poll workers and our two
+            //  service sockets (statefe and monitor), in any case. If we have
+            //  no ready workers, there's no point in looking at incoming
+            //  requests. These can remain on their internal 0MQ queues:
+            Poller primary = ctx.createPoller(4);
+            primary.register(localbe, Poller.POLLIN);
+            primary.register(cloudbe, Poller.POLLIN);
+            primary.register(statefe, Poller.POLLIN);
+            primary.register(monitor, Poller.POLLIN);
 
-        //  The main loop has two parts. First we poll workers and our two service
-        //  sockets (statefe and monitor), in any case. If we have no ready workers,
-        //  there's no point in looking at incoming requests. These can remain on
-        //  their internal 0MQ queues:
-        Poller primary = ctx.createPoller(4);
-        primary.register(localbe, Poller.POLLIN);
-        primary.register(cloudbe, Poller.POLLIN);
-        primary.register(statefe, Poller.POLLIN);
-        primary.register(monitor, Poller.POLLIN);
+            Poller secondary = ctx.createPoller(2);
+            secondary.register(localfe, Poller.POLLIN);
+            secondary.register(cloudfe, Poller.POLLIN);
 
-        Poller secondary = ctx.createPoller(2);
-        secondary.register(localfe, Poller.POLLIN);
-        secondary.register(cloudfe, Poller.POLLIN);
+            while (true) {
+                //  First, route any waiting replies from workers
 
-        while (true) {
-            //  First, route any waiting replies from workers
-
-            //  If we have no workers anyhow, wait indefinitely
-            int rc = primary.poll(localCapacity > 0 ? 1000 : -1);
-            if (rc == -1)
-                break; //  Interrupted
-
-            //  Track if capacity changes during this iteration
-            int previous = localCapacity;
-
-            //  Handle reply from local worker
-            ZMsg msg = null;
-            if (primary.pollin(0)) {
-                msg = ZMsg.recvMsg(localbe);
-                if (msg == null)
+                //  If we have no workers anyhow, wait indefinitely
+                int rc = primary.poll(localCapacity > 0 ? 1000 : -1);
+                if (rc == -1)
                     break; //  Interrupted
-                ZFrame address = msg.unwrap();
-                workers.add(address);
-                localCapacity++;
 
-                //  If it's READY, don't route the message any further
-                ZFrame frame = msg.getFirst();
-                if (new String(frame.getData(), ZMQ.CHARSET).equals(WORKER_READY)) {
-                    msg.destroy();
-                    msg = null;
+                //  Track if capacity changes during this iteration
+                int previous = localCapacity;
+
+                //  Handle reply from local worker
+                ZMsg msg = null;
+                if (primary.pollin(0)) {
+                    msg = ZMsg.recvMsg(localbe);
+                    if (msg == null)
+                        break; //  Interrupted
+                    ZFrame address = msg.unwrap();
+                    workers.add(address);
+                    localCapacity++;
+
+                    //  If it's READY, don't route the message any further
+                    ZFrame frame = msg.getFirst();
+                    String frameData = new String(frame.getData(), ZMQ.CHARSET);
+                    if (frameData.equals(WORKER_READY)) {
+                        msg.destroy();
+                        msg = null;
+                    }
+                }
+                //  Or handle reply from peer broker
+                else if (primary.pollin(1)) {
+                    msg = ZMsg.recvMsg(cloudbe);
+                    if (msg == null)
+                        break; //  Interrupted
+                    //  We don't use peer broker address for anything
+                    ZFrame address = msg.unwrap();
+                    address.destroy();
+                }
+                //  Route reply to cloud if it's addressed to a broker
+                for (argn = 1; msg != null && argn < argv.length; argn++) {
+                    byte[] data = msg.getFirst().getData();
+                    if (argv[argn].equals(new String(data, ZMQ.CHARSET))) {
+                        msg.send(cloudfe);
+                        msg = null;
+                    }
+                }
+                //  Route reply to client if we still need to
+                if (msg != null)
+                    msg.send(localfe);
+
+                //  If we have input messages on our statefe or monitor sockets
+                //  we can process these immediately:
+
+                if (primary.pollin(2)) {
+                    String peer = statefe.recvStr();
+                    String status = statefe.recvStr();
+                    cloudCapacity = Integer.parseInt(status);
+                }
+                if (primary.pollin(3)) {
+                    String status = monitor.recvStr();
+                    System.out.println(status);
+                }
+
+                //  Now we route as many client requests as we have worker
+                //  capacity for. We may reroute requests from our local
+                //  frontend, but not from the cloud frontend. We reroute
+                //  randomly now, just to test things out. In the next version
+                //  we'll do this properly by calculating cloud capacity.
+
+                while (localCapacity + cloudCapacity > 0) {
+                    rc = secondary.poll(0);
+
+                    assert (rc >= 0);
+
+                    if (secondary.pollin(0)) {
+                        msg = ZMsg.recvMsg(localfe);
+                    }
+                    else if (localCapacity > 0 && secondary.pollin(1)) {
+                        msg = ZMsg.recvMsg(cloudfe);
+                    }
+                    else break; //  No work, go back to backends
+
+                    if (localCapacity > 0) {
+                        ZFrame frame = workers.remove(0);
+                        msg.wrap(frame);
+                        msg.send(localbe);
+                        localCapacity--;
+
+                    }
+                    else {
+                        //  Route to random broker peer
+                        int random_peer = rand.nextInt(argv.length - 1) + 1;
+                        msg.push(argv[random_peer]);
+                        msg.send(cloudbe);
+                    }
+                }
+
+                //  We broadcast capacity messages to other peers; to reduce
+                //  chatter we do this only if our capacity changed.
+                if (localCapacity != previous) {
+                    //  We stick our own address onto the envelope
+                    statebe.sendMore(self);
+                    //  Broadcast new capacity
+                    statebe.send(String.format("%d", localCapacity), 0);
                 }
             }
-            //  Or handle reply from peer broker
-            else if (primary.pollin(1)) {
-                msg = ZMsg.recvMsg(cloudbe);
-                if (msg == null)
-                    break; //  Interrupted
-                //  We don't use peer broker address for anything
-                ZFrame address = msg.unwrap();
-                address.destroy();
-            }
-            //  Route reply to cloud if it's addressed to a broker
-            for (argn = 1; msg != null && argn < argv.length; argn++) {
-                byte[] data = msg.getFirst().getData();
-                if (argv[argn].equals(new String(data, ZMQ.CHARSET))) {
-                    msg.send(cloudfe);
-                    msg = null;
-                }
-            }
-            //  Route reply to client if we still need to
-            if (msg != null)
-                msg.send(localfe);
-
-            //  If we have input messages on our statefe or monitor sockets we
-            //  can process these immediately:
-
-            if (primary.pollin(2)) {
-                String peer = statefe.recvStr();
-                String status = statefe.recvStr();
-                cloudCapacity = Integer.parseInt(status);
-            }
-            if (primary.pollin(3)) {
-                String status = monitor.recvStr();
-                System.out.println(status);
-            }
-
-            //  Now we route as many client requests as we have worker capacity
-            //  for. We may reroute requests from our local frontend, but not from //
-            //  the cloud frontend. We reroute randomly now, just to test things
-            //  out. In the next version we'll do this properly by calculating
-            //  cloud capacity://
-
-            while (localCapacity + cloudCapacity > 0) {
-                rc = secondary.poll(0);
-
-                assert (rc >= 0);
-
-                if (secondary.pollin(0)) {
-                    msg = ZMsg.recvMsg(localfe);
-                }
-                else if (localCapacity > 0 && secondary.pollin(1)) {
-                    msg = ZMsg.recvMsg(cloudfe);
-                }
-                else break; //  No work, go back to backends
-
-                if (localCapacity > 0) {
-                    ZFrame frame = workers.remove(0);
-                    msg.wrap(frame);
-                    msg.send(localbe);
-                    localCapacity--;
-
-                }
-                else {
-                    //  Route to random broker peer
-                    int random_peer = rand.nextInt(argv.length - 1) + 1;
-                    msg.push(argv[random_peer]);
-                    msg.send(cloudbe);
-                }
-            }
-
-            //  We broadcast capacity messages to other peers; to reduce chatter
-            //  we do this only if our capacity changed.
-
-            if (localCapacity != previous) {
-                //  We stick our own address onto the envelope
-                statebe.sendMore(self);
-                //  Broadcast new capacity
-                statebe.send(String.format("%d", localCapacity), 0);
+            //  When we're done, clean up properly
+            while (workers.size() > 0) {
+                ZFrame frame = workers.remove(0);
+                frame.destroy();
             }
         }
-        //  When we're done, clean up properly
-        while (workers.size() > 0) {
-            ZFrame frame = workers.remove(0);
-            frame.destroy();
-        }
-
-        ctx.close();
     }
 }

--- a/src/test/java/guide/ppworker.java
+++ b/src/test/java/guide/ppworker.java
@@ -14,7 +14,6 @@ import org.zeromq.ZMsg;
 //
 public class ppworker
 {
-
     private final static int HEARTBEAT_LIVENESS = 3;     //  3-5 is reasonable
     private final static int HEARTBEAT_INTERVAL = 1000;  //  msecs
     private final static int INTERVAL_INIT      = 1000;  //  Initial reconnect
@@ -47,115 +46,124 @@ public class ppworker
 
     public static void main(String[] args)
     {
-        ZContext ctx = new ZContext();
-        Socket worker = worker_socket(ctx);
+        try (ZContext ctx = new ZContext()) {
+            Socket worker = worker_socket(ctx);
 
-        Poller poller = ctx.createPoller(1);
-        poller.register(worker, Poller.POLLIN);
+            Poller poller = ctx.createPoller(1);
+            poller.register(worker, Poller.POLLIN);
 
-        //  If liveness hits zero, queue is considered disconnected
-        int liveness = HEARTBEAT_LIVENESS;
-        int interval = INTERVAL_INIT;
+            //  If liveness hits zero, queue is considered disconnected
+            int liveness = HEARTBEAT_LIVENESS;
+            int interval = INTERVAL_INIT;
 
-        //  Send out heartbeats at regular intervals
-        long heartbeat_at = System.currentTimeMillis() + HEARTBEAT_INTERVAL;
+            //  Send out heartbeats at regular intervals
+            long heartbeat_at = System.currentTimeMillis() + HEARTBEAT_INTERVAL;
 
-        Random rand = new Random(System.nanoTime());
-        int cycles = 0;
-        while (true) {
-            int rc = poller.poll(HEARTBEAT_INTERVAL);
-            if (rc == -1)
-                break; //  Interrupted
-
-            if (poller.pollin(0)) {
-                //  Get message
-                //  - 3-part envelope + content -> request
-                //  - 1-part HEARTBEAT -> heartbeat
-                ZMsg msg = ZMsg.recvMsg(worker);
-                if (msg == null)
+            Random rand = new Random(System.nanoTime());
+            int cycles = 0;
+            while (true) {
+                int rc = poller.poll(HEARTBEAT_INTERVAL);
+                if (rc == -1)
                     break; //  Interrupted
 
-                //  To test the robustness of the queue implementation we //
-                //  simulate various typical problems, such as the worker
-                //  crashing, or running very slowly. We do this after a few
-                //  cycles so that the architecture can get up and running
-                //  first:
-                if (msg.size() == 3) {
-                    cycles++;
-                    if (cycles > 3 && rand.nextInt(5) == 0) {
-                        System.out.println("I: simulating a crash\n");
-                        msg.destroy();
-                        msg = null;
-                        break;
-                    }
-                    else if (cycles > 3 && rand.nextInt(5) == 0) {
-                        System.out.println("I: simulating CPU overload\n");
+                if (poller.pollin(0)) {
+                    //  Get message
+                    //  - 3-part envelope + content -> request
+                    //  - 1-part HEARTBEAT -> heartbeat
+                    ZMsg msg = ZMsg.recvMsg(worker);
+                    if (msg == null)
+                        break; //  Interrupted
+
+                    //  To test the robustness of the queue implementation we
+                    //  simulate various typical problems, such as the worker
+                    //  crashing, or running very slowly. We do this after a few
+                    //  cycles so that the architecture can get up and running
+                    //  first:
+                    if (msg.size() == 3) {
+                        cycles++;
+                        if (cycles > 3 && rand.nextInt(5) == 0) {
+                            System.out.println("I: simulating a crash\n");
+                            msg.destroy();
+                            msg = null;
+                            break;
+                        }
+                        else if (cycles > 3 && rand.nextInt(5) == 0) {
+                            System.out.println("I: simulating CPU overload\n");
+                            try {
+                                Thread.sleep(3000);
+                            }
+                            catch (InterruptedException e) {
+                                break;
+                            }
+                        }
+                        System.out.println("I: normal reply\n");
+                        msg.send(worker);
+                        liveness = HEARTBEAT_LIVENESS;
                         try {
-                            Thread.sleep(3000);
+                            Thread.sleep(1000);
                         }
                         catch (InterruptedException e) {
                             break;
+                        } //  Do some heavy work
+                    }
+                    else
+                        //  When we get a heartbeat message from the queue, it
+                        //  means the queue was (recently) alive, so reset our
+                        //  liveness indicator:
+                        if (msg.size() == 1) {
+                            ZFrame frame = msg.getFirst();
+                            String frameData = new String(
+                                frame.getData(), ZMQ.CHARSET
+                            );
+                            if (PPP_HEARTBEAT.equals(frameData))
+                                liveness = HEARTBEAT_LIVENESS;
+                            else {
+                                System.out.println("E: invalid message\n");
+                                msg.dump(System.out);
+                            }
+                            msg.destroy();
                         }
-                    }
-                    System.out.println("I: normal reply\n");
-                    msg.send(worker);
-                    liveness = HEARTBEAT_LIVENESS;
-                    try {
-                        Thread.sleep(1000);
-                    }
-                    catch (InterruptedException e) {
-                        break;
-                    } //  Do some heavy work
+                        else {
+                            System.out.println("E: invalid message\n");
+                            msg.dump(System.out);
+                        }
+                    interval = INTERVAL_INIT;
                 }
                 else
-                //  When we get a heartbeat message from the queue, it means the
-                //  queue was (recently) alive, so reset our liveness indicator:
-                if (msg.size() == 1) {
-                    ZFrame frame = msg.getFirst();
-                    if (PPP_HEARTBEAT.equals(new String(frame.getData(), ZMQ.CHARSET)))
+                    //  If the queue hasn't sent us heartbeats in a while,
+                    //  destroy the socket and reconnect. This is the simplest
+                    //  most brutal way of discarding any messages we might have
+                    //  sent in the meantime.
+                    if (--liveness == 0) {
+                        System.out.println(
+                            "W: heartbeat failure, can't reach queue\n"
+                        );
+                        System.out.printf(
+                            "W: reconnecting in %sd msec\n", interval
+                        );
+                        try {
+                            Thread.sleep(interval);
+                        }
+                        catch (InterruptedException e) {
+                            e.printStackTrace();
+                        }
+
+                        if (interval < INTERVAL_MAX)
+                            interval *= 2;
+                        ctx.destroySocket(worker);
+                        worker = worker_socket(ctx);
                         liveness = HEARTBEAT_LIVENESS;
-                    else {
-                        System.out.println("E: invalid message\n");
-                        msg.dump(System.out);
                     }
-                    msg.destroy();
-                }
-                else {
-                    System.out.println("E: invalid message\n");
-                    msg.dump(System.out);
-                }
-                interval = INTERVAL_INIT;
-            }
-            else
-            //  If the queue hasn't sent us heartbeats in a while, destroy the
-            //  socket and reconnect. This is the simplest most brutal way of
-            //  discarding any messages we might have sent in the meantime://
-            if (--liveness == 0) {
-                System.out.println("W: heartbeat failure, can't reach queue\n");
-                System.out.printf("W: reconnecting in %sd msec\n", interval);
-                try {
-                    Thread.sleep(interval);
-                }
-                catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
 
-                if (interval < INTERVAL_MAX)
-                    interval *= 2;
-                ctx.destroySocket(worker);
-                worker = worker_socket(ctx);
-                liveness = HEARTBEAT_LIVENESS;
-            }
-
-            //  Send heartbeat to queue if it's time
-            if (System.currentTimeMillis() > heartbeat_at) {
-                heartbeat_at = System.currentTimeMillis() + HEARTBEAT_INTERVAL;
-                System.out.println("I: worker heartbeat\n");
-                ZFrame frame = new ZFrame(PPP_HEARTBEAT);
-                frame.send(worker, 0);
+                //  Send heartbeat to queue if it's time
+                if (System.currentTimeMillis() > heartbeat_at) {
+                    long now = System.currentTimeMillis();
+                    heartbeat_at = now + HEARTBEAT_INTERVAL;
+                    System.out.println("I: worker heartbeat\n");
+                    ZFrame frame = new ZFrame(PPP_HEARTBEAT);
+                    frame.send(worker, 0);
+                }
             }
         }
-        ctx.close();
     }
-
 }

--- a/src/test/java/guide/psenvpub.java
+++ b/src/test/java/guide/psenvpub.java
@@ -1,8 +1,8 @@
 package guide;
 
 import org.zeromq.ZMQ;
-import org.zeromq.ZMQ.Context;
 import org.zeromq.ZMQ.Socket;
+import org.zeromq.ZContext;
 
 /**
  * Pubsub envelope publisher
@@ -14,18 +14,17 @@ public class psenvpub
     public static void main(String[] args) throws Exception
     {
         // Prepare our context and publisher
-        Context context = ZMQ.context(1);
-        Socket publisher = context.socket(ZMQ.PUB);
+        try (ZContext context = new ZContext()) {
+            Socket publisher = context.createSocket(ZMQ.PUB);
+            publisher.bind("tcp://*:5563");
 
-        publisher.bind("tcp://*:5563");
-        while (!Thread.currentThread().isInterrupted()) {
-            // Write two messages, each with an envelope and content
-            publisher.sendMore("A");
-            publisher.send("We don't want to see this");
-            publisher.sendMore("B");
-            publisher.send("We would like to see this");
+            while (!Thread.currentThread().isInterrupted()) {
+                // Write two messages, each with an envelope and content
+                publisher.sendMore("A");
+                publisher.send("We don't want to see this");
+                publisher.sendMore("B");
+                publisher.send("We would like to see this");
+            }
         }
-        publisher.close();
-        context.term();
     }
 }

--- a/src/test/java/guide/psenvsub.java
+++ b/src/test/java/guide/psenvsub.java
@@ -1,8 +1,8 @@
 package guide;
 
 import org.zeromq.ZMQ;
-import org.zeromq.ZMQ.Context;
 import org.zeromq.ZMQ.Socket;
+import org.zeromq.ZContext;
 
 /**
  * Pubsub envelope subscriber
@@ -13,21 +13,19 @@ public class psenvsub
 
     public static void main(String[] args)
     {
-
         // Prepare our context and subscriber
-        Context context = ZMQ.context(1);
-        Socket subscriber = context.socket(ZMQ.SUB);
+        try (ZContext context = new ZContext()) {
+            Socket subscriber = context.createSocket(ZMQ.SUB);
+            subscriber.connect("tcp://localhost:5563");
+            subscriber.subscribe("B".getBytes(ZMQ.CHARSET));
 
-        subscriber.connect("tcp://localhost:5563");
-        subscriber.subscribe("B".getBytes(ZMQ.CHARSET));
-        while (!Thread.currentThread().isInterrupted()) {
-            // Read envelope with address
-            String address = subscriber.recvStr();
-            // Read message contents
-            String contents = subscriber.recvStr();
-            System.out.println(address + " : " + contents);
+            while (!Thread.currentThread().isInterrupted()) {
+                // Read envelope with address
+                String address = subscriber.recvStr();
+                // Read message contents
+                String contents = subscriber.recvStr();
+                System.out.println(address + " : " + contents);
+            }
         }
-        subscriber.close();
-        context.term();
     }
 }

--- a/src/test/java/guide/rrbroker.java
+++ b/src/test/java/guide/rrbroker.java
@@ -1,9 +1,9 @@
 package guide;
 
 import org.zeromq.ZMQ;
-import org.zeromq.ZMQ.Context;
 import org.zeromq.ZMQ.Poller;
 import org.zeromq.ZMQ.Socket;
+import org.zeromq.ZContext;
 
 /**
 * Simple request-reply broker
@@ -15,58 +15,54 @@ public class rrbroker
     public static void main(String[] args)
     {
         //  Prepare our context and sockets
-        Context context = ZMQ.context(1);
+        try (ZContext context = new ZContext()) {
+            Socket frontend = context.createSocket(ZMQ.ROUTER);
+            Socket backend = context.createSocket(ZMQ.DEALER);
+            frontend.bind("tcp://*:5559");
+            backend.bind("tcp://*:5560");
 
-        Socket frontend = context.socket(ZMQ.ROUTER);
-        Socket backend = context.socket(ZMQ.DEALER);
-        frontend.bind("tcp://*:5559");
-        backend.bind("tcp://*:5560");
+            System.out.println("launch and connect broker.");
 
-        System.out.println("launch and connect broker.");
+            //  Initialize poll set
+            Poller items = context.createPoller(2);
+            items.register(frontend, Poller.POLLIN);
+            items.register(backend, Poller.POLLIN);
 
-        //  Initialize poll set
-        Poller items = context.poller(2);
-        items.register(frontend, Poller.POLLIN);
-        items.register(backend, Poller.POLLIN);
+            boolean more = false;
+            byte[] message;
 
-        boolean more = false;
-        byte[] message;
+            //  Switch messages between sockets
+            while (!Thread.currentThread().isInterrupted()) {
+                //  poll and memorize multipart detection
+                items.poll();
 
-        //  Switch messages between sockets
-        while (!Thread.currentThread().isInterrupted()) {
-            //  poll and memorize multipart detection
-            items.poll();
+                if (items.pollin(0)) {
+                    while (true) {
+                        // receive message
+                        message = frontend.recv(0);
+                        more = frontend.hasReceiveMore();
 
-            if (items.pollin(0)) {
-                while (true) {
-                    // receive message
-                    message = frontend.recv(0);
-                    more = frontend.hasReceiveMore();
-
-                    // Broker it
-                    backend.send(message, more ? ZMQ.SNDMORE : 0);
-                    if (!more) {
-                        break;
+                        // Broker it
+                        backend.send(message, more ? ZMQ.SNDMORE : 0);
+                        if (!more) {
+                            break;
+                        }
                     }
                 }
-            }
-            if (items.pollin(1)) {
-                while (true) {
-                    // receive message
-                    message = backend.recv(0);
-                    more = backend.hasReceiveMore();
-                    // Broker it
-                    frontend.send(message, more ? ZMQ.SNDMORE : 0);
-                    if (!more) {
-                        break;
+
+                if (items.pollin(1)) {
+                    while (true) {
+                        // receive message
+                        message = backend.recv(0);
+                        more = backend.hasReceiveMore();
+                        // Broker it
+                        frontend.send(message, more ? ZMQ.SNDMORE : 0);
+                        if (!more) {
+                            break;
+                        }
                     }
                 }
             }
         }
-        //  We never get here but clean up anyhow
-        items.close();
-        frontend.close();
-        backend.close();
-        context.term();
     }
 }

--- a/src/test/java/guide/rrclient.java
+++ b/src/test/java/guide/rrclient.java
@@ -1,8 +1,8 @@
 package guide;
 
 import org.zeromq.ZMQ;
-import org.zeromq.ZMQ.Context;
 import org.zeromq.ZMQ.Socket;
+import org.zeromq.ZContext;
 
 /**
 * Hello World client
@@ -14,21 +14,20 @@ public class rrclient
 
     public static void main(String[] args)
     {
-        Context context = ZMQ.context(1);
+        try (ZContext context = new ZContext()) {
+            //  Socket to talk to server
+            Socket requester = context.createSocket(ZMQ.REQ);
+            requester.connect("tcp://localhost:5559");
 
-        //  Socket to talk to server
-        Socket requester = context.socket(ZMQ.REQ);
-        requester.connect("tcp://localhost:5559");
+            System.out.println("launch and connect client.");
 
-        System.out.println("launch and connect client.");
-
-        for (int request_nbr = 0; request_nbr < 10; request_nbr++) {
-            requester.send("Hello", 0);
-            String reply = requester.recvStr(0);
-            System.out.println("Received reply " + request_nbr + " [" + reply + "]");
+            for (int request_nbr = 0; request_nbr < 10; request_nbr++) {
+                requester.send("Hello", 0);
+                String reply = requester.recvStr(0);
+                System.out.println(
+                    "Received reply " + request_nbr + " [" + reply + "]"
+                );
+            }
         }
-
-        requester.close();
-        context.term();
     }
 }

--- a/src/test/java/guide/rtdealer.java
+++ b/src/test/java/guide/rtdealer.java
@@ -3,8 +3,8 @@ package guide;
 import java.util.Random;
 
 import org.zeromq.ZMQ;
-import org.zeromq.ZMQ.Context;
 import org.zeromq.ZMQ.Socket;
+import org.zeromq.ZContext;
 
 /**
  * ROUTER-TO-REQ example
@@ -16,42 +16,39 @@ public class rtdealer
 
     private static class Worker extends Thread
     {
-
         @Override
         public void run()
         {
+            try (ZContext context = new ZContext()) {
+                Socket worker = context.createSocket(ZMQ.DEALER);
+                ZHelper.setId(worker); //  Set a printable identity
 
-            Context context = ZMQ.context(1);
-            Socket worker = context.socket(ZMQ.DEALER);
-            ZHelper.setId(worker); //  Set a printable identity
+                worker.connect("tcp://localhost:5671");
 
-            worker.connect("tcp://localhost:5671");
+                int total = 0;
+                while (true) {
+                    //  Tell the broker we're ready for work
+                    worker.sendMore("");
+                    worker.send("Hi Boss");
 
-            int total = 0;
-            while (true) {
-                //  Tell the broker we're ready for work
-                worker.sendMore("");
-                worker.send("Hi Boss");
+                    //  Get workload from broker, until finished
+                    worker.recvStr(); //  Envelope delimiter
+                    String workload = worker.recvStr();
+                    boolean finished = workload.equals("Fired!");
+                    if (finished) {
+                        System.out.printf("Completed: %d tasks\n", total);
+                        break;
+                    }
+                    total++;
 
-                //  Get workload from broker, until finished
-                worker.recvStr(); //  Envelope delimiter
-                String workload = worker.recvStr();
-                boolean finished = workload.equals("Fired!");
-                if (finished) {
-                    System.out.printf("Completed: %d tasks\n", total);
-                    break;
-                }
-                total++;
-
-                //  Do some random work
-                try {
-                    Thread.sleep(rand.nextInt(500) + 1);
-                }
-                catch (InterruptedException e) {
+                    //  Do some random work
+                    try {
+                        Thread.sleep(rand.nextInt(500) + 1);
+                    }
+                    catch (InterruptedException e) {
+                    }
                 }
             }
-            worker.close();
-            context.term();
         }
     }
 
@@ -62,37 +59,35 @@ public class rtdealer
      */
     public static void main(String[] args) throws Exception
     {
-        Context context = ZMQ.context(1);
-        Socket broker = context.socket(ZMQ.ROUTER);
-        broker.bind("tcp://*:5671");
+        try (ZContext context = new ZContext()) {
+            Socket broker = context.createSocket(ZMQ.ROUTER);
+            broker.bind("tcp://*:5671");
 
-        for (int workerNbr = 0; workerNbr < NBR_WORKERS; workerNbr++) {
-            Thread worker = new Worker();
-            worker.start();
-        }
+            for (int workerNbr = 0; workerNbr < NBR_WORKERS; workerNbr++) {
+                Thread worker = new Worker();
+                worker.start();
+            }
 
-        //  Run for five seconds and then tell workers to end
-        long endTime = System.currentTimeMillis() + 5000;
-        int workersFired = 0;
-        while (true) {
-            //  Next message gives us least recently used worker
-            String identity = broker.recvStr();
-            broker.sendMore(identity);
-            broker.recv(0); //  Envelope delimiter
-            broker.recv(0); //  Response from worker
-            broker.sendMore("");
+            //  Run for five seconds and then tell workers to end
+            long endTime = System.currentTimeMillis() + 5000;
+            int workersFired = 0;
+            while (true) {
+                //  Next message gives us least recently used worker
+                String identity = broker.recvStr();
+                broker.sendMore(identity);
+                broker.recv(0); //  Envelope delimiter
+                broker.recv(0); //  Response from worker
+                broker.sendMore("");
 
-            //  Encourage workers until it's time to fire them
-            if (System.currentTimeMillis() < endTime)
-                broker.send("Work harder");
-            else {
-                broker.send("Fired!");
-                if (++workersFired == NBR_WORKERS)
-                    break;
+                //  Encourage workers until it's time to fire them
+                if (System.currentTimeMillis() < endTime)
+                    broker.send("Work harder");
+                else {
+                    broker.send("Fired!");
+                    if (++workersFired == NBR_WORKERS)
+                        break;
+                }
             }
         }
-
-        broker.close();
-        context.term();
     }
 }

--- a/src/test/java/guide/rtmama.java
+++ b/src/test/java/guide/rtmama.java
@@ -1,6 +1,7 @@
 package guide;
 
 import org.zeromq.ZMQ;
+import org.zeromq.ZContext;
 
 //
 //Custom routing Router to Mama (ROUTER to REQ)
@@ -16,61 +17,56 @@ public class rtmama
 
         public void run()
         {
-            ZMQ.Context context = ZMQ.context(1);
-            ZMQ.Socket worker = context.socket(ZMQ.REQ);
-            // worker.setIdentity(); will set a random id automatically
-            worker.connect("ipc://routing.ipc");
+            try (ZContext context = new ZContext()) {
+                ZMQ.Socket worker = context.createSocket(ZMQ.REQ);
+                // worker.setIdentity(); will set a random id automatically
+                worker.connect("ipc://routing.ipc");
 
-            int total = 0;
-            while (true) {
-                worker.send("ready", 0);
-                byte[] workerload = worker.recv(0);
-                if (new String(workerload, ZMQ.CHARSET).equals("END")) {
-                    System.out.println(String.format("Processs %d tasks.", total));
-                    break;
+                int total = 0;
+                while (true) {
+                    worker.send("ready", 0);
+                    byte[] workerload = worker.recv(0);
+                    if (new String(workerload, ZMQ.CHARSET).equals("END")) {
+                        System.out.println(String.format("Processs %d tasks.", total));
+                        break;
+                    }
+                    total += 1;
                 }
-                total += 1;
             }
-            worker.close();
-            context.term();
         }
     }
 
     public static void main(String[] args)
     {
-        ZMQ.Context context = ZMQ.context(1);
-        ZMQ.Socket client = context.socket(ZMQ.ROUTER);
-        client.bind("ipc://routing.ipc");
+        try (ZContext context = new ZContext()) {
+            ZMQ.Socket client = context.createSocket(ZMQ.ROUTER);
+            client.bind("ipc://routing.ipc");
 
-        for (int i = 0; i != NBR_WORKERS; i++) {
-            new Thread(new Worker()).start();
+            for (int i = 0; i != NBR_WORKERS; i++) {
+                new Thread(new Worker()).start();
+            }
+
+            for (int i = 0; i != NBR_WORKERS; i++) {
+                //  LRU worker is next waiting in queue
+                byte[] address = client.recv(0);
+                byte[] empty = client.recv(0);
+                byte[] ready = client.recv(0);
+
+                client.send(address, ZMQ.SNDMORE);
+                client.send("", ZMQ.SNDMORE);
+                client.send("This is the workload", 0);
+            }
+
+            for (int i = 0; i != NBR_WORKERS; i++) {
+                //  LRU worker is next waiting in queue
+                byte[] address = client.recv(0);
+                byte[] empty = client.recv(0);
+                byte[] ready = client.recv(0);
+
+                client.send(address, ZMQ.SNDMORE);
+                client.send("", ZMQ.SNDMORE);
+                client.send("END", 0);
+            }
         }
-
-        for (int i = 0; i != NBR_WORKERS; i++) {
-            //  LRU worker is next waiting in queue
-            byte[] address = client.recv(0);
-            byte[] empty = client.recv(0);
-            byte[] ready = client.recv(0);
-
-            client.send(address, ZMQ.SNDMORE);
-            client.send("", ZMQ.SNDMORE);
-            client.send("This is the workload", 0);
-        }
-
-        for (int i = 0; i != NBR_WORKERS; i++) {
-            //  LRU worker is next waiting in queue
-            byte[] address = client.recv(0);
-            byte[] empty = client.recv(0);
-            byte[] ready = client.recv(0);
-
-            client.send(address, ZMQ.SNDMORE);
-            client.send("", ZMQ.SNDMORE);
-            client.send("END", 0);
-        }
-
-        //  Now ask mamas to shut down and report their results
-        client.close();
-        context.term();
     }
-
 }

--- a/src/test/java/guide/rtpapa.java
+++ b/src/test/java/guide/rtpapa.java
@@ -5,55 +5,47 @@ package guide;
 //
 
 import org.zeromq.ZMQ;
-import org.zeromq.ZMQ.Context;
 import org.zeromq.ZMQ.Socket;
+import org.zeromq.ZContext;
 
 public class rtpapa
 {
-
-    //  We will do this all in one thread to emphasize the getSequence
-    //  of events
+    //  We will do this all in one thread to emphasize the getSequence of events
     public static void main(String[] args)
     {
-        Context context = ZMQ.context(1);
+        try (ZContext context = new ZContext()) {
+            Socket client = context.createSocket(ZMQ.ROUTER);
+            client.bind("ipc://routing.ipc");
 
-        Socket client = context.socket(ZMQ.ROUTER);
-        client.bind("ipc://routing.ipc");
+            Socket worker = context.createSocket(ZMQ.REP);
+            worker.setIdentity("A".getBytes(ZMQ.CHARSET));
+            worker.connect("ipc://routing.ipc");
 
-        Socket worker = context.socket(ZMQ.REP);
-        worker.setIdentity("A".getBytes(ZMQ.CHARSET));
-        worker.connect("ipc://routing.ipc");
+            //  Wait for the worker to connect so that when we send a message
+            //  with routing envelope, it will actually match the worker
+            try {
+                Thread.sleep(1000);
+            }
+            catch (InterruptedException e) {
+                e.printStackTrace();
+            }
 
-        //  Wait for the worker to connect so that when we send a message
-        //  with routing envelope, it will actually match the worker
-        try {
-            Thread.sleep(1000);
+            //  Send papa address, address stack, empty part, and request
+            client.send("A", ZMQ.SNDMORE);
+            client.send("address 3", ZMQ.SNDMORE);
+            client.send("address 2", ZMQ.SNDMORE);
+            client.send("address 1", ZMQ.SNDMORE);
+            client.send("", ZMQ.SNDMORE);
+            client.send("This is the workload", 0);
+
+            //  Worker should get just the workload
+            ZHelper.dump(worker);
+
+            //  We don't play with envelopes in the worker
+            worker.send("This is the reply", 0);
+
+            //  Now dump what we got off the ROUTER socket
+            ZHelper.dump(client);
         }
-        catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-
-        //  Send papa address, address stack, empty part, and request
-        client.send("A", ZMQ.SNDMORE);
-        client.send("address 3", ZMQ.SNDMORE);
-        client.send("address 2", ZMQ.SNDMORE);
-        client.send("address 1", ZMQ.SNDMORE);
-        client.send("", ZMQ.SNDMORE);
-        client.send("This is the workload", 0);
-
-        //  Worker should get just the workload
-        ZHelper.dump(worker);
-
-        //  We don't play with envelopes in the worker
-        worker.send("This is the reply", 0);
-
-        //  Now dump what we got off the ROUTER socket
-        ZHelper.dump(client);
-
-        client.close();
-        worker.close();
-        context.term();
-
     }
-
 }

--- a/src/test/java/guide/rtreq.java
+++ b/src/test/java/guide/rtreq.java
@@ -3,8 +3,8 @@ package guide;
 import java.util.Random;
 
 import org.zeromq.ZMQ;
-import org.zeromq.ZMQ.Context;
 import org.zeromq.ZMQ.Socket;
+import org.zeromq.ZContext;
 
 /**
  * ROUTER-TO-REQ example
@@ -16,40 +16,37 @@ public class rtreq
 
     private static class Worker extends Thread
     {
-
         @Override
         public void run()
         {
+            try (ZContext context = new ZContext()) {
+                Socket worker = context.createSocket(ZMQ.REQ);
+                ZHelper.setId(worker); //  Set a printable identity
 
-            Context context = ZMQ.context(1);
-            Socket worker = context.socket(ZMQ.REQ);
-            ZHelper.setId(worker); //  Set a printable identity
+                worker.connect("tcp://localhost:5671");
 
-            worker.connect("tcp://localhost:5671");
+                int total = 0;
+                while (true) {
+                    //  Tell the broker we're ready for work
+                    worker.send("Hi Boss");
 
-            int total = 0;
-            while (true) {
-                //  Tell the broker we're ready for work
-                worker.send("Hi Boss");
+                    //  Get workload from broker, until finished
+                    String workload = worker.recvStr();
+                    boolean finished = workload.equals("Fired!");
+                    if (finished) {
+                        System.out.printf("Completed: %d tasks\n", total);
+                        break;
+                    }
+                    total++;
 
-                //  Get workload from broker, until finished
-                String workload = worker.recvStr();
-                boolean finished = workload.equals("Fired!");
-                if (finished) {
-                    System.out.printf("Completed: %d tasks\n", total);
-                    break;
-                }
-                total++;
-
-                //  Do some random work
-                try {
-                    Thread.sleep(rand.nextInt(500) + 1);
-                }
-                catch (InterruptedException e) {
+                    //  Do some random work
+                    try {
+                        Thread.sleep(rand.nextInt(500) + 1);
+                    }
+                    catch (InterruptedException e) {
+                    }
                 }
             }
-            worker.close();
-            context.term();
         }
     }
 
@@ -60,37 +57,35 @@ public class rtreq
      */
     public static void main(String[] args) throws Exception
     {
-        Context context = ZMQ.context(1);
-        Socket broker = context.socket(ZMQ.ROUTER);
-        broker.bind("tcp://*:5671");
+        try (ZContext context = new ZContext()) {
+            Socket broker = context.createSocket(ZMQ.ROUTER);
+            broker.bind("tcp://*:5671");
 
-        for (int workerNbr = 0; workerNbr < NBR_WORKERS; workerNbr++) {
-            Thread worker = new Worker();
-            worker.start();
-        }
+            for (int workerNbr = 0; workerNbr < NBR_WORKERS; workerNbr++) {
+                Thread worker = new Worker();
+                worker.start();
+            }
 
-        //  Run for five seconds and then tell workers to end
-        long endTime = System.currentTimeMillis() + 5000;
-        int workersFired = 0;
-        while (true) {
-            //  Next message gives us least recently used worker
-            String identity = broker.recvStr();
-            broker.sendMore(identity);
-            broker.recvStr(); //  Envelope delimiter
-            broker.recvStr(); //  Response from worker
-            broker.sendMore("");
+            //  Run for five seconds and then tell workers to end
+            long endTime = System.currentTimeMillis() + 5000;
+            int workersFired = 0;
+            while (true) {
+                //  Next message gives us least recently used worker
+                String identity = broker.recvStr();
+                broker.sendMore(identity);
+                broker.recvStr(); //  Envelope delimiter
+                broker.recvStr(); //  Response from worker
+                broker.sendMore("");
 
-            //  Encourage workers until it's time to fire them
-            if (System.currentTimeMillis() < endTime)
-                broker.send("Work harder");
-            else {
-                broker.send("Fired!");
-                if (++workersFired == NBR_WORKERS)
-                    break;
+                //  Encourage workers until it's time to fire them
+                if (System.currentTimeMillis() < endTime)
+                    broker.send("Work harder");
+                else {
+                    broker.send("Fired!");
+                    if (++workersFired == NBR_WORKERS)
+                        break;
+                }
             }
         }
-
-        broker.close();
-        context.term();
     }
 }

--- a/src/test/java/guide/spworker.java
+++ b/src/test/java/guide/spworker.java
@@ -20,42 +20,45 @@ public class spworker
 
     public static void main(String[] args) throws Exception
     {
-        ZContext ctx = new ZContext();
-        Socket worker = ctx.createSocket(ZMQ.REQ);
+        try (ZContext ctx = new ZContext()) {
+            Socket worker = ctx.createSocket(ZMQ.REQ);
 
-        //  Set random identity to make tracing easier
-        Random rand = new Random(System.nanoTime());
-        String identity = String.format("%04X-%04X", rand.nextInt(0x10000), rand.nextInt(0x10000));
-        worker.setIdentity(identity.getBytes(ZMQ.CHARSET));
-        worker.connect("tcp://localhost:5556");
+            //  Set random identity to make tracing easier
+            Random rand = new Random(System.nanoTime());
+            String identity = String.format(
+                "%04X-%04X", rand.nextInt(0x10000), rand.nextInt(0x10000)
+            );
+            worker.setIdentity(identity.getBytes(ZMQ.CHARSET));
+            worker.connect("tcp://localhost:5556");
 
-        //  Tell broker we're ready for work
-        System.out.printf("I: (%s) worker ready\n", identity);
-        ZFrame frame = new ZFrame(WORKER_READY);
-        frame.send(worker, 0);
+            //  Tell broker we're ready for work
+            System.out.printf("I: (%s) worker ready\n", identity);
+            ZFrame frame = new ZFrame(WORKER_READY);
+            frame.send(worker, 0);
 
-        int cycles = 0;
-        while (true) {
-            ZMsg msg = ZMsg.recvMsg(worker);
-            if (msg == null)
-                break; //  Interrupted
+            int cycles = 0;
+            while (true) {
+                ZMsg msg = ZMsg.recvMsg(worker);
+                if (msg == null)
+                    break; //  Interrupted
 
-            //  Simulate various problems, after a few cycles
-            cycles++;
-            if (cycles > 3 && rand.nextInt(5) == 0) {
-                System.out.printf("I: (%s) simulating a crash\n", identity);
-                msg.destroy();
-                break;
+                //  Simulate various problems, after a few cycles
+                cycles++;
+                if (cycles > 3 && rand.nextInt(5) == 0) {
+                    System.out.printf("I: (%s) simulating a crash\n", identity);
+                    msg.destroy();
+                    break;
+                }
+                else if (cycles > 3 && rand.nextInt(5) == 0) {
+                    System.out.printf(
+                        "I: (%s) simulating CPU overload\n", identity
+                    );
+                    Thread.sleep(3000);
+                }
+                System.out.printf("I: (%s) normal reply\n", identity);
+                Thread.sleep(1000); //  Do some heavy work
+                msg.send(worker);
             }
-            else if (cycles > 3 && rand.nextInt(5) == 0) {
-                System.out.printf("I: (%s) simulating CPU overload\n", identity);
-                Thread.sleep(3000);
-            }
-            System.out.printf("I: (%s) normal reply\n", identity);
-            Thread.sleep(1000); //  Do some heavy work
-            msg.send(worker);
         }
-        ctx.close();
     }
-
 }

--- a/src/test/java/guide/suisnail.java
+++ b/src/test/java/guide/suisnail.java
@@ -12,13 +12,13 @@ import org.zeromq.ZThread.IAttachedRunnable;
 
 public class suisnail
 {
-    private static final long MAX_ALLOWED_DELAY = 1000;                                  //  msecs
-    private static Random     rand              = new Random(System.currentTimeMillis());
+    private static final long MAX_ALLOWED_DELAY = 1000; //  msecs
+    private static Random rand = new Random(System.currentTimeMillis());
 
-    //  This is our subscriber. It connects to the publisher and subscribes
-    //  to everything. It sleeps for a short time between messages to
-    //  simulate doing too much work. If a message is more than one second
-    //  late, it croaks.
+    //  This is our subscriber. It connects to the publisher and subscribes to
+    //  everything. It sleeps for a short time between messages to simulate
+    //  doing too much work. If a message is more than one second late, it
+    //  croaks.
     private static class Subscriber implements IAttachedRunnable
     {
         @Override
@@ -37,7 +37,9 @@ public class suisnail
 
                 //  Suicide snail logic
                 if (System.currentTimeMillis() - clock > MAX_ALLOWED_DELAY) {
-                    System.err.println("E: subscriber cannot keep up, aborting");
+                    System.err.println(
+                        "E: subscriber cannot keep up, aborting"
+                    );
                     break;
                 }
                 //  Work for 1 msec plus some random additional time
@@ -78,21 +80,20 @@ public class suisnail
                 catch (InterruptedException e) {
                 }
             }
-
         }
     }
 
     //  .split main task
-    //  The main task simply starts a client and a server, and then
-    //  waits for the client to signal that it has died:
+    //  The main task simply starts a client and a server, and then waits for
+    //  the client to signal that it has died:
     public static void main(String[] args) throws Exception
     {
-        ZContext ctx = new ZContext();
-        Socket pubpipe = ZThread.fork(ctx, new Publisher());
-        Socket subpipe = ZThread.fork(ctx, new Subscriber());
-        subpipe.recvStr();
-        pubpipe.send("break");
-        Thread.sleep(100);
-        ctx.destroy();
+        try (ZContext ctx = new ZContext()) {
+            Socket pubpipe = ZThread.fork(ctx, new Publisher());
+            Socket subpipe = ZThread.fork(ctx, new Subscriber());
+            subpipe.recvStr();
+            pubpipe.send("break");
+            Thread.sleep(100);
+        }
     }
 }

--- a/src/test/java/guide/syncsub.java
+++ b/src/test/java/guide/syncsub.java
@@ -1,8 +1,8 @@
 package guide;
 
 import org.zeromq.ZMQ;
-import org.zeromq.ZMQ.Context;
 import org.zeromq.ZMQ.Socket;
+import org.zeromq.ZContext;
 
 /**
 * Synchronized subscriber.
@@ -12,36 +12,32 @@ public class syncsub
 
     public static void main(String[] args)
     {
-        Context context = ZMQ.context(1);
+        try (ZContext context = new ZContext()) {
+            //  First, connect our subscriber socket
+            Socket subscriber = context.createSocket(ZMQ.SUB);
+            subscriber.connect("tcp://localhost:5561");
+            subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
 
-        //  First, connect our subscriber socket
-        Socket subscriber = context.socket(ZMQ.SUB);
-        subscriber.connect("tcp://localhost:5561");
-        subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
+            //  Second, synchronize with publisher
+            Socket syncclient = context.createSocket(ZMQ.REQ);
+            syncclient.connect("tcp://localhost:5562");
 
-        //  Second, synchronize with publisher
-        Socket syncclient = context.socket(ZMQ.REQ);
-        syncclient.connect("tcp://localhost:5562");
+            //  - send a synchronization request
+            syncclient.send(ZMQ.MESSAGE_SEPARATOR, 0);
 
-        //  - send a synchronization request
-        syncclient.send(ZMQ.MESSAGE_SEPARATOR, 0);
+            //  - wait for synchronization reply
+            syncclient.recv(0);
 
-        //  - wait for synchronization reply
-        syncclient.recv(0);
-
-        //  Third, get our updates and report how many we got
-        int update_nbr = 0;
-        while (true) {
-            String string = subscriber.recvStr(0);
-            if (string.equals("END")) {
-                break;
+            //  Third, get our updates and report how many we got
+            int update_nbr = 0;
+            while (true) {
+                String string = subscriber.recvStr(0);
+                if (string.equals("END")) {
+                    break;
+                }
+                update_nbr++;
             }
-            update_nbr++;
+            System.out.println("Received " + update_nbr + " updates.");
         }
-        System.out.println("Received " + update_nbr + " updates.");
-
-        subscriber.close();
-        syncclient.close();
-        context.term();
     }
 }

--- a/src/test/java/guide/tasksink.java
+++ b/src/test/java/guide/tasksink.java
@@ -1,6 +1,7 @@
 package guide;
 
 import org.zeromq.ZMQ;
+import org.zeromq.ZContext;
 
 //
 //  Task sink in Java
@@ -9,38 +10,38 @@ import org.zeromq.ZMQ;
 //
 public class tasksink
 {
-
     public static void main(String[] args) throws Exception
     {
-
         //  Prepare our context and socket
-        ZMQ.Context context = ZMQ.context(1);
-        ZMQ.Socket receiver = context.socket(ZMQ.PULL);
-        receiver.bind("tcp://*:5558");
+        try (ZContext context = new ZContext()) {
+            ZMQ.Socket receiver = context.createSocket(ZMQ.PULL);
+            receiver.bind("tcp://*:5558");
 
-        //  Wait for start of batch
-        String string = new String(receiver.recv(0), ZMQ.CHARSET);
+            //  Wait for start of batch
+            String string = new String(receiver.recv(0), ZMQ.CHARSET);
 
-        //  Start our clock now
-        long tstart = System.currentTimeMillis();
+            //  Start our clock now
+            long tstart = System.currentTimeMillis();
 
-        //  Process 100 confirmations
-        int task_nbr;
-        int total_msec = 0; //  Total calculated cost in msecs
-        for (task_nbr = 0; task_nbr < 100; task_nbr++) {
-            string = new String(receiver.recv(0), ZMQ.CHARSET).trim();
-            if ((task_nbr / 10) * 10 == task_nbr) {
-                System.out.print(":");
+            //  Process 100 confirmations
+            int task_nbr;
+            int total_msec = 0; //  Total calculated cost in msecs
+            for (task_nbr = 0; task_nbr < 100; task_nbr++) {
+                string = new String(receiver.recv(0), ZMQ.CHARSET).trim();
+                if ((task_nbr / 10) * 10 == task_nbr) {
+                    System.out.print(":");
+                }
+                else {
+                    System.out.print(".");
+                }
             }
-            else {
-                System.out.print(".");
-            }
+
+            //  Calculate and report duration of batch
+            long tend = System.currentTimeMillis();
+
+            System.out.println(
+                "\nTotal elapsed time: " + (tend - tstart) + " msec"
+            );
         }
-        //  Calculate and report duration of batch
-        long tend = System.currentTimeMillis();
-
-        System.out.println("\nTotal elapsed time: " + (tend - tstart) + " msec");
-        receiver.close();
-        context.term();
     }
 }

--- a/src/test/java/guide/tasksink2.java
+++ b/src/test/java/guide/tasksink2.java
@@ -1,6 +1,7 @@
 package guide;
 
 import org.zeromq.ZMQ;
+import org.zeromq.ZContext;
 
 /**
  * Task sink - design 2
@@ -8,50 +9,47 @@ import org.zeromq.ZMQ;
  */
 public class tasksink2
 {
-
     public static void main(String[] args) throws Exception
     {
-
         //  Prepare our context and socket
-        ZMQ.Context context = ZMQ.context(1);
-        ZMQ.Socket receiver = context.socket(ZMQ.PULL);
-        receiver.bind("tcp://*:5558");
+        try (ZContext context = new ZContext()) {
+            ZMQ.Socket receiver = context.createSocket(ZMQ.PULL);
+            receiver.bind("tcp://*:5558");
 
-        // Socket for worker control
-        ZMQ.Socket controller = context.socket(ZMQ.PUB);
-        controller.bind("tcp://*:5559");
+            // Socket for worker control
+            ZMQ.Socket controller = context.createSocket(ZMQ.PUB);
+            controller.bind("tcp://*:5559");
 
-        //  Wait for start of batch
-        receiver.recv(0);
-
-        //  Start our clock now
-        long tstart = System.currentTimeMillis();
-
-        //  Process 100 confirmations
-        int task_nbr;
-        for (task_nbr = 0; task_nbr < 100; task_nbr++) {
+            //  Wait for start of batch
             receiver.recv(0);
-            if ((task_nbr / 10) * 10 == task_nbr) {
-                System.out.print(":");
+
+            //  Start our clock now
+            long tstart = System.currentTimeMillis();
+
+            //  Process 100 confirmations
+            int task_nbr;
+            for (task_nbr = 0; task_nbr < 100; task_nbr++) {
+                receiver.recv(0);
+                if ((task_nbr / 10) * 10 == task_nbr) {
+                    System.out.print(":");
+                }
+                else {
+                    System.out.print(".");
+                }
+                System.out.flush();
             }
-            else {
-                System.out.print(".");
-            }
-            System.out.flush();
+            //  Calculate and report duration of batch
+            long tend = System.currentTimeMillis();
+
+            System.out.println(
+                "Total elapsed time: " + (tend - tstart) + " msec"
+            );
+
+            //  Send the kill signal to the workers
+            controller.send("KILL", 0);
+
+            //  Give it some time to deliver
+            Thread.sleep(1);
         }
-        //  Calculate and report duration of batch
-        long tend = System.currentTimeMillis();
-
-        System.out.println("Total elapsed time: " + (tend - tstart) + " msec");
-
-        //  Send the kill signal to the workers
-        controller.send("KILL", 0);
-
-        //  Give it some time to deliver
-        Thread.sleep(1);
-
-        receiver.close();
-        controller.close();
-        context.term();
     }
 }

--- a/src/test/java/guide/taskvent.java
+++ b/src/test/java/guide/taskvent.java
@@ -3,6 +3,7 @@ package guide;
 import java.util.Random;
 
 import org.zeromq.ZMQ;
+import org.zeromq.ZContext;
 
 //
 //  Task ventilator in Java
@@ -11,46 +12,41 @@ import org.zeromq.ZMQ;
 //
 public class taskvent
 {
-
     public static void main(String[] args) throws Exception
     {
-        ZMQ.Context context = ZMQ.context(1);
+        try (ZContext context = new ZContext()) {
+            //  Socket to send messages on
+            ZMQ.Socket sender = context.createSocket(ZMQ.PUSH);
+            sender.bind("tcp://*:5557");
 
-        //  Socket to send messages on
-        ZMQ.Socket sender = context.socket(ZMQ.PUSH);
-        sender.bind("tcp://*:5557");
+            //  Socket to send messages on
+            ZMQ.Socket sink = context.createSocket(ZMQ.PUSH);
+            sink.connect("tcp://localhost:5558");
 
-        //  Socket to send messages on
-        ZMQ.Socket sink = context.socket(ZMQ.PUSH);
-        sink.connect("tcp://localhost:5558");
+            System.out.println("Press Enter when the workers are ready: ");
+            System.in.read();
+            System.out.println("Sending tasks to workers\n");
 
-        System.out.println("Press Enter when the workers are ready: ");
-        System.in.read();
-        System.out.println("Sending tasks to workers\n");
+            //  The first message is "0" and signals start of batch
+            sink.send("0", 0);
 
-        //  The first message is "0" and signals start of batch
-        sink.send("0", 0);
+            //  Initialize random number generator
+            Random srandom = new Random(System.currentTimeMillis());
 
-        //  Initialize random number generator
-        Random srandom = new Random(System.currentTimeMillis());
-
-        //  Send 100 tasks
-        int task_nbr;
-        int total_msec = 0; //  Total expected cost in msecs
-        for (task_nbr = 0; task_nbr < 100; task_nbr++) {
-            int workload;
-            //  Random workload from 1 to 100msecs
-            workload = srandom.nextInt(100) + 1;
-            total_msec += workload;
-            System.out.print(workload + ".");
-            String string = String.format("%d", workload);
-            sender.send(string, 0);
+            //  Send 100 tasks
+            int task_nbr;
+            int total_msec = 0; //  Total expected cost in msecs
+            for (task_nbr = 0; task_nbr < 100; task_nbr++) {
+                int workload;
+                //  Random workload from 1 to 100msecs
+                workload = srandom.nextInt(100) + 1;
+                total_msec += workload;
+                System.out.print(workload + ".");
+                String string = String.format("%d", workload);
+                sender.send(string, 0);
+            }
+            System.out.println("Total expected cost: " + total_msec + " msec");
+            Thread.sleep(1000); //  Give 0MQ time to deliver
         }
-        System.out.println("Total expected cost: " + total_msec + " msec");
-        Thread.sleep(1000); //  Give 0MQ time to deliver
-
-        sink.close();
-        sender.close();
-        context.term();
     }
 }

--- a/src/test/java/guide/taskwork.java
+++ b/src/test/java/guide/taskwork.java
@@ -1,6 +1,7 @@
 package guide;
 
 import org.zeromq.ZMQ;
+import org.zeromq.ZContext;
 
 //
 //  Task worker in Java
@@ -11,35 +12,31 @@ import org.zeromq.ZMQ;
 //
 public class taskwork
 {
-
     public static void main(String[] args) throws Exception
     {
-        ZMQ.Context context = ZMQ.context(1);
+        try (ZContext context = new ZContext()) {
+            //  Socket to receive messages on
+            ZMQ.Socket receiver = context.createSocket(ZMQ.PULL);
+            receiver.connect("tcp://localhost:5557");
 
-        //  Socket to receive messages on
-        ZMQ.Socket receiver = context.socket(ZMQ.PULL);
-        receiver.connect("tcp://localhost:5557");
+            //  Socket to send messages to
+            ZMQ.Socket sender = context.createSocket(ZMQ.PUSH);
+            sender.connect("tcp://localhost:5558");
 
-        //  Socket to send messages to
-        ZMQ.Socket sender = context.socket(ZMQ.PUSH);
-        sender.connect("tcp://localhost:5558");
+            //  Process tasks forever
+            while (!Thread.currentThread().isInterrupted()) {
+                String string = new String(receiver.recv(0), ZMQ.CHARSET).trim();
+                long msec = Long.parseLong(string);
+                //  Simple progress indicator for the viewer
+                System.out.flush();
+                System.out.print(string + '.');
 
-        //  Process tasks forever
-        while (!Thread.currentThread().isInterrupted()) {
-            String string = new String(receiver.recv(0), ZMQ.CHARSET).trim();
-            long msec = Long.parseLong(string);
-            //  Simple progress indicator for the viewer
-            System.out.flush();
-            System.out.print(string + '.');
+                //  Do the work
+                Thread.sleep(msec);
 
-            //  Do the work
-            Thread.sleep(msec);
-
-            //  Send results to sink
-            sender.send(ZMQ.MESSAGE_SEPARATOR, 0);
+                //  Send results to sink
+                sender.send(ZMQ.MESSAGE_SEPARATOR, 0);
+            }
         }
-        sender.close();
-        receiver.close();
-        context.term();
     }
 }

--- a/src/test/java/guide/tripping.java
+++ b/src/test/java/guide/tripping.java
@@ -12,73 +12,69 @@ import org.zeromq.ZMsg;
 */
 public class tripping
 {
-
     static class Broker implements Runnable
     {
         @Override
         public void run()
         {
-            ZContext ctx = new ZContext();
-            Socket frontend = ctx.createSocket(ZMQ.ROUTER);
-            Socket backend = ctx.createSocket(ZMQ.ROUTER);
-            frontend.setHWM(0);
-            backend.setHWM(0);
-            frontend.bind("tcp://*:5555");
-            backend.bind("tcp://*:5556");
+            try (ZContext ctx = new ZContext()) {
+                Socket frontend = ctx.createSocket(ZMQ.ROUTER);
+                Socket backend = ctx.createSocket(ZMQ.ROUTER);
+                frontend.setHWM(0);
+                backend.setHWM(0);
+                frontend.bind("tcp://*:5555");
+                backend.bind("tcp://*:5556");
 
-            while (!Thread.currentThread().isInterrupted()) {
-                ZMQ.Poller items = ctx.createPoller(2);
-                items.register(frontend, ZMQ.Poller.POLLIN);
-                items.register(backend, ZMQ.Poller.POLLIN);
+                while (!Thread.currentThread().isInterrupted()) {
+                    ZMQ.Poller items = ctx.createPoller(2);
+                    items.register(frontend, ZMQ.Poller.POLLIN);
+                    items.register(backend, ZMQ.Poller.POLLIN);
 
-                if (items.poll() == -1)
-                    break; // Interrupted
-                if (items.pollin(0)) {
-                    ZMsg msg = ZMsg.recvMsg(frontend);
-                    if (msg == null)
+                    if (items.poll() == -1)
                         break; // Interrupted
-                    ZFrame address = msg.pop();
-                    address.destroy();
-                    msg.addFirst(new ZFrame("W"));
-                    msg.send(backend);
-                }
-                if (items.pollin(1)) {
 
-                    ZMsg msg = ZMsg.recvMsg(backend);
-                    if (msg == null)
-                        break; // Interrupted
-                    ZFrame address = msg.pop();
-                    address.destroy();
-                    msg.addFirst(new ZFrame("C"));
-                    msg.send(frontend);
+                    if (items.pollin(0)) {
+                        ZMsg msg = ZMsg.recvMsg(frontend);
+                        if (msg == null)
+                            break; // Interrupted
+                        ZFrame address = msg.pop();
+                        address.destroy();
+                        msg.addFirst(new ZFrame("W"));
+                        msg.send(backend);
+                    }
+
+                    if (items.pollin(1)) {
+                        ZMsg msg = ZMsg.recvMsg(backend);
+                        if (msg == null)
+                            break; // Interrupted
+                        ZFrame address = msg.pop();
+                        address.destroy();
+                        msg.addFirst(new ZFrame("C"));
+                        msg.send(frontend);
+                    }
+
+                    items.close();
                 }
-                items.close();
             }
-            ctx.close();
         }
-
     }
 
     static class Worker implements Runnable
     {
-
         @Override
         public void run()
         {
-            ZContext ctx = new ZContext();
-            Socket worker = ctx.createSocket(ZMQ.DEALER);
-            worker.setHWM(0);
-            worker.setIdentity("W".getBytes(ZMQ.CHARSET));
-            worker.connect("tcp://localhost:5556");
-            while (!Thread.currentThread().isInterrupted()) {
-                ZMsg msg = ZMsg.recvMsg(worker);
-                msg.send(worker);
+            try (ZContext ctx = new ZContext()) {
+                Socket worker = ctx.createSocket(ZMQ.DEALER);
+                worker.setHWM(0);
+                worker.setIdentity("W".getBytes(ZMQ.CHARSET));
+                worker.connect("tcp://localhost:5556");
+                while (!Thread.currentThread().isInterrupted()) {
+                    ZMsg msg = ZMsg.recvMsg(worker);
+                    msg.send(worker);
+                }
             }
-
-            ctx.close();
-
         }
-
     }
 
     static class Client implements Runnable
@@ -88,56 +84,63 @@ public class tripping
         @Override
         public void run()
         {
-            ZContext ctx = new ZContext();
-            Socket client = ctx.createSocket(ZMQ.DEALER);
-            client.setHWM(0);
-            client.setIdentity("C".getBytes(ZMQ.CHARSET));
-            client.connect("tcp://localhost:5555");
-            System.out.println("Setting up test");
-            try {
-                Thread.sleep(100);
+            try (ZContext ctx = new ZContext()) {
+                Socket client = ctx.createSocket(ZMQ.DEALER);
+                client.setHWM(0);
+                client.setIdentity("C".getBytes(ZMQ.CHARSET));
+                client.connect("tcp://localhost:5555");
+                System.out.println("Setting up test");
+                try {
+                    Thread.sleep(100);
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+
+                int requests;
+                long start;
+
+                System.out.println("Synchronous round-trip test");
+                start = System.currentTimeMillis();
+
+                for (requests = 0; requests < SAMPLE_SIZE; requests++) {
+                    ZMsg req = new ZMsg();
+                    req.addString("hello");
+                    req.send(client);
+                    ZMsg.recvMsg(client).destroy();
+                }
+
+                long now = System.currentTimeMillis();
+                System.out.printf(
+                    " %d calls/second\n", (1000 * SAMPLE_SIZE) / (now - start)
+                );
+
+                System.out.println("Asynchronous round-trip test");
+                start = System.currentTimeMillis();
+
+                for (requests = 0; requests < SAMPLE_SIZE; requests++) {
+                    ZMsg req = new ZMsg();
+                    req.addString("hello");
+                    req.send(client);
+                }
+
+                for (requests = 0;
+                     requests < SAMPLE_SIZE && !Thread.currentThread()
+                                                      .isInterrupted();
+                     requests++) {
+                    ZMsg.recvMsg(client).destroy();
+                }
+
+                long now2 = System.currentTimeMillis();
+                System.out.printf(
+                    " %d calls/second\n", (1000 * SAMPLE_SIZE) / (now2 - start)
+                );
             }
-            catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-
-            int requests;
-            long start;
-
-            System.out.println("Synchronous round-trip test");
-            start = System.currentTimeMillis();
-
-            for (requests = 0; requests < SAMPLE_SIZE; requests++) {
-                ZMsg req = new ZMsg();
-                req.addString("hello");
-                req.send(client);
-                ZMsg.recvMsg(client).destroy();
-            }
-
-            System.out.printf(" %d calls/second\n", (1000 * SAMPLE_SIZE) / (System.currentTimeMillis() - start));
-
-            System.out.println("Asynchronous round-trip test");
-            start = System.currentTimeMillis();
-
-            for (requests = 0; requests < SAMPLE_SIZE; requests++) {
-                ZMsg req = new ZMsg();
-                req.addString("hello");
-                req.send(client);
-            }
-            for (requests = 0; requests < SAMPLE_SIZE && !Thread.currentThread().isInterrupted(); requests++) {
-                ZMsg.recvMsg(client).destroy();
-            }
-
-            System.out.printf(" %d calls/second\n", (1000 * SAMPLE_SIZE) / (System.currentTimeMillis() - start));
-
-            ctx.close();
         }
-
     }
 
     public static void main(String[] args)
     {
-
         if (args.length == 1)
             Client.SAMPLE_SIZE = Integer.parseInt(args[0]);
 
@@ -161,5 +164,4 @@ public class tripping
         catch (InterruptedException e) {
         }
     }
-
 }

--- a/src/test/java/guide/version.java
+++ b/src/test/java/guide/version.java
@@ -5,11 +5,15 @@ import org.zeromq.ZMQ;
 //  Report 0MQ version
 public class version
 {
-
     public static void main(String[] args)
     {
-        System.out.println(
-                String.format("Version string: %s, Version int: %d", ZMQ.getVersionString(), ZMQ.getFullVersion()));
-    }
+        String version = ZMQ.getVersionString();
+        int fullVersion = ZMQ.getFullVersion();
 
+        System.out.println(
+            String.format(
+                "Version string: %s, Version int: %d", version, fullVersion
+            )
+        );
+    }
 }

--- a/src/test/java/guide/wuclient.java
+++ b/src/test/java/guide/wuclient.java
@@ -3,6 +3,7 @@ package guide;
 import java.util.StringTokenizer;
 
 import org.zeromq.ZMQ;
+import org.zeromq.ZContext;
 
 //
 //  Weather update client in Java
@@ -11,38 +12,40 @@ import org.zeromq.ZMQ;
 //
 public class wuclient
 {
-
     public static void main(String[] args)
     {
-        ZMQ.Context context = ZMQ.context(1);
+        try (ZContext context = new ZContext()) {
+            //  Socket to talk to server
+            System.out.println("Collecting updates from weather server");
+            ZMQ.Socket subscriber = context.createSocket(ZMQ.SUB);
+            subscriber.connect("tcp://localhost:5556");
 
-        //  Socket to talk to server
-        System.out.println("Collecting updates from weather server");
-        ZMQ.Socket subscriber = context.socket(ZMQ.SUB);
-        subscriber.connect("tcp://localhost:5556");
+            //  Subscribe to zipcode, default is NYC, 10001
+            String filter = (args.length > 0) ? args[0] : "10001 ";
+            subscriber.subscribe(filter.getBytes(ZMQ.CHARSET));
 
-        //  Subscribe to zipcode, default is NYC, 10001
-        String filter = (args.length > 0) ? args[0] : "10001 ";
-        subscriber.subscribe(filter.getBytes(ZMQ.CHARSET));
+            //  Process 100 updates
+            int update_nbr;
+            long total_temp = 0;
+            for (update_nbr = 0; update_nbr < 100; update_nbr++) {
+                //  Use trim to remove the tailing '0' character
+                String string = subscriber.recvStr(0).trim();
 
-        //  Process 100 updates
-        int update_nbr;
-        long total_temp = 0;
-        for (update_nbr = 0; update_nbr < 100; update_nbr++) {
-            //  Use trim to remove the tailing '0' character
-            String string = subscriber.recvStr(0).trim();
+                StringTokenizer sscanf = new StringTokenizer(string, " ");
+                int zipcode = Integer.valueOf(sscanf.nextToken());
+                int temperature = Integer.valueOf(sscanf.nextToken());
+                int relhumidity = Integer.valueOf(sscanf.nextToken());
 
-            StringTokenizer sscanf = new StringTokenizer(string, " ");
-            int zipcode = Integer.valueOf(sscanf.nextToken());
-            int temperature = Integer.valueOf(sscanf.nextToken());
-            int relhumidity = Integer.valueOf(sscanf.nextToken());
+                total_temp += temperature;
+            }
 
-            total_temp += temperature;
-
+            System.out.println(
+                String.format(
+                    "Average temperature for zipcode '%s' was %d.",
+                    filter,
+                    (int)(total_temp / update_nbr)
+                )
+            );
         }
-        System.out.println("Average temperature for zipcode '" + filter + "' was " + (int) (total_temp / update_nbr));
-
-        subscriber.close();
-        context.term();
     }
 }

--- a/src/test/java/guide/wuproxy.java
+++ b/src/test/java/guide/wuproxy.java
@@ -1,36 +1,31 @@
 package guide;
 
 import org.zeromq.ZMQ;
-import org.zeromq.ZMQ.Context;
 import org.zeromq.ZMQ.Socket;
+import org.zeromq.ZContext;
 
 /**
 * Weather proxy device.
 */
 public class wuproxy
 {
-
     public static void main(String[] args)
     {
         //  Prepare our context and sockets
-        Context context = ZMQ.context(1);
+        try (ZContext context = new ZContext()) {
+            //  This is where the weather server sits
+            Socket frontend = context.createSocket(ZMQ.SUB);
+            frontend.connect("tcp://192.168.55.210:5556");
 
-        //  This is where the weather server sits
-        Socket frontend = context.socket(ZMQ.SUB);
-        frontend.connect("tcp://192.168.55.210:5556");
+            //  This is our public endpoint for subscribers
+            Socket backend = context.createSocket(ZMQ.PUB);
+            backend.bind("tcp://10.1.1.0:8100");
 
-        //  This is our public endpoint for subscribers
-        Socket backend = context.socket(ZMQ.PUB);
-        backend.bind("tcp://10.1.1.0:8100");
+            //  Subscribe on everything
+            frontend.subscribe(ZMQ.SUBSCRIPTION_ALL);
 
-        //  Subscribe on everything
-        frontend.subscribe(ZMQ.SUBSCRIPTION_ALL);
-
-        //  Run the proxy until the user interrupts us
-        ZMQ.proxy(frontend, backend, null);
-
-        frontend.close();
-        backend.close();
-        context.term();
+            //  Run the proxy until the user interrupts us
+            ZMQ.proxy(frontend, backend, null);
+        }
     }
 }

--- a/src/test/java/guide/wuserver.java
+++ b/src/test/java/guide/wuserver.java
@@ -3,6 +3,7 @@ package guide;
 import java.util.Random;
 
 import org.zeromq.ZMQ;
+import org.zeromq.ZContext;
 
 //
 //  Weather update server in Java
@@ -11,31 +12,29 @@ import org.zeromq.ZMQ;
 //
 public class wuserver
 {
-
     public static void main(String[] args) throws Exception
     {
         //  Prepare our context and publisher
-        ZMQ.Context context = ZMQ.context(1);
+        try (ZContext context = new ZContext()) {
+            ZMQ.Socket publisher = context.createSocket(ZMQ.PUB);
+            publisher.bind("tcp://*:5556");
+            publisher.bind("ipc://weather");
 
-        ZMQ.Socket publisher = context.socket(ZMQ.PUB);
-        publisher.bind("tcp://*:5556");
-        publisher.bind("ipc://weather");
+            //  Initialize random number generator
+            Random srandom = new Random(System.currentTimeMillis());
+            while (!Thread.currentThread().isInterrupted()) {
+                //  Get values that will fool the boss
+                int zipcode, temperature, relhumidity;
+                zipcode = 10000 + srandom.nextInt(10000);
+                temperature = srandom.nextInt(215) - 80 + 1;
+                relhumidity = srandom.nextInt(50) + 10 + 1;
 
-        //  Initialize random number generator
-        Random srandom = new Random(System.currentTimeMillis());
-        while (!Thread.currentThread().isInterrupted()) {
-            //  Get values that will fool the boss
-            int zipcode, temperature, relhumidity;
-            zipcode = 10000 + srandom.nextInt(10000);
-            temperature = srandom.nextInt(215) - 80 + 1;
-            relhumidity = srandom.nextInt(50) + 10 + 1;
-
-            //  Send message to all subscribers
-            String update = String.format("%05d %d %d", zipcode, temperature, relhumidity);
-            publisher.send(update, 0);
+                //  Send message to all subscribers
+                String update = String.format(
+                    "%05d %d %d", zipcode, temperature, relhumidity
+                );
+                publisher.send(update, 0);
+            }
         }
-
-        publisher.close();
-        context.term();
     }
 }


### PR DESCRIPTION
_NB: This PR contains a lot of whitespace-only changes! For easier viewing, I recommend adding `?w=1` to the end of the URL to hide the whitespace changes and only see the lines that changed._

Based on the discussion in #541, I set out to start writing a "getting started" guide to using JeroMQ.

I believe the current state of the art for JeroMQ is to create a ZContext and then use that to create pollers and sockets. I also believe that the implementations of the zguide examples in this repo should reflect recommended usage of JeroMQ. However, I noticed that while many of the examples do use ZContext, many do not; they use the older / more lower-level ZMQ.Context instead.

This PR updates all of the zguide examples to use ZContext. Additionally, in almost every example, I was able to translate the "create context, do stuff with it, close context when done" pattern into a [try-with-resources statement](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html), which I believe is a good practice because it encourages good resource management.