### PR TITLE
Problem: HEARTBEAT command breaks REQ connection

### DIFF
--- a/src/main/java/zmq/socket/reqrep/Req.java
+++ b/src/main/java/zmq/socket/reqrep/Req.java
@@ -256,6 +256,12 @@ public class Req extends Dealer
         @Override
         public boolean pushMsg(Msg msg)
         {
+            //  Ignore commands, they are processed by the engine and should not
+            //  affect the state machine.
+            if (msg.isCommand()) {
+                return true;
+            }
+
             switch (state) {
             case BOTTOM:
                 if (msg.hasMore() && msg.size() == 0) {


### PR DESCRIPTION
Solution: ignore command messages in the REQ session to avoid
disrupting the state machine.
Commands are handled by the engine before handing off to the session.

Fixes #551 