### PR TITLE
First cut of "getting started" documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Pure Java implementation of libzmq (http://zeromq.org).
 * Securities
  * [PLAIN](http://rfc.zeromq.org/spec:24).
  * [CURVE](http://rfc.zeromq.org/spec:25).
- 
-* Not too bad performance compared to zeromq.
+
+* Performance that's not too bad, compared to native libzmq.
  * 4.5M messages (100B) per sec.
  * [Performance](https://github.com/zeromq/jeromq/wiki/Performance).
 * Exactly same developer experience with zeromq and jzmq.
 
-## Not supported Features
+## Unsupported
 
 * ipc:// protocol with zeromq. Java doesn't support UNIX domain socket.
 * pgm:// protocol. Cannot find a pgm Java implementation.
@@ -81,8 +81,65 @@ To generate an ant build file from `pom.xml`, issue the following command:
 mvn ant:ant
 ```
 
+## Getting started
+
+### Simple example
+
+Here is how you might implement a server that prints the messages it receives
+and responds to them with "Hello, world!":
+
+```java
+import org.zeromq.ZMQ;
+import org.zeromq.ZContext;
+
+public class hwserver
+{
+    public static void main(String[] args) throws Exception
+    {
+        try (ZContext context = new ZContext()) {
+            // Socket to talk to clients
+            ZMQ.Socket socket = context.createSocket(ZMQ.REP);
+            socket.bind("tcp://*:5555");
+
+            while (!Thread.currentThread().isInterrupted()) {
+                // Block until a message is received
+                byte[] reply = socket.recv(0);
+
+                // Print the message
+                System.out.println(
+                    "Received " + ": [" + new String(reply, ZMQ.CHARSET) + "]"
+                );
+
+                // Send a response
+                String response = "Hello, world!";
+                socket.send(response.getBytes(ZMQ.CHARSET), 0);
+            }
+        }
+    }
+}
+```
+
+### More examples
+
+The JeroMQ [translations of the zguide examples](src/test/java/guide) are a good
+reference for recommended usage.
+
+(Note that the Java examples in the [zguide](http://zguide.zeromq.org) itself
+are out of date and do not necessarily reflect current recommended practices
+with JeroMQ.)
+
+### Documentation
+
+For API-level documentation, see the
+[Javadocs](http://www.javadoc.io/doc/org.zeromq/jeromq).
+
+This repo also has a [doc](doc/) folder, which contains assorted "how to do X"
+guides and other useful information about various topics related to using
+JeroMQ.
+
 ## License
 
-All source files are copyright © 2007-2017 contributors as noted in the AUTHORS file.
+All source files are copyright © 2007-2018 contributors as noted in the AUTHORS file.
 
 Free use of this software is granted under the terms of the Mozilla Public License 2.0. For details see the file `LICENSE` included with the JeroMQ distribution.
+

--- a/doc/contexts.md
+++ b/doc/contexts.md
@@ -1,0 +1,51 @@
+# Contexts
+
+You may have noticed that there are several different types of "context" classes
+in JeroMQ.
+
+## tl;dr: Which one do I use?
+
+Use ZContext. It is the current state of the art for JeroMQ.
+
+## zmq.Ctx
+
+[Ctx][ctx], part of the zmq package, contains low-level implementation details
+of a ZeroMQ context.
+
+It should not be used directly in code that uses the JeroMQ library.
+
+## org.zeromq.ZMQ.Context
+
+[ZMQ.Context][zmq-context] was the first cut at a higher-level API for a ZeroMQ
+context.
+
+Before destroying a ZMQ.Context, care must be taken to close any
+[sockets](sockets.md) and [pollers](pollers.md) that may have been created via
+the context. ZContext, by comparison, does this for you.
+
+## org.zeromq.ZContext
+
+[ZContext][zcontext] is an improvement over ZMQ.Context, lending itself to more
+concise, convenient, and safe usage.
+
+ZContext implements the [java.io.Closable][closable] interface, which makes it
+convenient to use in a [try-with-resources statement][try-with-resources].  When
+a ZContext is closed, resources such as sockets and pollers are cleaned up
+automatically.
+
+## See also
+
+* [zguide: Getting the Context Right][zguide-contexts]: general information
+  about contexts in ZeroMQ
+
+* [ZSocket][zsocket]: The next evolution of contexts (or lack thereof) in
+  ZeroMQ?
+
+
+[ctx]: http://static.javadoc.io/org.zeromq/jeromq/0.4.3/zmq/Ctx.html
+[zmq-context]: http://static.javadoc.io/org.zeromq/jeromq/0.4.3/org/zeromq/ZMQ.Context.html
+[zcontext]: http://static.javadoc.io/org.zeromq/jeromq/0.4.3/org/zeromq/ZContext.html
+[closable]: https://docs.oracle.com/javase/7/docs/api/java/io/Closeable.html
+[try-with-resources]: https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html
+[zguide-contexts]: http://zguide.zeromq.org/page:all#Getting-the-Context-Right
+[zsocket]: http://static.javadoc.io/org.zeromq/jeromq/0.4.3/org/zeromq/ZSocket.html

--- a/doc/exceptions.md
+++ b/doc/exceptions.md
@@ -1,0 +1,29 @@
+# Exceptions
+
+JeroMQ defines a handful of custom exceptions, which are thrown as a means of
+signaling various exceptional internal states.
+
+These exceptions are defined within the [ZError][zerror] class.
+
+## ZError.CtxTerminatedException
+
+This exception is thrown when an action is attempted which requires an open
+context, but the context in question has been terminated.
+
+## ZError.InstantiationException
+
+> If you know what this exception is for, please update this document with an
+> explanation!
+>
+> Anecdotally, I can find anywhere in the source code where this exception is
+> ever thrown, so perhaps it should be removed?
+
+## ZError.IOException
+
+This exception wraps [java.io.IOException][ioexception]. When JeroMQ throws one
+of these, it is an acknowledgment that a java.io.IOException has occurred, but
+it is not JeroMQ's responsibility to resolve it; it is up to the caller.
+
+
+[zerror]: http://static.javadoc.io/org.zeromq/jeromq/0.4.3/zmq/ZError.html
+[ioexception]: https://docs.oracle.com/javase/7/docs/api/java/io/IOException.html

--- a/doc/pollers.md
+++ b/doc/pollers.md
@@ -1,0 +1,42 @@
+# Pollers
+
+There are multiple classes implementing polling behavior in JeroMQ.
+
+## tl;dr: How do I construct a Poller?
+
+Use [ZContext.createPoller][create-poller]. This returns a
+[ZMQ.Poller][zmq-poller].
+
+## zmq.poll.Poller
+
+[zmq.poll.Poller][zmq-poll-poller] contains low-level implementation details of
+ZeroMQ polling behavior.
+
+It should not be used directly in code that uses the JeroMQ library.
+
+## org.zeromq.ZMQ.Poller
+
+[ZMQ.Poller][zmq-poller] is the user-facing API for working with pollers in
+JeroMQ.
+
+Pollers are constructed by calling [ZContext.createPoller][create-poller]. This
+is essential because it registers the poller with the context, so that when the
+context is closed, the poller and selector resources are cleaned up properly.
+
+## org.zeromq.ZPoller
+
+[ZPoller][zpoller] is a work-in-progress rewrite of the polling API.
+
+> If you use ZPoller, please update these docs with more information!
+
+## See also
+
+* [zguide: Handling Multiple Sockets][zguide-polling]: general
+  information about polling in ZeroMQ
+
+
+[zmq-poll-poller]: http://static.javadoc.io/org.zeromq/jeromq/0.4.3/zmq/poll/Poller.html
+[zmq-poller]: http://static.javadoc.io/org.zeromq/jeromq/0.4.3/org/zeromq/ZMQ.Poller.html
+[create-poller]: http://static.javadoc.io/org.zeromq/jeromq/0.4.3/org/zeromq/ZContext.html#createPoller(int)
+[zpoller]: http://static.javadoc.io/org.zeromq/jeromq/0.4.3/org/zeromq/ZPoller.html
+[zguide-polling]: http://zguide.zeromq.org/page:all#Handling-Multiple-Sockets

--- a/doc/security/curve.md
+++ b/doc/security/curve.md
@@ -1,0 +1,14 @@
+# CurveZMQ
+
+[CurveZMQ][curvezmq] is an authentication and encryption protocol for
+ZeroMQ.
+
+You can use Curve with JeroMQ, generating keypairs via the [Curve
+class][curve-class].
+
+For an example of this in action, see [this gist][curve-gist].
+
+
+[curvezmq]: http://curvezmq.org
+[curve-class]: http://static.javadoc.io/org.zeromq/jeromq/0.4.3/zmq/io/mechanism/curve/Curve.html
+[curve-gist]: https://gist.github.com/trevorbernard/6e3a8af0092cdced0f8b3e757a5b6b16

--- a/doc/sockets.md
+++ b/doc/sockets.md
@@ -1,0 +1,38 @@
+# Sockets
+
+There are multiple classes implementing socket behavior in JeroMQ.
+
+## tl;dr: How do I construct a Socket?
+
+Use [ZContext.createSocket][create-socket]. This returns a
+[ZMQ.Socket][zmq-socket].
+
+## zmq.SocketBase
+
+[zmq.SocketBase][socket-base] contains low-level implementation details of
+ZeroMQ socket behavior.
+
+It should not be used directly in code that uses the JeroMQ library.
+
+## org.zeromq.ZMQ.Socket
+
+[ZMQ.Socket][zmq-socket] is the user-facing API for working with sockets in
+JeroMQ.
+
+Sockets are constructed by calling [ZContext.createSocket][create-socket]. This
+is essential because it registers the poller with the context, so that when the
+context is closed, the poller and selector resources are cleaned up properly.
+
+## org.zeromq.ZPoller
+
+[ZPoller][zpoller] is a work-in-progress rewrite of the polling API.
+
+> If you use ZPoller, please update these docs with more information!
+
+## See also
+
+* [zguide: Handling Multiple Sockets][zguide-polling]: general
+  information about polling in ZeroMQ
+
+
+[socket-base]: http://static.javadoc.io/org.zeromq/jeromq/0.4.3/zmq/SocketBase.html

--- a/src/test/java/guide/hwserver.java
+++ b/src/test/java/guide/hwserver.java
@@ -14,7 +14,7 @@ public class hwserver
     public static void main(String[] args) throws Exception
     {
         try (ZContext context = new ZContext()) {
-            //  Socket to talk to clients
+            // Socket to talk to clients
             ZMQ.Socket socket = context.createSocket(ZMQ.REP);
             socket.bind("tcp://*:5555");
 
@@ -24,10 +24,8 @@ public class hwserver
                     "Received " + ": [" + new String(reply, ZMQ.CHARSET) + "]"
                 );
 
-                //  Create a "Hello" message.
-                String request = "world";
-                // Send the message
-                socket.send(request.getBytes(ZMQ.CHARSET), 0);
+                String response = "world";
+                socket.send(response.getBytes(ZMQ.CHARSET), 0);
 
                 Thread.sleep(1000); //  Do some 'work'
             }


### PR DESCRIPTION
Closes #541.

I don't claim to be an authority on JeroMQ by any means, but I've documented what I know. Hopefully this addresses the specific questions raised in #541 by @fbacchella, and can serve as a good starting point for the project to have nice, user-friendly documentation.

NB: I considered putting this information in the Javadocs, but it occurred to me that Javadocs are organized by packages and classes, which doesn't give us a good place to document general ideas about ZeroMQ and JeroMQ. For this reason, I think it's better to have a canonical "docs" folder where we can organize things in a more intuitive way.

Feedback welcome!