### PR TITLE
Initialize the internal ZMQ.Context of a ZContext only when creating it

### DIFF
--- a/src/test/java/org/zeromq/TestZContext.java
+++ b/src/test/java/org/zeromq/TestZContext.java
@@ -54,6 +54,8 @@ public class TestZContext
     {
         ZContext ctx = new ZContext();
         assertThat(ctx, notNullValue());
+        assertThat(ctx.getContext(), notNullValue());
+        assertThat(ctx.isClosed(), is(false));
         assertThat(ctx.getIoThreads(), is(1));
         assertThat(ctx.getLinger(), is(0));
         assertThat(ctx.isMain(), is(true));
@@ -65,6 +67,7 @@ public class TestZContext
     {
         ZContext ctx = new ZContext();
         ctx.close();
+        assertThat(ctx.isClosed(), is(true));
         assertThat(ctx.getSockets().isEmpty(), is(true));
 
         // Ensure context is not destroyed if not in main thread


### PR DESCRIPTION
Fixes #545.

Given a ZContext `ctx`, I don't think it ever makes sense for `ctx.getContext()` to be `null`. Currently, however, we are creating the internal ZMQ.Context lazily whenever `getContext()` is called. This causes unexpected behavior because `ctx.isClosed()` initially returns `true` (hence #545).

We are also setting the reference to the internal context to `null` after terminating the ZMQ.Context when the ZContext is closed. This is even worse, because if another thread happens to try to use the ZContext after it's closed, a new ZMQ.Context ends up secretly being created.

This PR solves both problems by creating the ZMQ.Context as part of the ZContext constructor, and never setting it to null. When a ZContext is destroyed, the internal ZMQ.Context is terminated, and any further attempt to use the ZContext will result in the behavior we would expect when trying to reuse a context that has been terminated. This should help users track down issues related to use of a context after it has been terminated.