### PR TITLE
Problem: using int flags to indicate socket type is error-prone

### DIFF
--- a/src/main/java/org/zeromq/SocketType.java
+++ b/src/main/java/org/zeromq/SocketType.java
@@ -1,0 +1,352 @@
+package org.zeromq;
+
+import zmq.ZMQ;
+
+/**
+ * Socket Type enumeration
+ *
+ * @author Isa Hekmatizadeh
+ */
+public enum SocketType {
+  /**
+   * Flag to specify a exclusive pair of sockets.
+   * <p/>
+   * A socket of type PAIR can only be connected to a single peer at any one time.
+   * <br/>
+   * No message routing or filtering is performed on messages sent over a PAIR socket.
+   * <br/>
+   * When a PAIR socket enters the mute state due to having reached the high water mark for the connected peer,
+   * or if no peer is connected, then any send() operations on the socket shall block until the peer becomes available for sending;
+   * messages are not discarded.
+   * <p/>
+   * <table summary="" border="1">
+   *   <th colspan="2">Summary of socket characteristics</th>
+   *   <tr><td>Compatible peer sockets</td><td>PAIR</td></tr>
+   *   <tr><td>Direction</td><td>Bidirectional</td></tr>
+   *   <tr><td>Send/receive pattern</td><td>Unrestricted</td></tr>
+   *   <tr><td>Incoming routing strategy</td><td>N/A</td></tr>
+   *   <tr><td>Outgoing routing strategy</td><td>N/A</td></tr>
+   *   <tr><td>Action in mute state</td><td>Block</td></tr>
+   * </table>
+   * <p/>
+   * <strong>PAIR sockets are designed for inter-thread communication across the inproc transport
+   * and do not implement functionality such as auto-reconnection.
+   * PAIR sockets are considered experimental and may have other missing or broken aspects.</strong>
+   */
+  PAIR(ZMQ.ZMQ_PAIR),
+
+  /**
+   * Flag to specify a PUB socket, receiving side must be a SUB or XSUB.
+   * <p/>
+   * A socket of type PUB is used by a publisher to distribute data.
+   * <br/>
+   * Messages sent are distributed in a fan out fashion to all connected peers.
+   * <br/>
+   * The {@link org.zeromq.ZMQ.Socket#recv()} function is not implemented for this socket type.
+   * <br/>
+   * When a PUB socket enters the mute state due to having reached the high water mark for a subscriber,
+   * then any messages that would be sent to the subscriber in question shall instead be dropped until the mute state ends.
+   * <br/>
+   * The send methods shall never block for this socket type.
+   * <p/>
+   * <table summary="" border="1">
+   *   <th colspan="2">Summary of socket characteristics</th>
+   *   <tr><td>Compatible peer sockets</td><td>{@link org.zeromq.ZMQ#SUB}, {@link org.zeromq.ZMQ#XSUB}</td></tr>
+   *   <tr><td>Direction</td><td>Unidirectional</td></tr>
+   *   <tr><td>Send/receive pattern</td><td>Send only</td></tr>
+   *   <tr><td>Incoming routing strategy</td><td>N/A</td></tr>
+   *   <tr><td>Outgoing routing strategy</td><td>Fan out</td></tr>
+   *   <tr><td>Action in mute state</td><td>Drop</td></tr>
+   * </table>
+   */
+  PUB(ZMQ.ZMQ_PUB),
+
+  /**
+   * Flag to specify the receiving part of the PUB or XPUB socket.
+   * <p/>
+   * A socket of type SUB is used by a subscriber to subscribe to data distributed by a publisher.
+   * <br/>
+   * Initially a SUB socket is not subscribed to any messages,
+   * use the {@link org.zeromq.ZMQ.Socket#subscribe(byte[])} option to specify which messages to subscribe to.
+   * <br/>
+   * The send methods are not implemented for this socket type.
+   * <p/>
+   * <table summary="" border="1">
+   *   <th colspan="2">Summary of socket characteristics</th>
+   *   <tr><td>Compatible peer sockets</td><td>{@link org.zeromq.ZMQ#PUB}, {@link org.zeromq.ZMQ#XPUB}</td></tr>
+   *   <tr><td>Direction</td><td>Unidirectional</td></tr>
+   *   <tr><td>Send/receive pattern</td><td>Receive only</td></tr>
+   *   <tr><td>Incoming routing strategy</td><td>Fair-queued</td></tr>
+   *   <tr><td>Outgoing routing strategy</td><td>N/A</td></tr>
+   * </table>
+   */
+  SUB(ZMQ.ZMQ_SUB),
+
+  /**
+   * Flag to specify a REQ socket, receiving side must be a REP or ROUTER.
+   * <p/>
+   * A socket of type REQ is used by a client to send requests to and receive replies from a service.
+   * <br/>
+   * This socket type allows only an alternating sequence of send(request) and subsequent recv(reply) calls.
+   * <br/>
+   * Each request sent is round-robined among all services, and each reply received is matched with the last issued request.
+   * <br/>
+   * If no services are available, then any send operation on the socket shall block until at least one service becomes available.
+   * <br/>
+   * The REQ socket shall not discard messages.
+   * <p/>
+   * <table summary="" border="1">
+   *   <th colspan="2">Summary of socket characteristics</th>
+   *   <tr><td>Compatible peer sockets</td><td>{@link org.zeromq.ZMQ#REP}, {@link org.zeromq.ZMQ#ROUTER}</td></tr>
+   *   <tr><td>Direction</td><td>Bidirectional</td></tr>
+   *   <tr><td>Send/receive pattern</td><td>Send, Receive, Send, Receive, ...</td></tr>
+   *   <tr><td>Incoming routing strategy</td><td>Last peer</td></tr>
+   *   <tr><td>Outgoing routing strategy</td><td>Round-robin</td></tr>
+   *   <tr><td>Action in mute state</td><td>Block</td></tr>
+   * </table>
+   */
+  REQ(ZMQ.ZMQ_REQ),
+
+  /**
+   * Flag to specify the receiving part of a REQ or DEALER socket.
+   * <p/>
+   * A socket of type REP is used by a service to receive requests from and send replies to a client.
+   * <br/>
+   * This socket type allows only an alternating sequence of recv(request) and subsequent send(reply) calls.
+   * <br/>
+   * Each request received is fair-queued from among all clients, and each reply sent is routed to the client that issued the last request.
+   * <br/>
+   * If the original requester does not exist any more the reply is silently discarded.
+   * <p/>
+   * <table summary="" border="1">
+   *   <th colspan="2">Summary of socket characteristics</th>
+   *   <tr><td>Compatible peer sockets</td><td>{@link org.zeromq.ZMQ#REQ}, {@link org.zeromq.ZMQ#DEALER}</td></tr>
+   *   <tr><td>Direction</td><td>Bidirectional</td></tr>
+   *   <tr><td>Send/receive pattern</td><td>Receive, Send, Receive, Send, ...</td></tr>
+   *   <tr><td>Incoming routing strategy</td><td>Fair-queued</td></tr>
+   *   <tr><td>Outgoing routing strategy</td><td>Last peer</td></tr>
+   * </table>
+   */
+  REP(ZMQ.ZMQ_REP),
+
+  /**
+   * Flag to specify a DEALER socket (aka XREQ).
+   * <p/>
+   * DEALER is really a combined ventilator / sink
+   * that does load-balancing on output and fair-queuing on input
+   * with no other semantics. It is the only socket type that lets
+   * you shuffle messages out to N nodes and shuffle the replies
+   * back, in a raw bidirectional asynch pattern.
+   * <p/>
+   * A socket of type DEALER is an advanced pattern used for extending request/reply sockets.
+   * <br/>
+   * Each message sent is round-robined among all connected peers, and each message received is fair-queued from all connected peers.
+   * <br/>
+   * When a DEALER socket enters the mute state due to having reached the high water mark for all peers,
+   * or if there are no peers at all, then any send() operations on the socket shall block
+   * until the mute state ends or at least one peer becomes available for sending; messages are not discarded.
+   * <br/>
+   * When a DEALER socket is connected to a {@link org.zeromq.ZMQ#REP} socket each message sent must consist of an empty message part, the delimiter, followed by one or more body parts.
+   * <p/>
+   * <table summary="" border="1">
+   *   <th colspan="2">Summary of socket characteristics</th>
+   *   <tr><td>Compatible peer sockets</td><td>{@link org.zeromq.ZMQ#ROUTER}, {@link org.zeromq.ZMQ#REP}, {@link org.zeromq.ZMQ#DEALER}</td></tr>
+   *   <tr><td>Direction</td><td>Bidirectional</td></tr>
+   *   <tr><td>Send/receive pattern</td><td>Unrestricted</td></tr>
+   *   <tr><td>Incoming routing strategy</td><td>Fair-queued</td></tr>
+   *   <tr><td>Outgoing routing strategy</td><td>Round-robin</td></tr>
+   *   <tr><td>Action in mute state</td><td>Block</td></tr>
+   * </table>
+   */
+  DEALER(ZMQ.ZMQ_DEALER),
+
+  /**
+   * Flag to specify ROUTER socket (aka XREP).
+   * <p/>
+   * ROUTER is the socket that creates and consumes request-reply
+   * routing envelopes. It is the only socket type that lets you route
+   * messages to specific connections if you know their identities.
+   * <p/>
+   * A socket of type ROUTER is an advanced socket type used for extending request/reply sockets.
+   * <p/>
+   * When receiving messages a ROUTER socket shall prepend a message part containing the identity
+   * of the originating peer to the message before passing it to the application.
+   * <br/>
+   * Messages received are fair-queued from among all connected peers.
+   * <p/>
+   * When sending messages a ROUTER socket shall remove the first part of the message
+   * and use it to determine the identity of the peer the message shall be routed to.
+   * If the peer does not exist anymore the message shall be silently discarded by default,
+   * unless {@link org.zeromq.ZMQ.Socket#setRouterMandatory(boolean)} socket option is set to true.
+   * <p/>
+   * When a ROUTER socket enters the mute state due to having reached the high water mark for all peers,
+   * then any messages sent to the socket shall be dropped until the mute state ends.
+   * <br/>
+   * Likewise, any messages routed to a peer for which the individual high water mark has been reached shall also be dropped,
+   * , unless {@link org.zeromq.ZMQ.Socket#setRouterMandatory(boolean)} socket option is set to true.
+   * <p/>
+   * When a {@link org.zeromq.ZMQ#REQ} socket is connected to a ROUTER socket, in addition to the identity of the originating peer
+   * each message received shall contain an empty delimiter message part.
+   * <br/>
+   * Hence, the entire structure of each received message as seen by the application becomes:
+   * one or more identity parts,
+   * delimiter part,
+   * one or more body parts.
+   * <p/>
+   * When sending replies to a REQ socket the application must include the delimiter part.
+   * <p/>
+   * <table summary="" border="1">
+   *   <th colspan="2">Summary of socket characteristics</th>
+   *   <tr><td>Compatible peer sockets</td><td>{@link org.zeromq.ZMQ#DEALER}, {@link org.zeromq.ZMQ#REQ}, {@link org.zeromq.ZMQ#ROUTER}</td></tr>
+   *   <tr><td>Direction</td><td>Bidirectional</td></tr>
+   *   <tr><td>Send/receive pattern</td><td>Unrestricted</td></tr>
+   *   <tr><td>Incoming routing strategy</td><td>Fair-queued</td></tr>
+   *   <tr><td>Outgoing routing strategy</td><td>See text</td></tr>
+   *   <tr><td>Action in mute state</td><td>Drop (See text)</td></tr>
+   * </table>
+   */
+  ROUTER(ZMQ.ZMQ_ROUTER),
+
+  /**
+   * Flag to specify the receiving part of a PUSH socket.
+   * <p/>
+   * A socket of type ZMQ_PULL is used by a pipeline node to receive messages from upstream pipeline nodes.
+   * <br/>
+   * Messages are fair-queued from among all connected upstream nodes.
+   * <br/>
+   * The send() function is not implemented for this socket type.
+   * <p/>
+   * <table summary="" border="1">
+   *   <th colspan="2">Summary of socket characteristics</th>
+   *   <tr><td>Compatible peer sockets</td><td>{@link org.zeromq.ZMQ#PUSH}</td></tr>
+   *   <tr><td>Direction</td><td>Unidirectional</td></tr>
+   *   <tr><td>Send/receive pattern</td><td>Receive only</td></tr>
+   *   <tr><td>Incoming routing strategy</td><td>Fair-queued</td></tr>
+   *   <tr><td>Outgoing routing strategy</td><td>N/A</td></tr>
+   *   <tr><td>Action in mute state</td><td>Block</td></tr>
+   * </table>
+   */
+  PULL(ZMQ.ZMQ_PULL),
+
+  /**
+   * Flag to specify a PUSH socket, receiving side must be a PULL.
+   * <p/>
+   * A socket of type PUSH is used by a pipeline node to send messages to downstream pipeline nodes.
+   * <br/>
+   * Messages are round-robined to all connected downstream nodes.
+   * <br/>
+   * The recv() function is not implemented for this socket type.
+   * <br/>
+   * When a PUSH socket enters the mute state due to having reached the high water mark for all downstream nodes,
+   * or if there are no downstream nodes at all, then any send() operations on the socket shall block until the mute state ends
+   * or at least one downstream node becomes available for sending; messages are not discarded.
+   * <p/>
+   * <table summary="" border="1">
+   *   <th colspan="2">Summary of socket characteristics</th>
+   *   <tr><td>Compatible peer sockets</td><td>{@link org.zeromq.ZMQ#PULL}</td></tr>
+   *   <tr><td>Direction</td><td>Unidirectional</td></tr>
+   *   <tr><td>Send/receive pattern</td><td>Send only</td></tr>
+   *   <tr><td>Incoming routing strategy</td><td>N/A</td></tr>
+   *   <tr><td>Outgoing routing strategy</td><td>Round-robin</td></tr>
+   *   <tr><td>Action in mute state</td><td>Block</td></tr>
+   * </table>
+   */
+  PUSH(ZMQ.ZMQ_PUSH),
+
+  /**
+   * Flag to specify a XPUB socket, receiving side must be a SUB or XSUB.
+   * <p/>
+   * Subscriptions can be received as a message. Subscriptions start with
+   * a '1' byte. Unsubscriptions start with a '0' byte.
+   * <p/>
+   * Same as {@link org.zeromq.ZMQ#PUB} except that you can receive subscriptions from the peers in form of incoming messages.
+   * <br/>
+   * Subscription message is a byte 1 (for subscriptions) or byte 0 (for unsubscriptions) followed by the subscription body.
+   * <br/>
+   * Messages without a sub/unsub prefix are also received, but have no effect on subscription status.
+   * <p/>
+   * <table summary="" border="1">
+   *   <th colspan="2">Summary of socket characteristics</th>
+   *   <tr><td>Compatible peer sockets</td><td>{@link org.zeromq.ZMQ#SUB}, {@link org.zeromq.ZMQ#XSUB}</td></tr>
+   *   <tr><td>Direction</td><td>Unidirectional</td></tr>
+   *   <tr><td>Send/receive pattern</td><td>Send messages, receive subscriptions</td></tr>
+   *   <tr><td>Incoming routing strategy</td><td>N/A</td></tr>
+   *   <tr><td>Outgoing routing strategy</td><td>Fan out</td></tr>
+   *   <tr><td>Action in mute state</td><td>Drop</td></tr>
+   * </table>
+   */
+  XPUB(ZMQ.ZMQ_XPUB),
+
+  /**
+   * Flag to specify the receiving part of the PUB or XPUB socket.
+   * <p/>
+   * Same as {@link org.zeromq.ZMQ#SUB} except that you subscribe by sending subscription messages to the socket.
+   * <br/>
+   * Subscription message is a byte 1 (for subscriptions) or byte 0 (for unsubscriptions) followed by the subscription body.
+   * <br/>
+   * Messages without a sub/unsub prefix may also be sent, but have no effect on subscription status.
+   * <p/>
+   * <table summary="" border="1">
+   *   <th colspan="2">Summary of socket characteristics</th>
+   *   <tr><td>Compatible peer sockets</td><td>{@link org.zeromq.ZMQ#PUB}, {@link org.zeromq.ZMQ#XPUB}</td></tr>
+   *   <tr><td>Direction</td><td>Unidirectional</td></tr>
+   *   <tr><td>Send/receive pattern</td><td>Receive messages, send subscriptions</td></tr>
+   *   <tr><td>Incoming routing strategy</td><td>Fair-queued</td></tr>
+   *   <tr><td>Outgoing routing strategy</td><td>N/A</td></tr>
+   *   <tr><td>Action in mute state</td><td>Drop</td></tr>
+   * </table>
+   */
+  XSUB(ZMQ.ZMQ_XSUB),
+
+  /**
+   * Flag to specify a STREAM socket.
+   * <p/>
+   * A socket of type STREAM is used to send and receive TCP data from a non-ØMQ peer, when using the tcp:// transport.
+   * A STREAM socket can act as client and/or server, sending and/or receiving TCP data asynchronously.
+   * <br/>
+   * When receiving TCP data, a STREAM socket shall prepend a message part containing the identity
+   * of the originating peer to the message before passing it to the application.
+   * <br/>
+   * Messages received are fair-queued from among all connected peers.
+   * When sending TCP data, a STREAM socket shall remove the first part of the message
+   * and use it to determine the identity of the peer the message shall be routed to,
+   * and unroutable messages shall cause an EHOSTUNREACH or EAGAIN error.
+   * <br/>
+   * To open a connection to a server, use the {@link org.zeromq.ZMQ.Socket#connect(String)} call, and then fetch the socket identity using the {@link org.zeromq.ZMQ.Socket#getIdentity()} call.
+   * To close a specific connection, send the identity frame followed by a zero-length message.
+   * When a connection is made, a zero-length message will be received by the application.
+   * Similarly, when the peer disconnects (or the connection is lost), a zero-length message will be received by the application.
+   * The {@link org.zeromq.ZMQ#SNDMORE} flag is ignored on data frames. You must send one identity frame followed by one data frame.
+   * <br/>
+   * Also, please note that omitting the SNDMORE flag will prevent sending further data (from any client) on the same socket.
+   * <p/>
+   * <table summary="" border="1">
+   *   <th colspan="2">Summary of socket characteristics</th>
+   *   <tr><td>Compatible peer sockets</td><td>none</td></tr>
+   *   <tr><td>Direction</td><td>Bidirectional</td></tr>
+   *   <tr><td>Send/receive pattern</td><td>Unrestricted</td></tr>
+   *   <tr><td>Incoming routing strategy</td><td>Fair-queued</td></tr>
+   *   <tr><td>Outgoing routing strategy</td><td>See text</td></tr>
+   *   <tr><td>Action in mute state</td><td>EAGAIN</td></tr>
+   * </table>
+   */
+  STREAM(ZMQ.ZMQ_STREAM);
+
+  private final int socketType;
+
+  SocketType(int socketType) {
+    this.socketType = socketType;
+  }
+
+  public static SocketType type(int baseType) {
+    for (SocketType type : values()) {
+      if (type.type() == baseType)
+        return type;
+    }
+    throw new IllegalArgumentException("no socket type found with value " + baseType);
+  }
+
+  public int type() {
+    return socketType;
+  }
+}

--- a/src/main/java/org/zeromq/ZAuth.java
+++ b/src/main/java/org/zeromq/ZAuth.java
@@ -641,7 +641,7 @@ public class ZAuth implements Closeable
 
         private ZAgent createAgent(ZContext ctx)
         {
-            Socket pipe = ctx.createSocket(ZMQ.PAIR);
+            Socket pipe = ctx.createSocket(SocketType.PAIR);
             boolean rc = pipe.connect(repliesAddress);
             assert (rc);
             return new ZAgent.SimpleAgent(pipe, repliesAddress);
@@ -657,11 +657,11 @@ public class ZAuth implements Closeable
         public List<Socket> createSockets(ZContext ctx, Object... args)
         {
             //create replies pipe that will forward replies to user
-            replies = ctx.createSocket(ZMQ.PAIR);
+            replies = ctx.createSocket(SocketType.PAIR);
             assert (replies != null);
 
             //create ZAP handler and get ready for requests
-            Socket handler = ctx.createSocket(ZMQ.REP);
+            Socket handler = ctx.createSocket(SocketType.REP);
             assert (handler != null);
             return Arrays.asList(handler, replies);
         }

--- a/src/main/java/org/zeromq/ZContext.java
+++ b/src/main/java/org/zeromq/ZContext.java
@@ -115,12 +115,11 @@ public class ZContext implements Closeable
      * Creates a new managed socket within this ZContext instance.
      * Use this to get automatic management of the socket at shutdown
      * @param type
-     *          socket type (see ZMQ static class members)
+     *          socket type
      * @return
      *          Newly created Socket object
      */
-    public Socket createSocket(int type)
-    {
+    public Socket createSocket(SocketType type){
         // Create and register socket
         Socket socket = context.socket(type);
         socket.setRcvHWM(this.rcvhwm);
@@ -133,6 +132,18 @@ public class ZContext implements Closeable
             mutex.unlock();
         }
         return socket;
+    }
+
+    /**
+     * @deprecated use {@link this.createSocket(SocketType)}
+     * @param type
+     *          socket type (see ZMQ static class members)
+     * @return
+     *          Newly created Socket object
+     */
+    @Deprecated
+    public Socket createSocket(int type){
+        return createSocket(SocketType.type(type));
     }
 
     /**

--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -41,7 +41,7 @@ import zmq.util.Z85;
  * Individual ØMQ sockets are not thread safe except in the case
  * where full memory barriers are issued when migrating a socket from one thread to another.
  * <br/>
- * In practice this means applications can create a socket in one thread with {@link ZMQ.Context#socket(int)}
+ * In practice this means applications can create a socket in one thread with * {@link ZMQ.Context#socket(SocketType)}
  * and then pass it to a newly created thread as part of thread initialization.
  * <p/>
  * <h2>Multiple contexts</h2>
@@ -100,152 +100,24 @@ public class ZMQ
     public static final int DONTWAIT = zmq.ZMQ.ZMQ_DONTWAIT;
     public static final int NOBLOCK  = zmq.ZMQ.ZMQ_DONTWAIT;
 
-    // Socket types, used when creating a Socket.
-    /**
-     * Flag to specify a exclusive pair of sockets.
-     * <p/>
-     * A socket of type PAIR can only be connected to a single peer at any one time.
-     * <br/>
-     * No message routing or filtering is performed on messages sent over a PAIR socket.
-     * <br/>
-     * When a PAIR socket enters the mute state due to having reached the high water mark for the connected peer,
-     * or if no peer is connected, then any send() operations on the socket shall block until the peer becomes available for sending;
-     * messages are not discarded.
-     * <p/>
-     * <table summary="" border="1">
-     *   <th colspan="2">Summary of socket characteristics</th>
-     *   <tr><td>Compatible peer sockets</td><td>PAIR</td></tr>
-     *   <tr><td>Direction</td><td>Bidirectional</td></tr>
-     *   <tr><td>Send/receive pattern</td><td>Unrestricted</td></tr>
-     *   <tr><td>Incoming routing strategy</td><td>N/A</td></tr>
-     *   <tr><td>Outgoing routing strategy</td><td>N/A</td></tr>
-     *   <tr><td>Action in mute state</td><td>Block</td></tr>
-     * </table>
-     * <p/>
-     * <strong>PAIR sockets are designed for inter-thread communication across the inproc transport
-     * and do not implement functionality such as auto-reconnection.
-     * PAIR sockets are considered experimental and may have other missing or broken aspects.</strong>
-     */
+    // Socket types, used when creating a Socket. Note that all of the int types here is
+    // deprecated, use SocketType instead
+
+    @Deprecated
     public static final int PAIR       = zmq.ZMQ.ZMQ_PAIR;
-    /**
-     * Flag to specify a PUB socket, receiving side must be a SUB or XSUB.
-     * <p/>
-     * A socket of type PUB is used by a publisher to distribute data.
-     * <br/>
-     * Messages sent are distributed in a fan out fashion to all connected peers.
-     * <br/>
-     * The {@link ZMQ.Socket#recv()} function is not implemented for this socket type.
-     * <br/>
-     * When a PUB socket enters the mute state due to having reached the high water mark for a subscriber,
-     * then any messages that would be sent to the subscriber in question shall instead be dropped until the mute state ends.
-     * <br/>
-     * The send methods shall never block for this socket type.
-     * <p/>
-     * <table summary="" border="1">
-     *   <th colspan="2">Summary of socket characteristics</th>
-     *   <tr><td>Compatible peer sockets</td><td>{@link ZMQ#SUB}, {@link ZMQ#XSUB}</td></tr>
-     *   <tr><td>Direction</td><td>Unidirectional</td></tr>
-     *   <tr><td>Send/receive pattern</td><td>Send only</td></tr>
-     *   <tr><td>Incoming routing strategy</td><td>N/A</td></tr>
-     *   <tr><td>Outgoing routing strategy</td><td>Fan out</td></tr>
-     *   <tr><td>Action in mute state</td><td>Drop</td></tr>
-     * </table>
-     */
+
+    @Deprecated
     public static final int PUB        = zmq.ZMQ.ZMQ_PUB;
-    /**
-     * Flag to specify the receiving part of the PUB or XPUB socket.
-     * <p/>
-     * A socket of type SUB is used by a subscriber to subscribe to data distributed by a publisher.
-     * <br/>
-     * Initially a SUB socket is not subscribed to any messages,
-     * use the {@link ZMQ.Socket#subscribe(byte[])} option to specify which messages to subscribe to.
-     * <br/>
-     * The send methods are not implemented for this socket type.
-     * <p/>
-     * <table summary="" border="1">
-     *   <th colspan="2">Summary of socket characteristics</th>
-     *   <tr><td>Compatible peer sockets</td><td>{@link ZMQ#PUB}, {@link ZMQ#XPUB}</td></tr>
-     *   <tr><td>Direction</td><td>Unidirectional</td></tr>
-     *   <tr><td>Send/receive pattern</td><td>Receive only</td></tr>
-     *   <tr><td>Incoming routing strategy</td><td>Fair-queued</td></tr>
-     *   <tr><td>Outgoing routing strategy</td><td>N/A</td></tr>
-     * </table>
-     */
+    @Deprecated
     public static final int SUB        = zmq.ZMQ.ZMQ_SUB;
-    /**
-     * Flag to specify a REQ socket, receiving side must be a REP or ROUTER.
-     * <p/>
-     * A socket of type REQ is used by a client to send requests to and receive replies from a service.
-     * <br/>
-     * This socket type allows only an alternating sequence of send(request) and subsequent recv(reply) calls.
-     * <br/>
-     * Each request sent is round-robined among all services, and each reply received is matched with the last issued request.
-     * <br/>
-     * If no services are available, then any send operation on the socket shall block until at least one service becomes available.
-     * <br/>
-     * The REQ socket shall not discard messages.
-     * <p/>
-     * <table summary="" border="1">
-     *   <th colspan="2">Summary of socket characteristics</th>
-     *   <tr><td>Compatible peer sockets</td><td>{@link ZMQ#REP}, {@link ZMQ#ROUTER}</td></tr>
-     *   <tr><td>Direction</td><td>Bidirectional</td></tr>
-     *   <tr><td>Send/receive pattern</td><td>Send, Receive, Send, Receive, ...</td></tr>
-     *   <tr><td>Incoming routing strategy</td><td>Last peer</td></tr>
-     *   <tr><td>Outgoing routing strategy</td><td>Round-robin</td></tr>
-     *   <tr><td>Action in mute state</td><td>Block</td></tr>
-     * </table>
-     */
+
+    @Deprecated
     public static final int REQ        = zmq.ZMQ.ZMQ_REQ;
-    /**
-     * Flag to specify the receiving part of a REQ or DEALER socket.
-     * <p/>
-     * A socket of type REP is used by a service to receive requests from and send replies to a client.
-     * <br/>
-     * This socket type allows only an alternating sequence of recv(request) and subsequent send(reply) calls.
-     * <br/>
-     * Each request received is fair-queued from among all clients, and each reply sent is routed to the client that issued the last request.
-     * <br/>
-     * If the original requester does not exist any more the reply is silently discarded.
-     * <p/>
-     * <table summary="" border="1">
-     *   <th colspan="2">Summary of socket characteristics</th>
-     *   <tr><td>Compatible peer sockets</td><td>{@link ZMQ#REQ}, {@link ZMQ#DEALER}</td></tr>
-     *   <tr><td>Direction</td><td>Bidirectional</td></tr>
-     *   <tr><td>Send/receive pattern</td><td>Receive, Send, Receive, Send, ...</td></tr>
-     *   <tr><td>Incoming routing strategy</td><td>Fair-queued</td></tr>
-     *   <tr><td>Outgoing routing strategy</td><td>Last peer</td></tr>
-     * </table>
-     */
+
+    @Deprecated
     public static final int REP        = zmq.ZMQ.ZMQ_REP;
-    /**
-     * Flag to specify a DEALER socket (aka XREQ).
-     * <p/>
-     * DEALER is really a combined ventilator / sink
-     * that does load-balancing on output and fair-queuing on input
-     * with no other semantics. It is the only socket type that lets
-     * you shuffle messages out to N nodes and shuffle the replies
-     * back, in a raw bidirectional asynch pattern.
-     * <p/>
-     * A socket of type DEALER is an advanced pattern used for extending request/reply sockets.
-     * <br/>
-     * Each message sent is round-robined among all connected peers, and each message received is fair-queued from all connected peers.
-     * <br/>
-     * When a DEALER socket enters the mute state due to having reached the high water mark for all peers,
-     * or if there are no peers at all, then any send() operations on the socket shall block
-     * until the mute state ends or at least one peer becomes available for sending; messages are not discarded.
-     * <br/>
-     * When a DEALER socket is connected to a {@link ZMQ#REP} socket each message sent must consist of an empty message part, the delimiter, followed by one or more body parts.
-     * <p/>
-     * <table summary="" border="1">
-     *   <th colspan="2">Summary of socket characteristics</th>
-     *   <tr><td>Compatible peer sockets</td><td>{@link ZMQ#ROUTER}, {@link ZMQ#REP}, {@link ZMQ#DEALER}</td></tr>
-     *   <tr><td>Direction</td><td>Bidirectional</td></tr>
-     *   <tr><td>Send/receive pattern</td><td>Unrestricted</td></tr>
-     *   <tr><td>Incoming routing strategy</td><td>Fair-queued</td></tr>
-     *   <tr><td>Outgoing routing strategy</td><td>Round-robin</td></tr>
-     *   <tr><td>Action in mute state</td><td>Block</td></tr>
-     * </table>
-     */
+
+    @Deprecated
     public static final int DEALER     = zmq.ZMQ.ZMQ_DEALER;
     /**
     * Old alias for DEALER flag.
@@ -255,51 +127,8 @@ public class ZMQ
     */
     @Deprecated
     public static final int XREQ       = DEALER;
-    /**
-     * Flag to specify ROUTER socket (aka XREP).
-     * <p/>
-     * ROUTER is the socket that creates and consumes request-reply
-     * routing envelopes. It is the only socket type that lets you route
-     * messages to specific connections if you know their identities.
-     * <p/>
-     * A socket of type ROUTER is an advanced socket type used for extending request/reply sockets.
-     * <p/>
-     * When receiving messages a ROUTER socket shall prepend a message part containing the identity
-     * of the originating peer to the message before passing it to the application.
-     * <br/>
-     * Messages received are fair-queued from among all connected peers.
-     * <p/>
-     * When sending messages a ROUTER socket shall remove the first part of the message
-     * and use it to determine the identity of the peer the message shall be routed to.
-     * If the peer does not exist anymore the message shall be silently discarded by default,
-     * unless {@link ZMQ.Socket#setRouterMandatory(boolean)} socket option is set to true.
-     * <p/>
-     * When a ROUTER socket enters the mute state due to having reached the high water mark for all peers,
-     * then any messages sent to the socket shall be dropped until the mute state ends.
-     * <br/>
-     * Likewise, any messages routed to a peer for which the individual high water mark has been reached shall also be dropped,
-     * , unless {@link ZMQ.Socket#setRouterMandatory(boolean)} socket option is set to true.
-     * <p/>
-     * When a {@link ZMQ#REQ} socket is connected to a ROUTER socket, in addition to the identity of the originating peer
-     * each message received shall contain an empty delimiter message part.
-     * <br/>
-     * Hence, the entire structure of each received message as seen by the application becomes:
-     * one or more identity parts,
-     * delimiter part,
-     * one or more body parts.
-     * <p/>
-     * When sending replies to a REQ socket the application must include the delimiter part.
-     * <p/>
-     * <table summary="" border="1">
-     *   <th colspan="2">Summary of socket characteristics</th>
-     *   <tr><td>Compatible peer sockets</td><td>{@link ZMQ#DEALER}, {@link ZMQ#REQ}, {@link ZMQ#ROUTER}</td></tr>
-     *   <tr><td>Direction</td><td>Bidirectional</td></tr>
-     *   <tr><td>Send/receive pattern</td><td>Unrestricted</td></tr>
-     *   <tr><td>Incoming routing strategy</td><td>Fair-queued</td></tr>
-     *   <tr><td>Outgoing routing strategy</td><td>See text</td></tr>
-     *   <tr><td>Action in mute state</td><td>Drop (See text)</td></tr>
-     * </table>
-     */
+
+    @Deprecated
     public static final int ROUTER     = zmq.ZMQ.ZMQ_ROUTER;
     /**
      * Old alias for ROUTER flag.
@@ -309,125 +138,20 @@ public class ZMQ
      */
     @Deprecated
     public static final int XREP       = ROUTER;
-    /**
-     * Flag to specify the receiving part of a PUSH socket.
-     * <p/>
-     * A socket of type ZMQ_PULL is used by a pipeline node to receive messages from upstream pipeline nodes.
-     * <br/>
-     * Messages are fair-queued from among all connected upstream nodes.
-     * <br/>
-     * The send() function is not implemented for this socket type.
-     * <p/>
-     * <table summary="" border="1">
-     *   <th colspan="2">Summary of socket characteristics</th>
-     *   <tr><td>Compatible peer sockets</td><td>{@link ZMQ#PUSH}</td></tr>
-     *   <tr><td>Direction</td><td>Unidirectional</td></tr>
-     *   <tr><td>Send/receive pattern</td><td>Receive only</td></tr>
-     *   <tr><td>Incoming routing strategy</td><td>Fair-queued</td></tr>
-     *   <tr><td>Outgoing routing strategy</td><td>N/A</td></tr>
-     *   <tr><td>Action in mute state</td><td>Block</td></tr>
-     * </table>
-     */
+
+    @Deprecated
     public static final int PULL       = zmq.ZMQ.ZMQ_PULL;
-    /**
-     * Flag to specify a PUSH socket, receiving side must be a PULL.
-     * <p/>
-     * A socket of type PUSH is used by a pipeline node to send messages to downstream pipeline nodes.
-     * <br/>
-     * Messages are round-robined to all connected downstream nodes.
-     * <br/>
-     * The recv() function is not implemented for this socket type.
-     * <br/>
-     * When a PUSH socket enters the mute state due to having reached the high water mark for all downstream nodes,
-     * or if there are no downstream nodes at all, then any send() operations on the socket shall block until the mute state ends
-     * or at least one downstream node becomes available for sending; messages are not discarded.
-     * <p/>
-     * <table summary="" border="1">
-     *   <th colspan="2">Summary of socket characteristics</th>
-     *   <tr><td>Compatible peer sockets</td><td>{@link ZMQ#PULL}</td></tr>
-     *   <tr><td>Direction</td><td>Unidirectional</td></tr>
-     *   <tr><td>Send/receive pattern</td><td>Send only</td></tr>
-     *   <tr><td>Incoming routing strategy</td><td>N/A</td></tr>
-     *   <tr><td>Outgoing routing strategy</td><td>Round-robin</td></tr>
-     *   <tr><td>Action in mute state</td><td>Block</td></tr>
-     * </table>
-     */
+
+    @Deprecated
     public static final int PUSH       = zmq.ZMQ.ZMQ_PUSH;
-    /**
-     * Flag to specify a XPUB socket, receiving side must be a SUB or XSUB.
-     * <p/>
-     * Subscriptions can be received as a message. Subscriptions start with
-     * a '1' byte. Unsubscriptions start with a '0' byte.
-     * <p/>
-     * Same as {@link ZMQ#PUB} except that you can receive subscriptions from the peers in form of incoming messages.
-     * <br/>
-     * Subscription message is a byte 1 (for subscriptions) or byte 0 (for unsubscriptions) followed by the subscription body.
-     * <br/>
-     * Messages without a sub/unsub prefix are also received, but have no effect on subscription status.
-     * <p/>
-     * <table summary="" border="1">
-     *   <th colspan="2">Summary of socket characteristics</th>
-     *   <tr><td>Compatible peer sockets</td><td>{@link ZMQ#SUB}, {@link ZMQ#XSUB}</td></tr>
-     *   <tr><td>Direction</td><td>Unidirectional</td></tr>
-     *   <tr><td>Send/receive pattern</td><td>Send messages, receive subscriptions</td></tr>
-     *   <tr><td>Incoming routing strategy</td><td>N/A</td></tr>
-     *   <tr><td>Outgoing routing strategy</td><td>Fan out</td></tr>
-     *   <tr><td>Action in mute state</td><td>Drop</td></tr>
-     * </table>
-     */
+
+    @Deprecated
     public static final int XPUB       = zmq.ZMQ.ZMQ_XPUB;
-    /**
-     * Flag to specify the receiving part of the PUB or XPUB socket.
-     * <p/>
-     * Same as {@link ZMQ#SUB} except that you subscribe by sending subscription messages to the socket.
-     * <br/>
-     * Subscription message is a byte 1 (for subscriptions) or byte 0 (for unsubscriptions) followed by the subscription body.
-     * <br/>
-     * Messages without a sub/unsub prefix may also be sent, but have no effect on subscription status.
-     * <p/>
-     * <table summary="" border="1">
-     *   <th colspan="2">Summary of socket characteristics</th>
-     *   <tr><td>Compatible peer sockets</td><td>{@link ZMQ#PUB}, {@link ZMQ#XPUB}</td></tr>
-     *   <tr><td>Direction</td><td>Unidirectional</td></tr>
-     *   <tr><td>Send/receive pattern</td><td>Receive messages, send subscriptions</td></tr>
-     *   <tr><td>Incoming routing strategy</td><td>Fair-queued</td></tr>
-     *   <tr><td>Outgoing routing strategy</td><td>N/A</td></tr>
-     *   <tr><td>Action in mute state</td><td>Drop</td></tr>
-     * </table>
-     */
+
+    @Deprecated
     public static final int XSUB       = zmq.ZMQ.ZMQ_XSUB;
-    /**
-     * Flag to specify a STREAM socket.
-     * <p/>
-     * A socket of type STREAM is used to send and receive TCP data from a non-ØMQ peer, when using the tcp:// transport.
-     * A STREAM socket can act as client and/or server, sending and/or receiving TCP data asynchronously.
-     * <br/>
-     * When receiving TCP data, a STREAM socket shall prepend a message part containing the identity
-     * of the originating peer to the message before passing it to the application.
-     * <br/>
-     * Messages received are fair-queued from among all connected peers.
-     * When sending TCP data, a STREAM socket shall remove the first part of the message
-     * and use it to determine the identity of the peer the message shall be routed to,
-     * and unroutable messages shall cause an EHOSTUNREACH or EAGAIN error.
-     * <br/>
-     * To open a connection to a server, use the {@link ZMQ.Socket#connect(String)} call, and then fetch the socket identity using the {@link ZMQ.Socket#getIdentity()} call.
-     * To close a specific connection, send the identity frame followed by a zero-length message.
-     * When a connection is made, a zero-length message will be received by the application.
-     * Similarly, when the peer disconnects (or the connection is lost), a zero-length message will be received by the application.
-     * The {@link ZMQ#SNDMORE} flag is ignored on data frames. You must send one identity frame followed by one data frame.
-     * <br/>
-     * Also, please note that omitting the SNDMORE flag will prevent sending further data (from any client) on the same socket.
-     * <p/>
-     * <table summary="" border="1">
-     *   <th colspan="2">Summary of socket characteristics</th>
-     *   <tr><td>Compatible peer sockets</td><td>none</td></tr>
-     *   <tr><td>Direction</td><td>Bidirectional</td></tr>
-     *   <tr><td>Send/receive pattern</td><td>Unrestricted</td></tr>
-     *   <tr><td>Incoming routing strategy</td><td>Fair-queued</td></tr>
-     *   <tr><td>Outgoing routing strategy</td><td>See text</td></tr>
-     *   <tr><td>Action in mute state</td><td>EAGAIN</td></tr>
-     * </table>
-     */
+
+    @Deprecated
     public static final int STREAM     = zmq.ZMQ.ZMQ_STREAM;
     /**
      * Flag to specify a STREAMER device.
@@ -703,9 +427,14 @@ public class ZMQ
          *            the socket type.
          * @return the newly created Socket.
          */
-        public Socket socket(int type)
+        public Socket socket(SocketType type)
         {
-            return new Socket(this, type);
+            return new Socket(this,type);
+        }
+
+        @Deprecated
+        public Socket socket(int type){
+            return socket(SocketType.type(type));
         }
 
         /**
@@ -871,10 +600,10 @@ public class ZMQ
          * @param type
          *            the socket type.
          */
-        protected Socket(Context context, int type)
+        protected Socket(Context context, SocketType type)
         {
             ctx = context.ctx;
-            base = ctx.createSocket(type);
+            base = ctx.createSocket(type.type());
         }
 
         protected Socket(SocketBase base)
@@ -912,9 +641,9 @@ public class ZMQ
          *
          * @return the socket type.
          */
-        public int getType()
+        public SocketType getType()
         {
-            return base.getSocketOpt(zmq.ZMQ.ZMQ_TYPE);
+            return SocketType.type(base.getSocketOpt(zmq.ZMQ.ZMQ_TYPE));
         }
 
         /**

--- a/src/main/java/org/zeromq/ZMonitor.java
+++ b/src/main/java/org/zeromq/ZMonitor.java
@@ -303,7 +303,7 @@ public class ZMonitor implements Closeable
         @Override
         public List<Socket> createSockets(ZContext ctx, Object... args)
         {
-            monitor = ctx.createSocket(ZMQ.PAIR);
+            monitor = ctx.createSocket(SocketType.PAIR);
             assert (monitor != null);
 
             return Collections.singletonList(monitor);

--- a/src/main/java/org/zeromq/ZThread.java
+++ b/src/main/java/org/zeromq/ZThread.java
@@ -86,7 +86,7 @@ public class ZThread
 
     public static Socket fork(ZContext ctx, IAttachedRunnable runnable, Object... args)
     {
-        Socket pipe = ctx.createSocket(ZMQ.PAIR);
+        Socket pipe = ctx.createSocket(SocketType.PAIR);
 
         if (pipe != null) {
             pipe.bind(String.format("inproc://zctx-pipe-%d", pipe.hashCode()));
@@ -97,7 +97,7 @@ public class ZThread
 
         //  Connect child pipe to our pipe
         ZContext ccontext = ZContext.shadow(ctx);
-        Socket cpipe = ccontext.createSocket(ZMQ.PAIR);
+        Socket cpipe = ccontext.createSocket(SocketType.PAIR);
         if (cpipe == null) {
             return null;
         }

--- a/src/test/java/guide/ZHelper.java
+++ b/src/test/java/guide/ZHelper.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Context;
 import org.zeromq.ZMQ.Socket;
@@ -46,11 +47,11 @@ public class ZHelper
 
     public static List<Socket> buildZPipe(Context ctx)
     {
-        Socket socket1 = ctx.socket(ZMQ.PAIR);
+        Socket socket1 = ctx.socket(SocketType.PAIR);
         socket1.setLinger(0);
         socket1.setHWM(1);
 
-        Socket socket2 = ctx.socket(ZMQ.PAIR);
+        Socket socket2 = ctx.socket(SocketType.PAIR);
         socket2.setLinger(0);
         socket2.setHWM(1);
 

--- a/src/test/java/guide/asyncsrv.java
+++ b/src/test/java/guide/asyncsrv.java
@@ -2,12 +2,9 @@ package guide;
 
 import java.util.Random;
 
-import org.zeromq.ZContext;
-import org.zeromq.ZFrame;
-import org.zeromq.ZMQ;
+import org.zeromq.*;
 import org.zeromq.ZMQ.Poller;
 import org.zeromq.ZMQ.Socket;
-import org.zeromq.ZMsg;
 
 //
 //Asynchronous client-to-server (DEALER to ROUTER)
@@ -33,7 +30,7 @@ public class asyncsrv
         public void run()
         {
             try (ZContext ctx = new ZContext()) {
-                Socket client = ctx.createSocket(ZMQ.DEALER);
+                Socket client = ctx.createSocket(SocketType.DEALER);
 
                 //  Set random identity to make tracing easier
                 String identity = String.format(
@@ -75,11 +72,11 @@ public class asyncsrv
         {
             try (ZContext ctx = new ZContext()) {
                 //  Frontend socket talks to clients over TCP
-                Socket frontend = ctx.createSocket(ZMQ.ROUTER);
+                Socket frontend = ctx.createSocket(SocketType.ROUTER);
                 frontend.bind("tcp://*:5570");
 
                 //  Backend socket talks to workers over inproc
-                Socket backend = ctx.createSocket(ZMQ.DEALER);
+                Socket backend = ctx.createSocket(SocketType.DEALER);
                 backend.bind("inproc://backend");
 
                 //  Launch pool of worker threads, precise number is not critical
@@ -107,7 +104,7 @@ public class asyncsrv
         @Override
         public void run()
         {
-            Socket worker = ctx.createSocket(ZMQ.DEALER);
+            Socket worker = ctx.createSocket(SocketType.DEALER);
             worker.connect("inproc://backend");
 
             while (!Thread.currentThread().isInterrupted()) {

--- a/src/test/java/guide/bstar.java
+++ b/src/test/java/guide/bstar.java
@@ -1,12 +1,9 @@
 package guide;
 
-import org.zeromq.ZContext;
-import org.zeromq.ZLoop;
+import org.zeromq.*;
 import org.zeromq.ZLoop.IZLoopHandler;
-import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.PollItem;
 import org.zeromq.ZMQ.Socket;
-import org.zeromq.ZMsg;
 
 //  bstar class - Binary Star reactor
 public class bstar
@@ -224,11 +221,11 @@ public class bstar
         state = primary ? State.STATE_PRIMARY : State.STATE_BACKUP;
 
         //  Create publisher for state going to peer
-        statepub = ctx.createSocket(ZMQ.PUB);
+        statepub = ctx.createSocket(SocketType.PUB);
         statepub.bind(local);
 
         //  Create subscriber for state coming from peer
-        statesub = ctx.createSocket(ZMQ.SUB);
+        statesub = ctx.createSocket(SocketType.SUB);
         statesub.subscribe(ZMQ.SUBSCRIPTION_ALL);
         statesub.connect(remote);
 
@@ -259,7 +256,7 @@ public class bstar
     //  on this socket provide the CLIENT_REQUEST events for the Binary Star
     //  FSM and are passed to the provided application handler. We require
     //  exactly one voter per {{bstar}} instance:
-    public int voter(String endpoint, int type, IZLoopHandler handler, Object arg)
+    public int voter(String endpoint, SocketType type, IZLoopHandler handler, Object arg)
     {
         //  Hold actual handler+arg so we can call this later
         Socket socket = ctx.createSocket(type);

--- a/src/test/java/guide/bstarcli.java
+++ b/src/test/java/guide/bstarcli.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Poller;
@@ -22,7 +23,7 @@ public class bstarcli
             System.out.printf("I: connecting to server at %s...\n",
                               server[serverNbr]);
 
-            Socket client = ctx.createSocket(ZMQ.REQ);
+            Socket client = ctx.createSocket(SocketType.REQ);
             client.connect(server[serverNbr]);
 
             Poller poller = ctx.createPoller(1);
@@ -67,7 +68,7 @@ public class bstarcli
                         serverNbr = (serverNbr + 1) % 2;
                         Thread.sleep(SETTLE_DELAY);
                         System.out.printf("I: connecting to server at %s...\n", server[serverNbr]);
-                        client = ctx.createSocket(ZMQ.REQ);
+                        client = ctx.createSocket(SocketType.REQ);
                         client.connect(server[serverNbr]);
                         poller.register(client, ZMQ.Poller.POLLIN);
 

--- a/src/test/java/guide/bstarsrv.java
+++ b/src/test/java/guide/bstarsrv.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Poller;
@@ -129,10 +130,10 @@ public class bstarsrv
         //      -b  backup server, at tcp://localhost:5002
 
         try (ZContext ctx = new ZContext()) {
-            Socket statepub = ctx.createSocket(ZMQ.PUB);
-            Socket statesub = ctx.createSocket(ZMQ.SUB);
+            Socket statepub = ctx.createSocket(SocketType.PUB);
+            Socket statesub = ctx.createSocket(SocketType.SUB);
             statesub.subscribe(ZMQ.SUBSCRIPTION_ALL);
-            Socket frontend = ctx.createSocket(ZMQ.ROUTER);
+            Socket frontend = ctx.createSocket(SocketType.ROUTER);
             bstarsrv fsm = new bstarsrv();
 
             if (argv.length == 1 && argv[0].equals("-p")) {

--- a/src/test/java/guide/bstarsrv2.java
+++ b/src/test/java/guide/bstarsrv2.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZLoop;
 import org.zeromq.ZLoop.IZLoopHandler;
 import org.zeromq.ZMQ;
@@ -30,12 +31,12 @@ public class bstarsrv2
         if (argv.length == 1 && argv[0].equals("-p")) {
             System.out.printf("I: Primary active, waiting for backup (passive)\n");
             bs = new bstar(true, "tcp://*:5003", "tcp://localhost:5004");
-            bs.voter("tcp://*:5001", ZMQ.ROUTER, Echo, null);
+            bs.voter("tcp://*:5001", SocketType.ROUTER, Echo, null);
         }
         else if (argv.length == 1 && argv[0].equals("-b")) {
             System.out.printf("I: Backup passive, waiting for primary (active)\n");
             bs = new bstar(false, "tcp://*:5004", "tcp://localhost:5003");
-            bs.voter("tcp://*:5002", ZMQ.ROUTER, Echo, null);
+            bs.voter("tcp://*:5002", SocketType.ROUTER, Echo, null);
         }
         else {
             System.out.printf("Usage: bstarsrv { -p | -b }\n");

--- a/src/test/java/guide/clone.java
+++ b/src/test/java/guide/clone.java
@@ -3,12 +3,9 @@ package guide;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.zeromq.ZContext;
-import org.zeromq.ZMQ;
+import org.zeromq.*;
 import org.zeromq.ZMQ.Poller;
 import org.zeromq.ZMQ.Socket;
-import org.zeromq.ZMsg;
-import org.zeromq.ZThread;
 import org.zeromq.ZThread.IAttachedRunnable;
 
 public class clone
@@ -107,9 +104,9 @@ public class clone
             this.address = address;
             this.port = port;
 
-            snapshot = ctx.createSocket(ZMQ.DEALER);
+            snapshot = ctx.createSocket(SocketType.DEALER);
             snapshot.connect(String.format("%s:%d", address, port));
-            subscriber = ctx.createSocket(ZMQ.SUB);
+            subscriber = ctx.createSocket(SocketType.SUB);
             subscriber.connect(String.format("%s:%d", address, port + 1));
             subscriber.subscribe(subtree.getBytes(ZMQ.CHARSET));
         }
@@ -153,7 +150,7 @@ public class clone
             kvmap = new HashMap<String, String>();
             subtree = "";
             state = STATE_INITIAL;
-            publisher = ctx.createSocket(ZMQ.PUB);
+            publisher = ctx.createSocket(SocketType.PUB);
 
             server = new Server[SERVER_MAX];
         }

--- a/src/test/java/guide/clonecli1.java
+++ b/src/test/java/guide/clonecli1.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
@@ -21,7 +22,7 @@ public class clonecli1
     public void run()
     {
         try (ZContext ctx = new ZContext()) {
-            Socket subscriber = ctx.createSocket(ZMQ.SUB);
+            Socket subscriber = ctx.createSocket(SocketType.SUB);
             subscriber.connect("tcp://localhost:5556");
             subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
 

--- a/src/test/java/guide/clonecli2.java
+++ b/src/test/java/guide/clonecli2.java
@@ -3,6 +3,7 @@ package guide;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
 import org.zeromq.ZContext;
@@ -20,10 +21,10 @@ public class clonecli2
     public void run()
     {
         try (ZContext ctx = new ZContext()) {
-            Socket snapshot = ctx.createSocket(ZMQ.DEALER);
+            Socket snapshot = ctx.createSocket(SocketType.DEALER);
             snapshot.connect("tcp://localhost:5556");
 
-            Socket subscriber = ctx.createSocket(ZMQ.SUB);
+            Socket subscriber = ctx.createSocket(SocketType.SUB);
             subscriber.connect("tcp://localhost:5557");
             subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
 

--- a/src/test/java/guide/clonecli3.java
+++ b/src/test/java/guide/clonecli3.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Poller;
@@ -22,14 +23,14 @@ public class clonecli3
     public void run()
     {
         try (ZContext ctx = new ZContext()) {
-            Socket snapshot = ctx.createSocket(ZMQ.DEALER);
+            Socket snapshot = ctx.createSocket(SocketType.DEALER);
             snapshot.connect("tcp://localhost:5556");
 
-            Socket subscriber = ctx.createSocket(ZMQ.SUB);
+            Socket subscriber = ctx.createSocket(SocketType.SUB);
             subscriber.connect("tcp://localhost:5557");
             subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
 
-            Socket push = ctx.createSocket(ZMQ.PUSH);
+            Socket push = ctx.createSocket(SocketType.PUSH);
             push.connect("tcp://localhost:5558");
 
             // get state snapshot

--- a/src/test/java/guide/clonecli4.java
+++ b/src/test/java/guide/clonecli4.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Poller;
@@ -25,14 +26,14 @@ public class clonecli4
     public void run()
     {
         try (ZContext ctx = new ZContext()) {
-            Socket snapshot = ctx.createSocket(ZMQ.DEALER);
+            Socket snapshot = ctx.createSocket(SocketType.DEALER);
             snapshot.connect("tcp://localhost:5556");
 
-            Socket subscriber = ctx.createSocket(ZMQ.SUB);
+            Socket subscriber = ctx.createSocket(SocketType.SUB);
             subscriber.connect("tcp://localhost:5557");
             subscriber.subscribe(SUBTREE.getBytes(ZMQ.CHARSET));
 
-            Socket push = ctx.createSocket(ZMQ.PUSH);
+            Socket push = ctx.createSocket(SocketType.PUSH);
             push.connect("tcp://localhost:5558");
 
             // get state snapshot

--- a/src/test/java/guide/clonecli5.java
+++ b/src/test/java/guide/clonecli5.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Poller;
@@ -22,14 +23,14 @@ public class clonecli5
     public void run()
     {
         try (ZContext ctx = new ZContext()) {
-            Socket snapshot = ctx.createSocket(ZMQ.DEALER);
+            Socket snapshot = ctx.createSocket(SocketType.DEALER);
             snapshot.connect("tcp://localhost:5556");
 
-            Socket subscriber = ctx.createSocket(ZMQ.SUB);
+            Socket subscriber = ctx.createSocket(SocketType.SUB);
             subscriber.connect("tcp://localhost:5557");
             subscriber.subscribe(SUBTREE.getBytes(ZMQ.CHARSET));
 
-            Socket publisher = ctx.createSocket(ZMQ.PUSH);
+            Socket publisher = ctx.createSocket(SocketType.PUSH);
             publisher.connect("tcp://localhost:5558");
 
             Map<String, kvmsg> kvMap = new HashMap<String, kvmsg>();

--- a/src/test/java/guide/clonesrv1.java
+++ b/src/test/java/guide/clonesrv1.java
@@ -4,6 +4,7 @@ import java.nio.ByteBuffer;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
 import org.zeromq.ZContext;
@@ -21,7 +22,7 @@ public class clonesrv1
     public void run()
     {
         try (ZContext ctx = new ZContext()) {
-            Socket publisher = ctx.createSocket(ZMQ.PUB);
+            Socket publisher = ctx.createSocket(SocketType.PUB);
             publisher.bind("tcp://*:5556");
 
             try {

--- a/src/test/java/guide/clonesrv2.java
+++ b/src/test/java/guide/clonesrv2.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Poller;
@@ -26,7 +27,7 @@ public class clonesrv2
     public void run()
     {
         try (ZContext ctx = new ZContext()) {
-            Socket publisher = ctx.createSocket(ZMQ.PUB);
+            Socket publisher = ctx.createSocket(SocketType.PUB);
             publisher.bind("tcp://*:5557");
 
             Socket updates = ZThread.fork(ctx, new StateManager());
@@ -67,7 +68,7 @@ public class clonesrv2
         {
             pipe.send("READY"); // optional
 
-            Socket snapshot = ctx.createSocket(ZMQ.ROUTER);
+            Socket snapshot = ctx.createSocket(SocketType.ROUTER);
             snapshot.bind("tcp://*:5556");
 
             Poller poller = ctx.createPoller(2);

--- a/src/test/java/guide/clonesrv3.java
+++ b/src/test/java/guide/clonesrv3.java
@@ -5,6 +5,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Poller;
@@ -22,13 +23,13 @@ public class clonesrv3
     public void run()
     {
         try (ZContext ctx = new ZContext()) {
-            Socket snapshot = ctx.createSocket(ZMQ.ROUTER);
+            Socket snapshot = ctx.createSocket(SocketType.ROUTER);
             snapshot.bind("tcp://*:5556");
 
-            Socket publisher = ctx.createSocket(ZMQ.PUB);
+            Socket publisher = ctx.createSocket(SocketType.PUB);
             publisher.bind("tcp://*:5557");
 
-            Socket collector = ctx.createSocket(ZMQ.PULL);
+            Socket collector = ctx.createSocket(SocketType.PULL);
             collector.bind("tcp://*:5558");
 
             Poller poller = ctx.createPoller(2);

--- a/src/test/java/guide/clonesrv4.java
+++ b/src/test/java/guide/clonesrv4.java
@@ -5,6 +5,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Poller;
@@ -20,13 +21,13 @@ public class clonesrv4
     public void run()
     {
         try (ZContext ctx = new ZContext()) {
-            Socket snapshot = ctx.createSocket(ZMQ.ROUTER);
+            Socket snapshot = ctx.createSocket(SocketType.ROUTER);
             snapshot.bind("tcp://*:5556");
 
-            Socket publisher = ctx.createSocket(ZMQ.PUB);
+            Socket publisher = ctx.createSocket(SocketType.PUB);
             publisher.bind("tcp://*:5557");
 
-            Socket collector = ctx.createSocket(ZMQ.PULL);
+            Socket collector = ctx.createSocket(SocketType.PULL);
             collector.bind("tcp://*:5558");
 
             Poller poller = ctx.createPoller(2);

--- a/src/test/java/guide/clonesrv5.java
+++ b/src/test/java/guide/clonesrv5.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZLoop;
 import org.zeromq.ZLoop.IZLoopHandler;
@@ -116,11 +117,11 @@ public class clonesrv5
         loop.verbose(false);
 
         //  Set up our clone server sockets
-        snapshot = ctx.createSocket(ZMQ.ROUTER);
+        snapshot = ctx.createSocket(SocketType.ROUTER);
         snapshot.bind(String.format("tcp://*:%d", port));
-        publisher = ctx.createSocket(ZMQ.PUB);
+        publisher = ctx.createSocket(SocketType.PUB);
         publisher.bind(String.format("tcp://*:%d", port + 1));
-        collector = ctx.createSocket(ZMQ.PULL);
+        collector = ctx.createSocket(SocketType.PULL);
         collector.bind(String.format("tcp://*:%d", port + 2));
     }
 

--- a/src/test/java/guide/clonesrv6.java
+++ b/src/test/java/guide/clonesrv6.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZLoop;
 import org.zeromq.ZLoop.IZLoopHandler;
@@ -202,7 +203,7 @@ public class clonesrv6
             //  Get state snapshot if necessary
             if (srv.kvmap == null) {
                 srv.kvmap = new HashMap<String, kvmsg>();
-                Socket snapshot = srv.ctx.createSocket(ZMQ.DEALER);
+                Socket snapshot = srv.ctx.createSocket(SocketType.DEALER);
                 snapshot.connect(String.format("tcp://localhost:%d", srv.peer));
 
                 System.out.printf("I: asking for snapshot from: tcp://localhost:%d\n", srv.peer);
@@ -254,7 +255,7 @@ public class clonesrv6
     {
         if (primary) {
             bStar = new bstar(true, "tcp://*:5003", "tcp://localhost:5004");
-            bStar.voter("tcp://*:5556", ZMQ.ROUTER, new Snapshots(), this);
+            bStar.voter("tcp://*:5556", SocketType.ROUTER, new Snapshots(), this);
 
             port = 5556;
             peer = 5566;
@@ -262,7 +263,7 @@ public class clonesrv6
         }
         else {
             bStar = new bstar(false, "tcp://*:5004", "tcp://localhost:5003");
-            bStar.voter("tcp://*:5566", ZMQ.ROUTER, new Snapshots(), this);
+            bStar.voter("tcp://*:5566", SocketType.ROUTER, new Snapshots(), this);
 
             port = 5566;
             peer = 5556;
@@ -278,14 +279,14 @@ public class clonesrv6
         bStar.setVerbose(true);
 
         //  Set up our clone server sockets
-        publisher = ctx.createSocket(ZMQ.PUB);
-        collector = ctx.createSocket(ZMQ.SUB);
+        publisher = ctx.createSocket(SocketType.PUB);
+        collector = ctx.createSocket(SocketType.SUB);
         collector.subscribe(ZMQ.SUBSCRIPTION_ALL);
         publisher.bind(String.format("tcp://*:%d", port + 1));
         collector.bind(String.format("tcp://*:%d", port + 2));
 
         //  Set up our own clone client interface to peer
-        subscriber = ctx.createSocket(ZMQ.SUB);
+        subscriber = ctx.createSocket(SocketType.SUB);
         subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
         subscriber.connect(String.format("tcp://localhost:%d", peer + 1));
     }

--- a/src/test/java/guide/espresso.java
+++ b/src/test/java/guide/espresso.java
@@ -2,11 +2,8 @@ package guide;
 
 import java.util.Random;
 
-import org.zeromq.ZContext;
-import org.zeromq.ZFrame;
-import org.zeromq.ZMQ;
+import org.zeromq.*;
 import org.zeromq.ZMQ.Socket;
-import org.zeromq.ZThread;
 import org.zeromq.ZThread.IAttachedRunnable;
 
 //  Espresso Pattern
@@ -22,7 +19,7 @@ public class espresso
         public void run(Object[] args, ZContext ctx, Socket pipe)
         {
             //  Subscribe to "A" and "B"
-            Socket subscriber = ctx.createSocket(ZMQ.SUB);
+            Socket subscriber = ctx.createSocket(SocketType.SUB);
             subscriber.connect("tcp://localhost:6001");
             subscriber.subscribe("A".getBytes(ZMQ.CHARSET));
             subscriber.subscribe("B".getBytes(ZMQ.CHARSET));
@@ -45,7 +42,7 @@ public class espresso
         @Override
         public void run(Object[] args, ZContext ctx, Socket pipe)
         {
-            Socket publisher = ctx.createSocket(ZMQ.PUB);
+            Socket publisher = ctx.createSocket(SocketType.PUB);
             publisher.bind("tcp://*:6000");
             Random rand = new Random(System.currentTimeMillis());
 
@@ -93,9 +90,9 @@ public class espresso
             ZThread.fork(ctx, new Publisher());
             ZThread.fork(ctx, new Subscriber());
 
-            Socket subscriber = ctx.createSocket(ZMQ.XSUB);
+            Socket subscriber = ctx.createSocket(SocketType.XSUB);
             subscriber.connect("tcp://localhost:6000");
-            Socket publisher = ctx.createSocket(ZMQ.XPUB);
+            Socket publisher = ctx.createSocket(SocketType.XPUB);
             publisher.bind("tcp://*:6001");
             Socket listener = ZThread.fork(ctx, new Listener());
             ZMQ.proxy(subscriber, publisher, listener);

--- a/src/test/java/guide/flcliapi.java
+++ b/src/test/java/guide/flcliapi.java
@@ -5,12 +5,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.zeromq.ZContext;
-import org.zeromq.ZMQ;
+import org.zeromq.*;
 import org.zeromq.ZMQ.Poller;
 import org.zeromq.ZMQ.Socket;
-import org.zeromq.ZMsg;
-import org.zeromq.ZThread;
 import org.zeromq.ZThread.IAttachedRunnable;
 
 //  flcliapi class - Freelance Pattern agent class
@@ -149,7 +146,7 @@ public class flcliapi
         {
             this.ctx = ctx;
             this.pipe = pipe;
-            router = ctx.createSocket(ZMQ.ROUTER);
+            router = ctx.createSocket(SocketType.ROUTER);
             servers = new HashMap<String, Server>();
             actives = new ArrayList<Server>();
         }

--- a/src/test/java/guide/flclient1.java
+++ b/src/test/java/guide/flclient1.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Poller;
@@ -16,7 +17,7 @@ public class flclient1
     private static ZMsg tryRequest(ZContext ctx, String endpoint, ZMsg request)
     {
         System.out.printf("I: trying echo service at %s...\n", endpoint);
-        Socket client = ctx.createSocket(ZMQ.REQ);
+        Socket client = ctx.createSocket(SocketType.REQ);
         client.connect(endpoint);
 
         //  Send request, wait safely for reply

--- a/src/test/java/guide/flclient2.java
+++ b/src/test/java/guide/flclient2.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Poller;
@@ -25,7 +26,7 @@ public class flclient2
     public flclient2()
     {
         ctx = new ZContext();
-        socket = ctx.createSocket(ZMQ.DEALER);
+        socket = ctx.createSocket(SocketType.DEALER);
     }
 
     public void destroy()

--- a/src/test/java/guide/flserver1.java
+++ b/src/test/java/guide/flserver1.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
@@ -17,7 +18,7 @@ public class flserver1
         }
 
         try (ZContext ctx = new ZContext()) {
-            Socket server = ctx.createSocket(ZMQ.REP);
+            Socket server = ctx.createSocket(SocketType.REP);
             server.bind(args[0]);
 
             System.out.printf("I: echo service is ready at %s\n", args[0]);

--- a/src/test/java/guide/flserver2.java
+++ b/src/test/java/guide/flserver2.java
@@ -1,10 +1,7 @@
 package guide;
 
-import org.zeromq.ZContext;
-import org.zeromq.ZFrame;
-import org.zeromq.ZMQ;
+import org.zeromq.*;
 import org.zeromq.ZMQ.Socket;
-import org.zeromq.ZMsg;
 
 //  Freelance server - Model 2
 //  Does some work, replies OK, with message sequencing
@@ -18,7 +15,7 @@ public class flserver2
         }
 
         try (ZContext ctx = new ZContext()) {
-            Socket server = ctx.createSocket(ZMQ.REP);
+            Socket server = ctx.createSocket(SocketType.REP);
             server.bind(args[0]);
 
             System.out.printf("I: echo service is ready at %s\n", args[0]);

--- a/src/test/java/guide/flserver3.java
+++ b/src/test/java/guide/flserver3.java
@@ -1,10 +1,7 @@
 package guide;
 
-import org.zeromq.ZContext;
-import org.zeromq.ZFrame;
-import org.zeromq.ZMQ;
+import org.zeromq.*;
 import org.zeromq.ZMQ.Socket;
-import org.zeromq.ZMsg;
 
 //  Freelance server - Model 3
 //  Uses an ROUTER/ROUTER socket but just one thread
@@ -18,7 +15,7 @@ public class flserver3
             //  Prepare server socket with predictable identity
             String bindEndpoint = "tcp://*:5555";
             String connectEndpoint = "tcp://localhost:5555";
-            Socket server = ctx.createSocket(ZMQ.ROUTER);
+            Socket server = ctx.createSocket(SocketType.ROUTER);
             server.setIdentity(connectEndpoint.getBytes(ZMQ.CHARSET));
             server.bind(bindEndpoint);
             System.out.printf("I: service is ready at %s\n", bindEndpoint);

--- a/src/test/java/guide/hwclient.java
+++ b/src/test/java/guide/hwclient.java
@@ -6,6 +6,7 @@ package guide;
 //  Sends "Hello" to server, expects "World" back
 //
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZContext;
 
@@ -17,7 +18,7 @@ public class hwclient
             //  Socket to talk to server
             System.out.println("Connecting to hello world server");
 
-            ZMQ.Socket socket = context.createSocket(ZMQ.REQ);
+            ZMQ.Socket socket = context.createSocket(SocketType.REQ);
             socket.connect("tcp://localhost:5555");
 
             for (int requestNbr = 0; requestNbr != 10; requestNbr++) {

--- a/src/test/java/guide/hwserver.java
+++ b/src/test/java/guide/hwserver.java
@@ -6,6 +6,7 @@ package guide;
 //  Expects "Hello" from client, replies with "World"
 //
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZContext;
 
@@ -15,7 +16,7 @@ public class hwserver
     {
         try (ZContext context = new ZContext()) {
             // Socket to talk to clients
-            ZMQ.Socket socket = context.createSocket(ZMQ.REP);
+            ZMQ.Socket socket = context.createSocket(SocketType.REP);
             socket.bind("tcp://*:5555");
 
             while (!Thread.currentThread().isInterrupted()) {

--- a/src/test/java/guide/identity.java
+++ b/src/test/java/guide/identity.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
 import org.zeromq.ZContext;
@@ -12,18 +13,18 @@ public class identity
     public static void main(String[] args) throws InterruptedException
     {
         try (ZContext context = new ZContext()) {
-            Socket sink = context.createSocket(ZMQ.ROUTER);
+            Socket sink = context.createSocket(SocketType.ROUTER);
             sink.bind("inproc://example");
 
             //  First allow 0MQ to set the identity, [00] + random 4byte
-            Socket anonymous = context.createSocket(ZMQ.REQ);
+            Socket anonymous = context.createSocket(SocketType.REQ);
 
             anonymous.connect("inproc://example");
             anonymous.send("ROUTER uses a generated UUID", 0);
             ZHelper.dump(sink);
 
             //  Then set the identity ourself
-            Socket identified = context.createSocket(ZMQ.REQ);
+            Socket identified = context.createSocket(SocketType.REQ);
             identified.setIdentity("Hello".getBytes(ZMQ.CHARSET));
             identified.connect("inproc://example");
             identified.send("ROUTER socket uses REQ's socket identity", 0);

--- a/src/test/java/guide/interrupt.java
+++ b/src/test/java/guide/interrupt.java
@@ -6,6 +6,7 @@ package guide;
 *  Shows how to handle Ctrl-C
 */
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQException;
 import org.zeromq.ZContext;
@@ -22,7 +23,7 @@ public class interrupt
             @Override
             public void run()
             {
-                ZMQ.Socket socket = context.createSocket(ZMQ.REP);
+                ZMQ.Socket socket = context.createSocket(SocketType.REP);
                 socket.bind("tcp://*:5555");
 
                 while (!Thread.currentThread().isInterrupted()) {

--- a/src/test/java/guide/kvmsg.java
+++ b/src/test/java/guide/kvmsg.java
@@ -7,6 +7,7 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.UUID;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
@@ -328,9 +329,9 @@ public class kvmsg
 
         //  Prepare our context and sockets
         try (ZContext ctx = new ZContext()) {
-            Socket output = ctx.createSocket(ZMQ.DEALER);
+            Socket output = ctx.createSocket(SocketType.DEALER);
             output.bind("ipc://kvmsg_selftest.ipc");
-            Socket input = ctx.createSocket(ZMQ.DEALER);
+            Socket input = ctx.createSocket(SocketType.DEALER);
             input.connect("ipc://kvmsg_selftest.ipc");
 
             Map<String, kvmsg> kvmap = new HashMap<String, kvmsg>();

--- a/src/test/java/guide/lbbroker.java
+++ b/src/test/java/guide/lbbroker.java
@@ -3,6 +3,7 @@ package guide;
 import java.util.LinkedList;
 import java.util.Queue;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Poller;
 import org.zeromq.ZMQ.Socket;
@@ -23,7 +24,7 @@ public class lbbroker
         {
             //  Prepare our context and sockets
             try (ZContext context = new ZContext()) {
-                Socket client = context.createSocket(ZMQ.REQ);
+                Socket client = context.createSocket(SocketType.REQ);
                 ZHelper.setId(client); //  Set a printable identity
 
                 client.connect("ipc://frontend.ipc");
@@ -49,7 +50,7 @@ public class lbbroker
         {
             //  Prepare our context and sockets
             try (ZContext context = new ZContext()) {
-                Socket worker = context.createSocket(ZMQ.REQ);
+                Socket worker = context.createSocket(SocketType.REQ);
                 ZHelper.setId(worker); //  Set a printable identity
 
                 worker.connect("ipc://backend.ipc");
@@ -85,8 +86,8 @@ public class lbbroker
     {
         //  Prepare our context and sockets
         try (ZContext context = new ZContext()) {
-            Socket frontend = context.createSocket(ZMQ.ROUTER);
-            Socket backend = context.createSocket(ZMQ.ROUTER);
+            Socket frontend = context.createSocket(SocketType.ROUTER);
+            Socket backend = context.createSocket(SocketType.ROUTER);
             frontend.bind("ipc://frontend.ipc");
             backend.bind("ipc://backend.ipc");
 

--- a/src/test/java/guide/lbbroker2.java
+++ b/src/test/java/guide/lbbroker2.java
@@ -4,13 +4,9 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.Queue;
 
-import org.zeromq.ZContext;
-import org.zeromq.ZFrame;
-import org.zeromq.ZMQ;
+import org.zeromq.*;
 import org.zeromq.ZMQ.Poller;
 import org.zeromq.ZMQ.Socket;
-import org.zeromq.ZMsg;
-import org.zeromq.ZThread;
 
 /**
  * Load-balancing broker
@@ -32,7 +28,7 @@ public class lbbroker2
         {
             //  Prepare our context and sockets
             try (ZContext context = new ZContext()) {
-                Socket client = context.createSocket(ZMQ.REQ);
+                Socket client = context.createSocket(SocketType.REQ);
                 ZHelper.setId(client); //  Set a printable identity
 
                 client.connect("ipc://frontend.ipc");
@@ -55,7 +51,7 @@ public class lbbroker2
         {
             //  Prepare our context and sockets
             try (ZContext context = new ZContext()) {
-                Socket worker = context.createSocket(ZMQ.REQ);
+                Socket worker = context.createSocket(SocketType.REQ);
                 ZHelper.setId(worker); //  Set a printable identity
 
                 worker.connect("ipc://backend.ipc");
@@ -85,8 +81,8 @@ public class lbbroker2
     {
         //  Prepare our context and sockets
         try (ZContext context = new ZContext()) {
-            Socket frontend = context.createSocket(ZMQ.ROUTER);
-            Socket backend = context.createSocket(ZMQ.ROUTER);
+            Socket frontend = context.createSocket(SocketType.ROUTER);
+            Socket backend = context.createSocket(SocketType.ROUTER);
             frontend.bind("ipc://frontend.ipc");
             backend.bind("ipc://backend.ipc");
 

--- a/src/test/java/guide/lbbroker3.java
+++ b/src/test/java/guide/lbbroker3.java
@@ -4,14 +4,9 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.Queue;
 
-import org.zeromq.ZContext;
-import org.zeromq.ZFrame;
-import org.zeromq.ZLoop;
-import org.zeromq.ZMQ;
+import org.zeromq.*;
 import org.zeromq.ZMQ.PollItem;
 import org.zeromq.ZMQ.Socket;
-import org.zeromq.ZMsg;
-import org.zeromq.ZThread;
 
 /**
  * Load-balancing broker
@@ -35,7 +30,7 @@ public class lbbroker3
         {
             //  Prepare our context and sockets
             try (ZContext context = new ZContext()) {
-                Socket client = context.createSocket(ZMQ.REQ);
+                Socket client = context.createSocket(SocketType.REQ);
                 ZHelper.setId(client); //  Set a printable identity
 
                 client.connect("ipc://frontend.ipc");
@@ -58,7 +53,7 @@ public class lbbroker3
         {
             //  Prepare our context and sockets
             try (ZContext context = new ZContext()) {
-                Socket worker = context.createSocket(ZMQ.REQ);
+                Socket worker = context.createSocket(SocketType.REQ);
                 ZHelper.setId(worker); //  Set a printable identity
 
                 worker.connect("ipc://backend.ipc");
@@ -155,8 +150,8 @@ public class lbbroker3
         //  Prepare our context and sockets
         try (ZContext context = new ZContext()) {
             LBBroker arg = new LBBroker();
-            arg.frontend = context.createSocket(ZMQ.ROUTER);
-            arg.backend = context.createSocket(ZMQ.ROUTER);
+            arg.frontend = context.createSocket(SocketType.ROUTER);
+            arg.backend = context.createSocket(SocketType.ROUTER);
             arg.frontend.bind("ipc://frontend.ipc");
             arg.backend.bind("ipc://backend.ipc");
 

--- a/src/test/java/guide/lpclient.java
+++ b/src/test/java/guide/lpclient.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Poller;
@@ -22,7 +23,7 @@ public class lpclient
     {
         try (ZContext ctx = new ZContext()) {
             System.out.println("I: connecting to server");
-            Socket client = ctx.createSocket(ZMQ.REQ);
+            Socket client = ctx.createSocket(SocketType.REQ);
             assert (client != null);
             client.connect(SERVER_ENDPOINT);
 
@@ -80,7 +81,7 @@ public class lpclient
                         poller.unregister(client);
                         ctx.destroySocket(client);
                         System.out.println("I: reconnecting to server\n");
-                        client = ctx.createSocket(ZMQ.REQ);
+                        client = ctx.createSocket(SocketType.REQ);
                         client.connect(SERVER_ENDPOINT);
                         poller.register(client, Poller.POLLIN);
                         //  Send request again, on new socket

--- a/src/test/java/guide/lpserver.java
+++ b/src/test/java/guide/lpserver.java
@@ -2,6 +2,7 @@ package guide;
 
 import java.util.Random;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
 import org.zeromq.ZContext;
@@ -21,7 +22,7 @@ public class lpserver
         Random rand = new Random(System.nanoTime());
 
         try (ZContext context = new ZContext()) {
-            Socket server = context.createSocket(ZMQ.REP);
+            Socket server = context.createSocket(SocketType.REP);
             server.bind("tcp://*:5555");
 
             int cycles = 0;

--- a/src/test/java/guide/lruqueue3.java
+++ b/src/test/java/guide/lruqueue3.java
@@ -3,13 +3,9 @@ package guide;
 import java.util.LinkedList;
 import java.util.Queue;
 
-import org.zeromq.ZContext;
-import org.zeromq.ZFrame;
-import org.zeromq.ZLoop;
-import org.zeromq.ZMQ;
+import org.zeromq.*;
 import org.zeromq.ZMQ.PollItem;
 import org.zeromq.ZMQ.Socket;
-import org.zeromq.ZMsg;
 
 class ClientThread3 extends Thread
 {
@@ -18,7 +14,7 @@ class ClientThread3 extends Thread
     {
         //  Prepare our context and sockets
         try (ZContext context = new ZContext()) {
-            Socket client = context.createSocket(ZMQ.REQ);
+            Socket client = context.createSocket(SocketType.REQ);
 
             //  Initialize random number generator
             client.connect("ipc://frontend.ipc");
@@ -53,7 +49,7 @@ class WorkerThread3 extends Thread
     {
         //  Prepare our context and sockets
         try (ZContext context = new ZContext()) {
-            Socket worker = context.createSocket(ZMQ.REQ);
+            Socket worker = context.createSocket(SocketType.REQ);
 
             worker.connect("ipc://backend.ipc");
 
@@ -154,8 +150,8 @@ public class lruqueue3
         //  Prepare our context and sockets
         try (ZContext context = new ZContext()) {
             LRUQueueArg arg = new LRUQueueArg();
-            Socket frontend = context.createSocket(ZMQ.ROUTER);
-            Socket backend = context.createSocket(ZMQ.ROUTER);
+            Socket frontend = context.createSocket(SocketType.ROUTER);
+            Socket backend = context.createSocket(SocketType.ROUTER);
             arg.frontend = frontend;
             arg.backend = backend;
 

--- a/src/test/java/guide/lvcache.java
+++ b/src/test/java/guide/lvcache.java
@@ -3,6 +3,7 @@ package guide;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZFrame;
 import org.zeromq.ZMQ;
@@ -16,9 +17,9 @@ public class lvcache
     public static void main(String[] args)
     {
         try (ZContext context = new ZContext()) {
-            Socket frontend = context.createSocket(ZMQ.SUB);
+            Socket frontend = context.createSocket(SocketType.SUB);
             frontend.bind("tcp://*:5557");
-            Socket backend = context.createSocket(ZMQ.XPUB);
+            Socket backend = context.createSocket(SocketType.XPUB);
             backend.bind("tcp://*:5558");
 
             //  Subscribe to every single topic from publisher

--- a/src/test/java/guide/mdbroker.java
+++ b/src/test/java/guide/mdbroker.java
@@ -6,10 +6,7 @@ import java.util.Formatter;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.zeromq.ZContext;
-import org.zeromq.ZFrame;
-import org.zeromq.ZMQ;
-import org.zeromq.ZMsg;
+import org.zeromq.*;
 
 /**
 *  Majordomo Protocol broker
@@ -98,7 +95,7 @@ public class mdbroker
         this.waiting = new ArrayDeque<Worker>();
         this.heartbeatAt = System.currentTimeMillis() + HEARTBEAT_INTERVAL;
         this.ctx = new ZContext();
-        this.socket = ctx.createSocket(ZMQ.ROUTER);
+        this.socket = ctx.createSocket(SocketType.ROUTER);
     }
 
     // ---------------------------------------------------------------------

--- a/src/test/java/guide/mdcliapi.java
+++ b/src/test/java/guide/mdcliapi.java
@@ -2,10 +2,7 @@ package guide;
 
 import java.util.Formatter;
 
-import org.zeromq.ZContext;
-import org.zeromq.ZFrame;
-import org.zeromq.ZMQ;
-import org.zeromq.ZMsg;
+import org.zeromq.*;
 
 /**
 * Majordomo Protocol Client API, Java version Implements the MDP/Worker spec at
@@ -59,7 +56,7 @@ public class mdcliapi
         if (client != null) {
             ctx.destroySocket(client);
         }
-        client = ctx.createSocket(ZMQ.REQ);
+        client = ctx.createSocket(SocketType.REQ);
         client.connect(broker);
         if (verbose)
             log.format("I: connecting to broker at %s\n", broker);

--- a/src/test/java/guide/mdcliapi2.java
+++ b/src/test/java/guide/mdcliapi2.java
@@ -2,10 +2,7 @@ package guide;
 
 import java.util.Formatter;
 
-import org.zeromq.ZContext;
-import org.zeromq.ZFrame;
-import org.zeromq.ZMQ;
-import org.zeromq.ZMsg;
+import org.zeromq.*;
 
 /**
  * Majordomo Protocol Client API, asynchronous Java version. Implements the
@@ -47,7 +44,7 @@ public class mdcliapi2
         if (client != null) {
             ctx.destroySocket(client);
         }
-        client = ctx.createSocket(ZMQ.DEALER);
+        client = ctx.createSocket(SocketType.DEALER);
         client.connect(broker);
         if (verbose)
             log.format("I: connecting to broker at %s...\n", broker);

--- a/src/test/java/guide/mdwrkapi.java
+++ b/src/test/java/guide/mdwrkapi.java
@@ -2,10 +2,7 @@ package guide;
 
 import java.util.Formatter;
 
-import org.zeromq.ZContext;
-import org.zeromq.ZFrame;
-import org.zeromq.ZMQ;
-import org.zeromq.ZMsg;
+import org.zeromq.*;
 
 /**
 * Majordomo Protocol Client API, Java version Implements the MDP/Worker spec at
@@ -81,7 +78,7 @@ public class mdwrkapi
         if (worker != null) {
             ctx.destroySocket(worker);
         }
-        worker = ctx.createSocket(ZMQ.DEALER);
+        worker = ctx.createSocket(SocketType.DEALER);
         worker.connect(broker);
         if (verbose)
             log.format("I: connecting to broker at %s\n", broker);

--- a/src/test/java/guide/msgqueue.java
+++ b/src/test/java/guide/msgqueue.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
 import org.zeromq.ZContext;
@@ -16,11 +17,11 @@ public class msgqueue
         //  Prepare our context and sockets
         try (ZContext context = new ZContext()) {
             //  Socket facing clients
-            Socket frontend = context.createSocket(ZMQ.ROUTER);
+            Socket frontend = context.createSocket(SocketType.ROUTER);
             frontend.bind("tcp://*:5559");
 
             //  Socket facing services
-            Socket backend = context.createSocket(ZMQ.DEALER);
+            Socket backend = context.createSocket(SocketType.DEALER);
             backend.bind("tcp://*:5560");
 
             //  Start the proxy

--- a/src/test/java/guide/mspoller.java
+++ b/src/test/java/guide/mspoller.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZContext;
 
@@ -14,11 +15,11 @@ public class mspoller
     {
         try (ZContext context = new ZContext()) {
             // Connect to task ventilator
-            ZMQ.Socket receiver = context.createSocket(ZMQ.PULL);
+            ZMQ.Socket receiver = context.createSocket(SocketType.PULL);
             receiver.connect("tcp://localhost:5557");
 
             //  Connect to weather server
-            ZMQ.Socket subscriber = context.createSocket(ZMQ.SUB);
+            ZMQ.Socket subscriber = context.createSocket(SocketType.SUB);
             subscriber.connect("tcp://localhost:5556");
             subscriber.subscribe("10001 ".getBytes(ZMQ.CHARSET));
 

--- a/src/test/java/guide/msreader.java
+++ b/src/test/java/guide/msreader.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZContext;
 
@@ -15,11 +16,11 @@ public class msreader
         //  Prepare our context and sockets
         try (ZContext context = new ZContext()) {
             // Connect to task ventilator
-            ZMQ.Socket receiver = context.createSocket(ZMQ.PULL);
+            ZMQ.Socket receiver = context.createSocket(SocketType.PULL);
             receiver.connect("tcp://localhost:5557");
 
             //  Connect to weather server
-            ZMQ.Socket subscriber = context.createSocket(ZMQ.SUB);
+            ZMQ.Socket subscriber = context.createSocket(SocketType.SUB);
             subscriber.connect("tcp://localhost:5556");
             subscriber.subscribe("10001 ".getBytes(ZMQ.CHARSET));
 

--- a/src/test/java/guide/mtrelay.java
+++ b/src/test/java/guide/mtrelay.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
 import org.zeromq.ZContext;
@@ -23,7 +24,7 @@ public class mtrelay
         public void run()
         {
             //  Signal downstream to step 2
-            Socket xmitter = context.createSocket(ZMQ.PAIR);
+            Socket xmitter = context.createSocket(SocketType.PAIR);
             xmitter.connect("inproc://step2");
             System.out.println("Step 1 ready, signaling step 2");
             xmitter.send("READY", 0);
@@ -45,7 +46,7 @@ public class mtrelay
         public void run()
         {
             //  Bind to inproc: endpoint, then start upstream thread
-            Socket receiver = context.createSocket(ZMQ.PAIR);
+            Socket receiver = context.createSocket(SocketType.PAIR);
             receiver.bind("inproc://step2");
             Thread step1 = new Step1(context);
             step1.start();
@@ -55,7 +56,7 @@ public class mtrelay
             receiver.close();
 
             //  Connect to step3 and tell it we're ready
-            Socket xmitter = context.createSocket(ZMQ.PAIR);
+            Socket xmitter = context.createSocket(SocketType.PAIR);
             xmitter.connect("inproc://step3");
             xmitter.send("READY", 0);
 
@@ -68,7 +69,7 @@ public class mtrelay
     {
         try (ZContext context = new ZContext()) {
             //  Bind to inproc: endpoint, then start upstream thread
-            Socket receiver = context.createSocket(ZMQ.PAIR);
+            Socket receiver = context.createSocket(SocketType.PAIR);
             receiver.bind("inproc://step3");
 
             //  Step 2 relays the signal to step 3

--- a/src/test/java/guide/mtserver.java
+++ b/src/test/java/guide/mtserver.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
 import org.zeromq.ZContext;
@@ -22,7 +23,7 @@ public class mtserver
         @Override
         public void run()
         {
-            ZMQ.Socket socket = context.createSocket(ZMQ.REP);
+            ZMQ.Socket socket = context.createSocket(SocketType.REP);
             socket.connect("inproc://workers");
 
             while (true) {
@@ -47,10 +48,10 @@ public class mtserver
     public static void main(String[] args)
     {
         try (ZContext context = new ZContext()) {
-            Socket clients = context.createSocket(ZMQ.ROUTER);
+            Socket clients = context.createSocket(SocketType.ROUTER);
             clients.bind("tcp://*:5555");
 
-            Socket workers = context.createSocket(ZMQ.DEALER);
+            Socket workers = context.createSocket(SocketType.DEALER);
             workers.bind("inproc://workers");
 
             for (int thread_nbr = 0; thread_nbr < 5; thread_nbr++) {

--- a/src/test/java/guide/pathopub.java
+++ b/src/test/java/guide/pathopub.java
@@ -2,6 +2,7 @@ package guide;
 
 import java.util.Random;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
@@ -13,7 +14,7 @@ public class pathopub
     public static void main(String[] args) throws Exception
     {
         try (ZContext context = new ZContext()) {
-            Socket publisher = context.createSocket(ZMQ.PUB);
+            Socket publisher = context.createSocket(SocketType.PUB);
             if (args.length == 1)
                 publisher.connect(args[0]);
             else publisher.bind("tcp://*:5556");

--- a/src/test/java/guide/pathosub.java
+++ b/src/test/java/guide/pathosub.java
@@ -2,6 +2,7 @@ package guide;
 
 import java.util.Random;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
@@ -13,7 +14,7 @@ public class pathosub
     public static void main(String[] args)
     {
         try (ZContext context = new ZContext()) {
-            Socket subscriber = context.createSocket(ZMQ.SUB);
+            Socket subscriber = context.createSocket(SocketType.SUB);
             if (args.length == 1)
                 subscriber.connect(args[0]);
             else subscriber.connect("tcp://localhost:5556");

--- a/src/test/java/guide/peering1.java
+++ b/src/test/java/guide/peering1.java
@@ -2,6 +2,7 @@ package guide;
 
 import java.util.Random;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Poller;
@@ -28,11 +29,11 @@ public class peering1
 
         try (ZContext ctx = new ZContext()) {
             //  Bind state backend to endpoint
-            Socket statebe = ctx.createSocket(ZMQ.PUB);
+            Socket statebe = ctx.createSocket(SocketType.PUB);
             statebe.bind(String.format("ipc://%s-state.ipc", self));
 
             //  Connect statefe to all peers
-            Socket statefe = ctx.createSocket(ZMQ.SUB);
+            Socket statefe = ctx.createSocket(SocketType.SUB);
             statefe.subscribe(ZMQ.SUBSCRIPTION_ALL);
             int argn;
             for (argn = 1; argn < argv.length; argn++) {

--- a/src/test/java/guide/peering2.java
+++ b/src/test/java/guide/peering2.java
@@ -4,12 +4,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Random;
 
-import org.zeromq.ZContext;
-import org.zeromq.ZFrame;
-import org.zeromq.ZMQ;
+import org.zeromq.*;
 import org.zeromq.ZMQ.Poller;
 import org.zeromq.ZMQ.Socket;
-import org.zeromq.ZMsg;
 
 //  Broker peering simulation (part 2)
 //  Prototypes the request-reply flow
@@ -32,7 +29,7 @@ public class peering2
         public void run()
         {
             try (ZContext ctx = new ZContext()) {
-                Socket client = ctx.createSocket(ZMQ.REQ);
+                Socket client = ctx.createSocket(SocketType.REQ);
                 client.connect(String.format("ipc://%s-localfe.ipc", self));
 
                 while (true) {
@@ -61,7 +58,7 @@ public class peering2
         public void run()
         {
             try (ZContext ctx = new ZContext()) {
-                Socket worker = ctx.createSocket(ZMQ.REQ);
+                Socket worker = ctx.createSocket(SocketType.REQ);
                 worker.connect(String.format("ipc://%s-localbe.ipc", self));
 
                 //  Tell broker we're ready for work
@@ -99,12 +96,12 @@ public class peering2
 
         try (ZContext ctx = new ZContext()) {
             //  Bind cloud frontend to endpoint
-            Socket cloudfe = ctx.createSocket(ZMQ.ROUTER);
+            Socket cloudfe = ctx.createSocket(SocketType.ROUTER);
             cloudfe.setIdentity(self.getBytes(ZMQ.CHARSET));
             cloudfe.bind(String.format("ipc://%s-cloud.ipc", self));
 
             //  Connect cloud backend to all peers
-            Socket cloudbe = ctx.createSocket(ZMQ.ROUTER);
+            Socket cloudbe = ctx.createSocket(SocketType.ROUTER);
             cloudbe.setIdentity(self.getBytes(ZMQ.CHARSET));
             int argn;
             for (argn = 1; argn < argv.length; argn++) {
@@ -116,9 +113,9 @@ public class peering2
             }
 
             //  Prepare local frontend and backend
-            Socket localfe = ctx.createSocket(ZMQ.ROUTER);
+            Socket localfe = ctx.createSocket(SocketType.ROUTER);
             localfe.bind(String.format("ipc://%s-localfe.ipc", self));
-            Socket localbe = ctx.createSocket(ZMQ.ROUTER);
+            Socket localbe = ctx.createSocket(SocketType.ROUTER);
             localbe.bind(String.format("ipc://%s-localbe.ipc", self));
 
             //  Get user to tell us when we can start

--- a/src/test/java/guide/ppqueue.java
+++ b/src/test/java/guide/ppqueue.java
@@ -3,12 +3,9 @@ package guide;
 import java.util.ArrayList;
 import java.util.Iterator;
 
-import org.zeromq.ZContext;
-import org.zeromq.ZFrame;
-import org.zeromq.ZMQ;
+import org.zeromq.*;
 import org.zeromq.ZMQ.Poller;
 import org.zeromq.ZMQ.Socket;
-import org.zeromq.ZMsg;
 
 //
 // Paranoid Pirate queue
@@ -82,8 +79,8 @@ public class ppqueue
     public static void main(String[] args)
     {
         try (ZContext ctx = new ZContext()) {
-            Socket frontend = ctx.createSocket(ZMQ.ROUTER);
-            Socket backend = ctx.createSocket(ZMQ.ROUTER);
+            Socket frontend = ctx.createSocket(SocketType.ROUTER);
+            Socket backend = ctx.createSocket(SocketType.ROUTER);
             frontend.bind("tcp://*:5555"); //  For clients
             backend.bind("tcp://*:5556"); //  For workers
 

--- a/src/test/java/guide/ppworker.java
+++ b/src/test/java/guide/ppworker.java
@@ -2,12 +2,9 @@ package guide;
 
 import java.util.Random;
 
-import org.zeromq.ZContext;
-import org.zeromq.ZFrame;
-import org.zeromq.ZMQ;
+import org.zeromq.*;
 import org.zeromq.ZMQ.Poller;
 import org.zeromq.ZMQ.Socket;
-import org.zeromq.ZMsg;
 
 //
 // Paranoid Pirate worker
@@ -28,7 +25,7 @@ public class ppworker
 
     private static Socket worker_socket(ZContext ctx)
     {
-        Socket worker = ctx.createSocket(ZMQ.DEALER);
+        Socket worker = ctx.createSocket(SocketType.DEALER);
         worker.connect("tcp://localhost:5556");
 
         //  Tell queue we're ready for work

--- a/src/test/java/guide/psenvpub.java
+++ b/src/test/java/guide/psenvpub.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
 import org.zeromq.ZContext;
@@ -15,7 +16,7 @@ public class psenvpub
     {
         // Prepare our context and publisher
         try (ZContext context = new ZContext()) {
-            Socket publisher = context.createSocket(ZMQ.PUB);
+            Socket publisher = context.createSocket(SocketType.PUB);
             publisher.bind("tcp://*:5563");
 
             while (!Thread.currentThread().isInterrupted()) {

--- a/src/test/java/guide/psenvsub.java
+++ b/src/test/java/guide/psenvsub.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
 import org.zeromq.ZContext;
@@ -15,7 +16,7 @@ public class psenvsub
     {
         // Prepare our context and subscriber
         try (ZContext context = new ZContext()) {
-            Socket subscriber = context.createSocket(ZMQ.SUB);
+            Socket subscriber = context.createSocket(SocketType.SUB);
             subscriber.connect("tcp://localhost:5563");
             subscriber.subscribe("B".getBytes(ZMQ.CHARSET));
 

--- a/src/test/java/guide/rrbroker.java
+++ b/src/test/java/guide/rrbroker.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Poller;
 import org.zeromq.ZMQ.Socket;
@@ -16,8 +17,8 @@ public class rrbroker
     {
         //  Prepare our context and sockets
         try (ZContext context = new ZContext()) {
-            Socket frontend = context.createSocket(ZMQ.ROUTER);
-            Socket backend = context.createSocket(ZMQ.DEALER);
+            Socket frontend = context.createSocket(SocketType.ROUTER);
+            Socket backend = context.createSocket(SocketType.DEALER);
             frontend.bind("tcp://*:5559");
             backend.bind("tcp://*:5560");
 

--- a/src/test/java/guide/rrclient.java
+++ b/src/test/java/guide/rrclient.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
 import org.zeromq.ZContext;
@@ -16,7 +17,7 @@ public class rrclient
     {
         try (ZContext context = new ZContext()) {
             //  Socket to talk to server
-            Socket requester = context.createSocket(ZMQ.REQ);
+            Socket requester = context.createSocket(SocketType.REQ);
             requester.connect("tcp://localhost:5559");
 
             System.out.println("launch and connect client.");

--- a/src/test/java/guide/rrworker.java
+++ b/src/test/java/guide/rrworker.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
 import org.zeromq.ZContext;
@@ -13,7 +14,7 @@ public class rrworker
     {
         try (ZContext context = new ZContext()) {
             //  Socket to talk to server
-            Socket responder = context.createSocket(ZMQ.REP);
+            Socket responder = context.createSocket(SocketType.REP);
             responder.connect("tcp://localhost:5560");
 
             while (!Thread.currentThread().isInterrupted()) {

--- a/src/test/java/guide/rtdealer.java
+++ b/src/test/java/guide/rtdealer.java
@@ -2,6 +2,7 @@ package guide;
 
 import java.util.Random;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
 import org.zeromq.ZContext;
@@ -20,7 +21,7 @@ public class rtdealer
         public void run()
         {
             try (ZContext context = new ZContext()) {
-                Socket worker = context.createSocket(ZMQ.DEALER);
+                Socket worker = context.createSocket(SocketType.DEALER);
                 ZHelper.setId(worker); //  Set a printable identity
 
                 worker.connect("tcp://localhost:5671");
@@ -60,7 +61,7 @@ public class rtdealer
     public static void main(String[] args) throws Exception
     {
         try (ZContext context = new ZContext()) {
-            Socket broker = context.createSocket(ZMQ.ROUTER);
+            Socket broker = context.createSocket(SocketType.ROUTER);
             broker.bind("tcp://*:5671");
 
             for (int workerNbr = 0; workerNbr < NBR_WORKERS; workerNbr++) {

--- a/src/test/java/guide/rtmama.java
+++ b/src/test/java/guide/rtmama.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZContext;
 
@@ -18,7 +19,7 @@ public class rtmama
         public void run()
         {
             try (ZContext context = new ZContext()) {
-                ZMQ.Socket worker = context.createSocket(ZMQ.REQ);
+                ZMQ.Socket worker = context.createSocket(SocketType.REQ);
                 // worker.setIdentity(); will set a random id automatically
                 worker.connect("ipc://routing.ipc");
 
@@ -39,7 +40,7 @@ public class rtmama
     public static void main(String[] args)
     {
         try (ZContext context = new ZContext()) {
-            ZMQ.Socket client = context.createSocket(ZMQ.ROUTER);
+            ZMQ.Socket client = context.createSocket(SocketType.ROUTER);
             client.bind("ipc://routing.ipc");
 
             for (int i = 0; i != NBR_WORKERS; i++) {

--- a/src/test/java/guide/rtpapa.java
+++ b/src/test/java/guide/rtpapa.java
@@ -4,6 +4,7 @@ package guide;
 //Custom routing Router to Papa (ROUTER to REP)
 //
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
 import org.zeromq.ZContext;
@@ -14,10 +15,10 @@ public class rtpapa
     public static void main(String[] args)
     {
         try (ZContext context = new ZContext()) {
-            Socket client = context.createSocket(ZMQ.ROUTER);
+            Socket client = context.createSocket(SocketType.ROUTER);
             client.bind("ipc://routing.ipc");
 
-            Socket worker = context.createSocket(ZMQ.REP);
+            Socket worker = context.createSocket(SocketType.REP);
             worker.setIdentity("A".getBytes(ZMQ.CHARSET));
             worker.connect("ipc://routing.ipc");
 

--- a/src/test/java/guide/rtreq.java
+++ b/src/test/java/guide/rtreq.java
@@ -2,6 +2,7 @@ package guide;
 
 import java.util.Random;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
 import org.zeromq.ZContext;
@@ -20,7 +21,7 @@ public class rtreq
         public void run()
         {
             try (ZContext context = new ZContext()) {
-                Socket worker = context.createSocket(ZMQ.REQ);
+                Socket worker = context.createSocket(SocketType.REQ);
                 ZHelper.setId(worker); //  Set a printable identity
 
                 worker.connect("tcp://localhost:5671");
@@ -58,7 +59,7 @@ public class rtreq
     public static void main(String[] args) throws Exception
     {
         try (ZContext context = new ZContext()) {
-            Socket broker = context.createSocket(ZMQ.ROUTER);
+            Socket broker = context.createSocket(SocketType.ROUTER);
             broker.bind("tcp://*:5671");
 
             for (int workerNbr = 0; workerNbr < NBR_WORKERS; workerNbr++) {

--- a/src/test/java/guide/spqueue.java
+++ b/src/test/java/guide/spqueue.java
@@ -2,12 +2,9 @@ package guide;
 
 import java.util.ArrayList;
 
-import org.zeromq.ZContext;
-import org.zeromq.ZFrame;
-import org.zeromq.ZMQ;
+import org.zeromq.*;
 import org.zeromq.ZMQ.Poller;
 import org.zeromq.ZMQ.Socket;
-import org.zeromq.ZMsg;
 
 //
 // Simple Pirate queue
@@ -22,8 +19,8 @@ public class spqueue
     public static void main(String[] args)
     {
         try (ZContext ctx = new ZContext()) {
-            Socket frontend = ctx.createSocket(ZMQ.ROUTER);
-            Socket backend = ctx.createSocket(ZMQ.ROUTER);
+            Socket frontend = ctx.createSocket(SocketType.ROUTER);
+            Socket backend = ctx.createSocket(SocketType.ROUTER);
             frontend.bind("tcp://*:5555"); //  For clients
             backend.bind("tcp://*:5556"); //  For workers
 

--- a/src/test/java/guide/spworker.java
+++ b/src/test/java/guide/spworker.java
@@ -2,11 +2,8 @@ package guide;
 
 import java.util.Random;
 
-import org.zeromq.ZContext;
-import org.zeromq.ZFrame;
-import org.zeromq.ZMQ;
+import org.zeromq.*;
 import org.zeromq.ZMQ.Socket;
-import org.zeromq.ZMsg;
 
 //
 // Simple Pirate worker
@@ -21,7 +18,7 @@ public class spworker
     public static void main(String[] args) throws Exception
     {
         try (ZContext ctx = new ZContext()) {
-            Socket worker = ctx.createSocket(ZMQ.REQ);
+            Socket worker = ctx.createSocket(SocketType.REQ);
 
             //  Set random identity to make tracing easier
             Random rand = new Random(System.nanoTime());

--- a/src/test/java/guide/suisnail.java
+++ b/src/test/java/guide/suisnail.java
@@ -4,6 +4,7 @@ import java.util.Random;
 
 //  Suicidal Snail
 
+import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
@@ -25,7 +26,7 @@ public class suisnail
         public void run(Object[] args, ZContext ctx, Socket pipe)
         {
             //  Subscribe to everything
-            Socket subscriber = ctx.createSocket(ZMQ.SUB);
+            Socket subscriber = ctx.createSocket(SocketType.SUB);
             subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
             subscriber.connect("tcp://localhost:5556");
 
@@ -63,7 +64,7 @@ public class suisnail
         public void run(Object[] args, ZContext ctx, Socket pipe)
         {
             //  Prepare publisher
-            Socket publisher = ctx.createSocket(ZMQ.PUB);
+            Socket publisher = ctx.createSocket(SocketType.PUB);
             publisher.bind("tcp://*:5556");
 
             while (true) {

--- a/src/test/java/guide/syncpub.java
+++ b/src/test/java/guide/syncpub.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
 import org.zeromq.ZContext;
@@ -18,7 +19,7 @@ public class syncpub
     {
         try (ZContext context = new ZContext()) {
             //  Socket to talk to clients
-            Socket publisher = context.createSocket(ZMQ.PUB);
+            Socket publisher = context.createSocket(SocketType.PUB);
             publisher.setLinger(5000);
             // In 0MQ 3.x pub socket could drop messages if sub can follow the
             // generation of pub messages
@@ -26,7 +27,7 @@ public class syncpub
             publisher.bind("tcp://*:5561");
 
             //  Socket to receive signals
-            Socket syncservice = context.createSocket(ZMQ.REP);
+            Socket syncservice = context.createSocket(SocketType.REP);
             syncservice.bind("tcp://*:5562");
 
             System.out.println("Waiting for subscribers");

--- a/src/test/java/guide/syncsub.java
+++ b/src/test/java/guide/syncsub.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
 import org.zeromq.ZContext;
@@ -14,12 +15,12 @@ public class syncsub
     {
         try (ZContext context = new ZContext()) {
             //  First, connect our subscriber socket
-            Socket subscriber = context.createSocket(ZMQ.SUB);
+            Socket subscriber = context.createSocket(SocketType.SUB);
             subscriber.connect("tcp://localhost:5561");
             subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
 
             //  Second, synchronize with publisher
-            Socket syncclient = context.createSocket(ZMQ.REQ);
+            Socket syncclient = context.createSocket(SocketType.REQ);
             syncclient.connect("tcp://localhost:5562");
 
             //  - send a synchronization request

--- a/src/test/java/guide/tasksink.java
+++ b/src/test/java/guide/tasksink.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZContext;
 
@@ -14,7 +15,7 @@ public class tasksink
     {
         //  Prepare our context and socket
         try (ZContext context = new ZContext()) {
-            ZMQ.Socket receiver = context.createSocket(ZMQ.PULL);
+            ZMQ.Socket receiver = context.createSocket(SocketType.PULL);
             receiver.bind("tcp://*:5558");
 
             //  Wait for start of batch

--- a/src/test/java/guide/tasksink2.java
+++ b/src/test/java/guide/tasksink2.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZContext;
 
@@ -13,11 +14,11 @@ public class tasksink2
     {
         //  Prepare our context and socket
         try (ZContext context = new ZContext()) {
-            ZMQ.Socket receiver = context.createSocket(ZMQ.PULL);
+            ZMQ.Socket receiver = context.createSocket(SocketType.PULL);
             receiver.bind("tcp://*:5558");
 
             // Socket for worker control
-            ZMQ.Socket controller = context.createSocket(ZMQ.PUB);
+            ZMQ.Socket controller = context.createSocket(SocketType.PUB);
             controller.bind("tcp://*:5559");
 
             //  Wait for start of batch

--- a/src/test/java/guide/taskvent.java
+++ b/src/test/java/guide/taskvent.java
@@ -2,6 +2,7 @@ package guide;
 
 import java.util.Random;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZContext;
 
@@ -16,11 +17,11 @@ public class taskvent
     {
         try (ZContext context = new ZContext()) {
             //  Socket to send messages on
-            ZMQ.Socket sender = context.createSocket(ZMQ.PUSH);
+            ZMQ.Socket sender = context.createSocket(SocketType.PUSH);
             sender.bind("tcp://*:5557");
 
             //  Socket to send messages on
-            ZMQ.Socket sink = context.createSocket(ZMQ.PUSH);
+            ZMQ.Socket sink = context.createSocket(SocketType.PUSH);
             sink.connect("tcp://localhost:5558");
 
             System.out.println("Press Enter when the workers are ready: ");

--- a/src/test/java/guide/taskwork.java
+++ b/src/test/java/guide/taskwork.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZContext;
 
@@ -16,11 +17,11 @@ public class taskwork
     {
         try (ZContext context = new ZContext()) {
             //  Socket to receive messages on
-            ZMQ.Socket receiver = context.createSocket(ZMQ.PULL);
+            ZMQ.Socket receiver = context.createSocket(SocketType.PULL);
             receiver.connect("tcp://localhost:5557");
 
             //  Socket to send messages to
-            ZMQ.Socket sender = context.createSocket(ZMQ.PUSH);
+            ZMQ.Socket sender = context.createSocket(SocketType.PUSH);
             sender.connect("tcp://localhost:5558");
 
             //  Process tasks forever

--- a/src/test/java/guide/taskwork2.java
+++ b/src/test/java/guide/taskwork2.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZContext;
 
@@ -12,13 +13,13 @@ public class taskwork2
     public static void main(String[] args) throws InterruptedException
     {
         try (ZContext context = new ZContext()) {
-            ZMQ.Socket receiver = context.createSocket(ZMQ.PULL);
+            ZMQ.Socket receiver = context.createSocket(SocketType.PULL);
             receiver.connect("tcp://localhost:5557");
 
-            ZMQ.Socket sender = context.createSocket(ZMQ.PUSH);
+            ZMQ.Socket sender = context.createSocket(SocketType.PUSH);
             sender.connect("tcp://localhost:5558");
 
-            ZMQ.Socket controller = context.createSocket(ZMQ.SUB);
+            ZMQ.Socket controller = context.createSocket(SocketType.SUB);
             controller.connect("tcp://localhost:5559");
             controller.subscribe(ZMQ.SUBSCRIPTION_ALL);
 

--- a/src/test/java/guide/tripping.java
+++ b/src/test/java/guide/tripping.java
@@ -1,10 +1,7 @@
 package guide;
 
-import org.zeromq.ZContext;
-import org.zeromq.ZFrame;
-import org.zeromq.ZMQ;
+import org.zeromq.*;
 import org.zeromq.ZMQ.Socket;
-import org.zeromq.ZMsg;
 
 /**
 * Round-trip demonstrator. Broker, Worker and Client are mocked as separate
@@ -18,8 +15,8 @@ public class tripping
         public void run()
         {
             try (ZContext ctx = new ZContext()) {
-                Socket frontend = ctx.createSocket(ZMQ.ROUTER);
-                Socket backend = ctx.createSocket(ZMQ.ROUTER);
+                Socket frontend = ctx.createSocket(SocketType.ROUTER);
+                Socket backend = ctx.createSocket(SocketType.ROUTER);
                 frontend.setHWM(0);
                 backend.setHWM(0);
                 frontend.bind("tcp://*:5555");
@@ -65,7 +62,7 @@ public class tripping
         public void run()
         {
             try (ZContext ctx = new ZContext()) {
-                Socket worker = ctx.createSocket(ZMQ.DEALER);
+                Socket worker = ctx.createSocket(SocketType.DEALER);
                 worker.setHWM(0);
                 worker.setIdentity("W".getBytes(ZMQ.CHARSET));
                 worker.connect("tcp://localhost:5556");
@@ -85,7 +82,7 @@ public class tripping
         public void run()
         {
             try (ZContext ctx = new ZContext()) {
-                Socket client = ctx.createSocket(ZMQ.DEALER);
+                Socket client = ctx.createSocket(SocketType.DEALER);
                 client.setHWM(0);
                 client.setIdentity("C".getBytes(ZMQ.CHARSET));
                 client.connect("tcp://localhost:5555");

--- a/src/test/java/guide/wuclient.java
+++ b/src/test/java/guide/wuclient.java
@@ -2,6 +2,7 @@ package guide;
 
 import java.util.StringTokenizer;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZContext;
 
@@ -17,7 +18,7 @@ public class wuclient
         try (ZContext context = new ZContext()) {
             //  Socket to talk to server
             System.out.println("Collecting updates from weather server");
-            ZMQ.Socket subscriber = context.createSocket(ZMQ.SUB);
+            ZMQ.Socket subscriber = context.createSocket(SocketType.SUB);
             subscriber.connect("tcp://localhost:5556");
 
             //  Subscribe to zipcode, default is NYC, 10001

--- a/src/test/java/guide/wuproxy.java
+++ b/src/test/java/guide/wuproxy.java
@@ -1,5 +1,6 @@
 package guide;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMQ.Socket;
 import org.zeromq.ZContext;
@@ -14,11 +15,11 @@ public class wuproxy
         //  Prepare our context and sockets
         try (ZContext context = new ZContext()) {
             //  This is where the weather server sits
-            Socket frontend = context.createSocket(ZMQ.SUB);
+            Socket frontend = context.createSocket(SocketType.SUB);
             frontend.connect("tcp://192.168.55.210:5556");
 
             //  This is our public endpoint for subscribers
-            Socket backend = context.createSocket(ZMQ.PUB);
+            Socket backend = context.createSocket(SocketType.PUB);
             backend.bind("tcp://10.1.1.0:8100");
 
             //  Subscribe on everything

--- a/src/test/java/guide/wuserver.java
+++ b/src/test/java/guide/wuserver.java
@@ -2,6 +2,7 @@ package guide;
 
 import java.util.Random;
 
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZContext;
 
@@ -16,7 +17,7 @@ public class wuserver
     {
         //  Prepare our context and publisher
         try (ZContext context = new ZContext()) {
-            ZMQ.Socket publisher = context.createSocket(ZMQ.PUB);
+            ZMQ.Socket publisher = context.createSocket(SocketType.PUB);
             publisher.bind("tcp://*:5556");
             publisher.bind("ipc://weather");
 

--- a/src/test/java/org/zeromq/ByteBuffersTest.java
+++ b/src/test/java/org/zeromq/ByteBuffersTest.java
@@ -28,7 +28,7 @@ public class ByteBuffersTest
         {
             System.out.println("Start client thread ");
             ZMQ.Context context = ZMQ.context(1);
-            Socket pullConnect = context.socket(ZMQ.PULL);
+            Socket pullConnect = context.socket(SocketType.PULL);
 
             pullConnect.connect("tcp://127.0.0.1:" + port);
             pullConnect.recv(0);
@@ -48,8 +48,8 @@ public class ByteBuffersTest
         ZMQ.Socket push = null;
         ZMQ.Socket pull = null;
         try {
-            push = context.socket(ZMQ.PUSH);
-            pull = context.socket(ZMQ.PULL);
+            push = context.socket(SocketType.PUSH);
+            pull = context.socket(SocketType.PULL);
             pull.bind("tcp://*:" + port);
             push.connect("tcp://localhost:" + port);
 
@@ -90,8 +90,8 @@ public class ByteBuffersTest
         ZMQ.Socket push = null;
         ZMQ.Socket pull = null;
         try {
-            push = context.socket(ZMQ.PUSH);
-            pull = context.socket(ZMQ.PULL);
+            push = context.socket(SocketType.PUSH);
+            pull = context.socket(SocketType.PULL);
             pull.bind("tcp://*:" + port);
             push.connect("tcp://localhost:" + port);
 
@@ -147,8 +147,8 @@ public class ByteBuffersTest
         ZMQ.Socket push = null;
         ZMQ.Socket pull = null;
         try {
-            push = context.socket(ZMQ.PUSH);
-            pull = context.socket(ZMQ.PULL);
+            push = context.socket(SocketType.PUSH);
+            pull = context.socket(SocketType.PULL);
             pull.bind("tcp://*:" + port);
             push.connect("tcp://localhost:" + port);
 
@@ -208,8 +208,8 @@ public class ByteBuffersTest
         ZMQ.Socket push = null;
         ZMQ.Socket pull = null;
         try {
-            push = context.socket(ZMQ.PUSH);
-            pull = context.socket(ZMQ.PULL);
+            push = context.socket(SocketType.PUSH);
+            pull = context.socket(SocketType.PULL);
             pull.bind("tcp://*:" + port);
             push.connect("tcp://localhost:" + port);
 

--- a/src/test/java/org/zeromq/DealerDealerTest.java
+++ b/src/test/java/org/zeromq/DealerDealerTest.java
@@ -41,7 +41,7 @@ public class DealerDealerTest
         @Override
         public void run()
         {
-            ZMQ.Socket worker = context.socket(ZMQ.DEALER);
+            ZMQ.Socket worker = context.socket(SocketType.DEALER);
             worker.connect(host);
 
             int msg = messagesCount;
@@ -69,7 +69,7 @@ public class DealerDealerTest
                         System.out.println("Reconnecting...");
                     }
                     worker.close();
-                    worker = context.socket(ZMQ.DEALER);
+                    worker = context.socket(SocketType.DEALER);
                     worker.connect(host);
                 }
 
@@ -99,7 +99,7 @@ public class DealerDealerTest
             @Override
             public void run()
             {
-                final ZMQ.Socket server = context.socket(ZMQ.DEALER);
+                final ZMQ.Socket server = context.socket(SocketType.DEALER);
                 server.bind(host);
                 int msg = messagesCount;
 

--- a/src/test/java/org/zeromq/HighWatermarkTest.java
+++ b/src/test/java/org/zeromq/HighWatermarkTest.java
@@ -45,11 +45,11 @@ public class HighWatermarkTest
             ZContext context = new ZContext(1);
 
             //  Socket to send messages on
-            ZMQ.Socket sender = context.createSocket(ZMQ.PUSH);
+            ZMQ.Socket sender = context.createSocket(SocketType.PUSH);
             sender.setImmediate(false);
             sender.bind(dispatch);
 
-            ZMQ.Socket controller = context.createSocket(ZMQ.SUB);
+            ZMQ.Socket controller = context.createSocket(SocketType.SUB);
             controller.subscribe(ZMQ.SUBSCRIPTION_ALL);
             controller.connect(control);
 
@@ -109,16 +109,16 @@ public class HighWatermarkTest
             ZContext context = new ZContext(1);
 
             //  Socket to receive messages on
-            ZMQ.Socket receiver = context.createSocket(ZMQ.PULL);
+            ZMQ.Socket receiver = context.createSocket(SocketType.PULL);
             receiver.setImmediate(false);
             receiver.connect(dispatch);
 
             //  Socket to send messages to
-            ZMQ.Socket sender = context.createSocket(ZMQ.PUSH);
+            ZMQ.Socket sender = context.createSocket(SocketType.PUSH);
             sender.setImmediate(false);
             sender.connect(collect);
 
-            ZMQ.Socket controller = context.createSocket(ZMQ.SUB);
+            ZMQ.Socket controller = context.createSocket(SocketType.SUB);
             controller.subscribe("FINISH");
             controller.connect(control);
 
@@ -208,11 +208,11 @@ public class HighWatermarkTest
             //  Prepare our context and socket
             ZContext context = new ZContext(1);
 
-            ZMQ.Socket receiver = context.createSocket(ZMQ.PULL);
+            ZMQ.Socket receiver = context.createSocket(SocketType.PULL);
             receiver.setImmediate(false);
             receiver.bind(collect);
 
-            ZMQ.Socket controller = context.createSocket(ZMQ.PUB);
+            ZMQ.Socket controller = context.createSocket(SocketType.PUB);
             controller.bind(control);
 
             try {

--- a/src/test/java/org/zeromq/ParanoidPiratServerWithLazyPiratClientTest.java
+++ b/src/test/java/org/zeromq/ParanoidPiratServerWithLazyPiratClientTest.java
@@ -110,8 +110,8 @@ public class ParanoidPiratServerWithLazyPiratClientTest
         {
             Thread.currentThread().setName("Queue");
             final ZContext ctx = new ZContext();
-            final Socket frontend = ctx.createSocket(ZMQ.ROUTER);
-            final Socket backend = ctx.createSocket(ZMQ.ROUTER);
+            final Socket frontend = ctx.createSocket(SocketType.ROUTER);
+            final Socket backend = ctx.createSocket(SocketType.ROUTER);
             frontend.bind("tcp://*:" + portQueue); //  For clients
             backend.bind("tcp://*:" + portWorkers); //  For workers
 
@@ -207,7 +207,7 @@ public class ParanoidPiratServerWithLazyPiratClientTest
 
         private Socket workerSocket(ZContext ctx)
         {
-            final Socket worker = ctx.createSocket(ZMQ.DEALER);
+            final Socket worker = ctx.createSocket(SocketType.DEALER);
             worker.connect("tcp://localhost:" + portWorkers);
 
             //  Tell queue we're ready for work
@@ -357,7 +357,7 @@ public class ParanoidPiratServerWithLazyPiratClientTest
             Thread.currentThread().setName("Client");
             final ZContext ctx = new ZContext();
             System.out.println("I: Client - connecting to server");
-            Socket client = ctx.createSocket(ZMQ.REQ);
+            Socket client = ctx.createSocket(SocketType.REQ);
             assert (client != null);
             client.connect("tcp://localhost:" + portQueue);
 
@@ -410,7 +410,7 @@ public class ParanoidPiratServerWithLazyPiratClientTest
                         poller.unregister(client);
                         ctx.destroySocket(client);
                         System.out.println("I: Client - reconnecting to server");
-                        client = ctx.createSocket(ZMQ.REQ);
+                        client = ctx.createSocket(SocketType.REQ);
                         client.connect("tcp://localhost:" + portQueue);
                         poller.register(client, Poller.POLLIN);
                         //  Send request again, on new socket

--- a/src/test/java/org/zeromq/PubSubTest.java
+++ b/src/test/java/org/zeromq/PubSubTest.java
@@ -34,7 +34,7 @@ public class PubSubTest
             @Override
             public void run()
             {
-                ZMQ.Socket publisher = context.socket(ZMQ.PUB);
+                ZMQ.Socket publisher = context.socket(SocketType.PUB);
                 publisher.bind(address);
                 int count = messagesNumber;
                 while (count-- > 0) {
@@ -51,7 +51,7 @@ public class PubSubTest
             @Override
             public void run()
             {
-                ZMQ.Socket subscriber = context.socket(ZMQ.SUB);
+                ZMQ.Socket subscriber = context.socket(SocketType.SUB);
                 subscriber.connect(address);
                 subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
                 int count = messagesNumber;
@@ -95,10 +95,10 @@ public class PubSubTest
     public void testPubConnectSubBindIssue289and342() throws IOException
     {
         ZMQ.Context context = ZMQ.context(1);
-        Socket pub = context.socket(ZMQ.XPUB);
+        Socket pub = context.socket(SocketType.XPUB);
         assertThat(pub, notNullValue());
 
-        Socket sub = context.socket(ZMQ.SUB);
+        Socket sub = context.socket(SocketType.SUB);
         assertThat(sub, notNullValue());
         boolean rc = sub.subscribe(new byte[0]);
         assertThat(rc, is(true));
@@ -135,7 +135,7 @@ public class PubSubTest
             {
                 final ZMQ.Context ctx = ZMQ.context(1);
                 assertThat(ctx, notNullValue());
-                final ZMQ.Socket pub = ctx.socket(ZMQ.PUB);
+                final ZMQ.Socket pub = ctx.socket(SocketType.PUB);
                 assertThat(pub, notNullValue());
 
                 boolean rc = pub.bind("tcp://*:" + port);
@@ -161,7 +161,7 @@ public class PubSubTest
             {
                 final ZMQ.Context ctx = ZMQ.context(1);
                 assertThat(ctx, notNullValue());
-                final ZMQ.Socket sub = ctx.socket(ZMQ.SUB);
+                final ZMQ.Socket sub = ctx.socket(SocketType.SUB);
                 assertThat(sub, notNullValue());
 
                 boolean rc = sub.setReceiveTimeOut(3000);

--- a/src/test/java/org/zeromq/PushPullTest.java
+++ b/src/test/java/org/zeromq/PushPullTest.java
@@ -33,7 +33,7 @@ public class PushPullTest
 
             ZMQ.Context context = ZMQ.context(1);
             assertThat(context, notNullValue());
-            ZMQ.Socket socket = context.socket(ZMQ.PUSH);
+            ZMQ.Socket socket = context.socket(SocketType.PUSH);
             assertThat(socket, notNullValue());
 
             // Socket options
@@ -79,7 +79,7 @@ public class PushPullTest
 
             ZMQ.Context context = ZMQ.context(1);
             assertThat(context, notNullValue());
-            ZMQ.Socket socket = context.socket(ZMQ.PULL);
+            ZMQ.Socket socket = context.socket(SocketType.PULL);
             assertThat(socket, notNullValue());
 
             // Options Section

--- a/src/test/java/org/zeromq/ReqRepTest.java
+++ b/src/test/java/org/zeromq/ReqRepTest.java
@@ -56,7 +56,7 @@ public class ReqRepTest
             int currentServCount = 0;
             try (
                  ZMQ.Context context = ZMQ.context(1);
-                 ZMQ.Socket responder = context.socket(ZMQ.REP);) {
+                 ZMQ.Socket responder = context.socket(SocketType.REP);) {
                 assertThat(responder, notNullValue());
                 boolean rc = responder.bind(address);
                 assertThat(rc, is(true));
@@ -111,7 +111,7 @@ public class ReqRepTest
         {
             try (
                  ZMQ.Context context = ZMQ.context(10);
-                 ZMQ.Socket socket = context.socket(ZMQ.REQ);) {
+                 ZMQ.Socket socket = context.socket(SocketType.REQ);) {
                 boolean rc = socket.connect(address);
                 assertThat(rc, is(true));
                 for (int idx = 0; idx < loopCount; idx++) {
@@ -220,7 +220,7 @@ public class ReqRepTest
             // simulates a server reply
             public void run()
             {
-                final ZMQ.Socket rep = context.socket(ZMQ.REP);
+                final ZMQ.Socket rep = context.socket(SocketType.REP);
                 rep.bind(addr);
                 latch.countDown();
 
@@ -240,7 +240,7 @@ public class ReqRepTest
         latch.await(1, TimeUnit.SECONDS);
         final long start = System.currentTimeMillis();
         try (
-             final ZMQ.Socket req = context.socket(ZMQ.REQ);) {
+             final ZMQ.Socket req = context.socket(SocketType.REQ);) {
             req.connect(addr);
             request.send(req);
             final ZMsg response = ZMsg.recvMsg(req);

--- a/src/test/java/org/zeromq/TestDisconnectInprocZeromq.java
+++ b/src/test/java/org/zeromq/TestDisconnectInprocZeromq.java
@@ -14,8 +14,8 @@ public class TestDisconnectInprocZeromq
         boolean isSubscribed = false;
 
         ZContext ctx = new ZContext();
-        ZMQ.Socket pubSocket = ctx.createSocket(ZMQ.XPUB);
-        ZMQ.Socket subSocket = ctx.createSocket(ZMQ.SUB);
+        ZMQ.Socket pubSocket = ctx.createSocket(SocketType.XPUB);
+        ZMQ.Socket subSocket = ctx.createSocket(SocketType.SUB);
 
         subSocket.subscribe("foo".getBytes());
         pubSocket.bind("inproc://someInProcDescriptor");

--- a/src/test/java/org/zeromq/TestEvents.java
+++ b/src/test/java/org/zeromq/TestEvents.java
@@ -18,11 +18,11 @@ public class TestEvents
         Context context = ZMQ.context(1);
         ZMQ.Event event;
 
-        Socket helper = context.socket(ZMQ.REQ);
+        Socket helper = context.socket(SocketType.REQ);
         int port = helper.bindToRandomPort("tcp://127.0.0.1");
 
-        Socket socket = context.socket(ZMQ.REP);
-        Socket monitor = context.socket(ZMQ.PAIR);
+        Socket socket = context.socket(SocketType.REP);
+        Socket monitor = context.socket(SocketType.PAIR);
         monitor.setReceiveTimeOut(100);
 
         assertTrue(socket.monitor("inproc://monitor.socket", ZMQ.EVENT_CONNECTED));
@@ -45,8 +45,8 @@ public class TestEvents
         Context context = ZMQ.context(1);
         ZMQ.Event event;
 
-        Socket socket = context.socket(ZMQ.REP);
-        Socket monitor = context.socket(ZMQ.PAIR);
+        Socket socket = context.socket(SocketType.REP);
+        Socket monitor = context.socket(SocketType.PAIR);
         monitor.setReceiveTimeOut(100);
 
         assertTrue(socket.monitor("inproc://monitor.socket", ZMQ.EVENT_CONNECT_DELAYED));
@@ -70,8 +70,8 @@ public class TestEvents
         Context context = ZMQ.context(1);
         ZMQ.Event event;
 
-        Socket socket = context.socket(ZMQ.REP);
-        Socket monitor = context.socket(ZMQ.PAIR);
+        Socket socket = context.socket(SocketType.REP);
+        Socket monitor = context.socket(SocketType.PAIR);
         monitor.setReceiveTimeOut(100);
 
         assertTrue(socket.monitor("inproc://monitor.socket", ZMQ.EVENT_CONNECT_RETRIED));
@@ -96,8 +96,8 @@ public class TestEvents
         Context context = ZMQ.context(1);
         ZMQ.Event event;
 
-        Socket socket = context.socket(ZMQ.REP);
-        Socket monitor = context.socket(ZMQ.PAIR);
+        Socket socket = context.socket(SocketType.REP);
+        Socket monitor = context.socket(SocketType.PAIR);
         monitor.setReceiveTimeOut(100);
 
         assertTrue(socket.monitor("inproc://monitor.socket", ZMQ.EVENT_LISTENING));
@@ -119,11 +119,11 @@ public class TestEvents
         Context context = ZMQ.context(1);
         ZMQ.Event event;
 
-        Socket helper = context.socket(ZMQ.REP);
+        Socket helper = context.socket(SocketType.REP);
         int port = helper.bindToRandomPort("tcp://127.0.0.1");
 
-        Socket socket = context.socket(ZMQ.REP);
-        Socket monitor = context.socket(ZMQ.PAIR);
+        Socket socket = context.socket(SocketType.REP);
+        Socket monitor = context.socket(SocketType.PAIR);
         monitor.setReceiveTimeOut(100);
 
         assertTrue(socket.monitor("inproc://monitor.socket", ZMQ.EVENT_BIND_FAILED));
@@ -150,9 +150,9 @@ public class TestEvents
         Context context = ZMQ.context(1);
         ZMQ.Event event;
 
-        Socket socket = context.socket(ZMQ.REP);
-        Socket monitor = context.socket(ZMQ.PAIR);
-        Socket helper = context.socket(ZMQ.REQ);
+        Socket socket = context.socket(SocketType.REP);
+        Socket monitor = context.socket(SocketType.PAIR);
+        Socket helper = context.socket(SocketType.REQ);
         monitor.setReceiveTimeOut(100);
 
         assertTrue(socket.monitor("inproc://monitor.socket", ZMQ.EVENT_ACCEPTED));
@@ -175,11 +175,11 @@ public class TestEvents
     public void testEventClosed()
     {
         Context context = ZMQ.context(1);
-        Socket monitor = context.socket(ZMQ.PAIR);
+        Socket monitor = context.socket(SocketType.PAIR);
         try {
             ZMQ.Event event;
 
-            Socket socket = context.socket(ZMQ.REP);
+            Socket socket = context.socket(SocketType.REP);
             monitor.setReceiveTimeOut(100);
 
             socket.bindToRandomPort("tcp://127.0.0.1");
@@ -205,9 +205,9 @@ public class TestEvents
         Context context = ZMQ.context(1);
         ZMQ.Event event;
 
-        Socket socket = context.socket(ZMQ.REP);
-        Socket monitor = context.socket(ZMQ.PAIR);
-        Socket helper = context.socket(ZMQ.REQ);
+        Socket socket = context.socket(SocketType.REP);
+        Socket monitor = context.socket(SocketType.PAIR);
+        Socket helper = context.socket(SocketType.REQ);
         monitor.setReceiveTimeOut(100);
 
         int port = socket.bindToRandomPort("tcp://127.0.0.1");
@@ -234,8 +234,8 @@ public class TestEvents
         Context context = ZMQ.context(1);
         ZMQ.Event event;
 
-        Socket socket = context.socket(ZMQ.REP);
-        Socket monitor = context.socket(ZMQ.PAIR);
+        Socket socket = context.socket(SocketType.REP);
+        Socket monitor = context.socket(SocketType.PAIR);
         monitor.setReceiveTimeOut(100);
 
         assertTrue(socket.monitor("inproc://monitor.socket", ZMQ.EVENT_MONITOR_STOPPED));

--- a/src/test/java/org/zeromq/TestPoller.java
+++ b/src/test/java/org/zeromq/TestPoller.java
@@ -27,7 +27,7 @@ public class TestPoller
         public void run()
         {
             ZMQ.Context context = ZMQ.context(1);
-            Socket pullConnect = context.socket(ZMQ.PULL);
+            Socket pullConnect = context.socket(SocketType.PULL);
 
             pullConnect.connect(address);
 
@@ -52,7 +52,7 @@ public class TestPoller
         ZMQ.Context context = ZMQ.context(1);
 
         //  Socket to send messages to
-        ZMQ.Socket sender = context.socket(ZMQ.PUSH);
+        ZMQ.Socket sender = context.socket(SocketType.PUSH);
         sender.setImmediate(false);
         sender.bind(addr);
 

--- a/src/test/java/org/zeromq/TestProxy.java
+++ b/src/test/java/org/zeromq/TestProxy.java
@@ -36,7 +36,7 @@ public class TestProxy
             Context ctx = ZMQ.context(1);
             assertThat(ctx, notNullValue());
 
-            Socket socket = ctx.socket(ZMQ.REQ);
+            Socket socket = ctx.socket(SocketType.REQ);
             boolean rc;
             rc = socket.setIdentity(id(name));
             assertThat(rc, is(true));
@@ -102,7 +102,7 @@ public class TestProxy
             Thread.currentThread().setName(name);
             System.out.println("Start " + name);
 
-            Socket socket = ctx.socket(ZMQ.DEALER);
+            Socket socket = ctx.socket(SocketType.DEALER);
             boolean rc;
             rc = socket.setIdentity(id(name));
             assertThat(rc, is(true));
@@ -177,16 +177,16 @@ public class TestProxy
             assert (ctx != null);
 
             setName("Proxy");
-            Socket frontend = ctx.socket(ZMQ.ROUTER);
+            Socket frontend = ctx.socket(SocketType.ROUTER);
 
             assertThat(frontend, notNullValue());
             frontend.bind(this.frontend);
 
-            Socket backend = ctx.socket(ZMQ.DEALER);
+            Socket backend = ctx.socket(SocketType.DEALER);
             assertThat(backend, notNullValue());
             backend.bind(this.backend);
 
-            Socket control = ctx.socket(ZMQ.PAIR);
+            Socket control = ctx.socket(SocketType.PAIR);
             assertThat(control, notNullValue());
             control.bind(this.control);
 
@@ -235,7 +235,7 @@ public class TestProxy
         executor.awaitTermination(40, TimeUnit.SECONDS);
 
         Context ctx = ZMQ.context(1);
-        Socket control = ctx.socket(ZMQ.PAIR);
+        Socket control = ctx.socket(SocketType.PAIR);
         control.connect(controlEndpoint);
         control.send(ZMQ.PROXY_TERMINATE);
         proxy.join();

--- a/src/test/java/org/zeromq/TestPushPullThreadedTcp.java
+++ b/src/test/java/org/zeromq/TestPushPullThreadedTcp.java
@@ -115,12 +115,12 @@ public class TestPushPullThreadedTcp
 
         ZContext ctx = new ZContext();
 
-        ZMQ.Socket receiver = ctx.createSocket(ZMQ.PULL);
+        ZMQ.Socket receiver = ctx.createSocket(SocketType.PULL);
         assertThat(receiver, notNullValue());
         receiver.setImmediate(false);
         final int port = receiver.bindToRandomPort("tcp://localhost");
 
-        ZMQ.Socket sender = ctx.createSocket(ZMQ.PUSH);
+        ZMQ.Socket sender = ctx.createSocket(SocketType.PUSH);
         assertThat(sender, notNullValue());
         boolean rc = sender.connect("tcp://localhost:" + port);
         assertThat(rc, is(true));

--- a/src/test/java/org/zeromq/TestRapidOpenCloseSocket.java
+++ b/src/test/java/org/zeromq/TestRapidOpenCloseSocket.java
@@ -24,14 +24,14 @@ public class TestRapidOpenCloseSocket
   {
     ZContext ctx = new ZContext();
 
-    Socket recvMsgSock = ctx.createSocket(ZMQ.PULL);
+    Socket recvMsgSock = ctx.createSocket(SocketType.PULL);
     recvMsgSock.bind("tcp://*:" + Utils.findOpenPort());
-    Socket processMsgSock = ctx.createSocket(ZMQ.PUSH);
+    Socket processMsgSock = ctx.createSocket(SocketType.PUSH);
     processMsgSock.bind("inproc://process-msg");
 
     List<Socket> workerSocks = new ArrayList<Socket>();
     for (int i = 0; i < 5; i++) {
-      Socket workerSock = ctx.createSocket(ZMQ.PULL);
+      Socket workerSock = ctx.createSocket(SocketType.PULL);
       workerSock.connect("inproc://process-msg");
       workerSocks.add(workerSock);
     }

--- a/src/test/java/org/zeromq/TestReqRouterThreadedTcp.java
+++ b/src/test/java/org/zeromq/TestReqRouterThreadedTcp.java
@@ -43,7 +43,7 @@ public class TestReqRouterThreadedTcp
         {
             ZContext ctx = new ZContext();
 
-            ZMQ.Socket server = ctx.createSocket(ZMQ.ROUTER);
+            ZMQ.Socket server = ctx.createSocket(SocketType.ROUTER);
             server.bind("tcp://localhost:" + port);
 
             System.out.println("Server started");
@@ -82,7 +82,7 @@ public class TestReqRouterThreadedTcp
         {
             ZContext ctx = new ZContext();
 
-            ZMQ.Socket client = ctx.createSocket(ZMQ.REQ);
+            ZMQ.Socket client = ctx.createSocket(SocketType.REQ);
 
             client.connect("tcp://localhost:" + port);
 

--- a/src/test/java/org/zeromq/TestZActor.java
+++ b/src/test/java/org/zeromq/TestZActor.java
@@ -20,7 +20,7 @@ public class TestZActor
             public List<Socket> createSockets(ZContext ctx, Object... args)
             {
                 assert ("TEST".equals(args[0]));
-                return Arrays.asList(ctx.createSocket(ZMQ.PUB));
+                return Arrays.asList(ctx.createSocket(SocketType.PUB));
             }
 
             @Override

--- a/src/test/java/org/zeromq/TestZContext.java
+++ b/src/test/java/org/zeromq/TestZContext.java
@@ -14,12 +14,11 @@ public class TestZContext
     public void testZContext()
     {
         ZContext ctx = new ZContext();
-        ctx.createSocket(ZMQ.PAIR);
-        ctx.createSocket(ZMQ.XREQ);
-        ctx.createSocket(ZMQ.REQ);
-        ctx.createSocket(ZMQ.REP);
-        ctx.createSocket(ZMQ.PUB);
-        ctx.createSocket(ZMQ.SUB);
+        ctx.createSocket(SocketType.PAIR);
+        ctx.createSocket(SocketType.REQ);
+        ctx.createSocket(SocketType.REP);
+        ctx.createSocket(SocketType.PUB);
+        ctx.createSocket(SocketType.SUB);
         ctx.close();
         assertThat(ctx.getSockets().isEmpty(), is(true));
     }
@@ -28,8 +27,8 @@ public class TestZContext
     public void testZContextSocketCloseBeforeContextClose()
     {
         ZContext ctx = new ZContext();
-        Socket s1 = ctx.createSocket(ZMQ.PUSH);
-        Socket s2 = ctx.createSocket(ZMQ.PULL);
+        Socket s1 = ctx.createSocket(SocketType.PUSH);
+        Socket s2 = ctx.createSocket(SocketType.PULL);
         s1.close();
         s2.close();
         ctx.close();
@@ -74,7 +73,7 @@ public class TestZContext
         ZContext ctx1 = new ZContext();
         ctx1.setMain(false);
         @SuppressWarnings("unused")
-        Socket s = ctx1.createSocket(ZMQ.PAIR);
+        Socket s = ctx1.createSocket(SocketType.PAIR);
         ctx1.close();
         assertThat(ctx1.getSockets().isEmpty(), is(true));
         assertThat(ctx1.getContext(), notNullValue());
@@ -85,12 +84,12 @@ public class TestZContext
     {
         ZContext ctx = new ZContext();
         try {
-            Socket s = ctx.createSocket(ZMQ.PUB);
+            Socket s = ctx.createSocket(SocketType.PUB);
             assertThat(s, notNullValue());
-            assertThat(s.getType(), is(ZMQ.PUB));
-            Socket s1 = ctx.createSocket(ZMQ.REQ);
+            assertThat(s.getType(), is(SocketType.PUB));
+            Socket s1 = ctx.createSocket(SocketType.REQ);
             assertThat(s1, notNullValue());
-            assertThat(s1.getType(), is(ZMQ.REQ));
+            assertThat(s1.getType(), is(SocketType.REQ));
             assertThat(ctx.getSockets().size(), is(2));
         }
         finally {
@@ -103,7 +102,7 @@ public class TestZContext
     {
         ZContext ctx = new ZContext();
         try {
-            Socket s = ctx.createSocket(ZMQ.PUB);
+            Socket s = ctx.createSocket(SocketType.PUB);
             assertThat(s, notNullValue());
             assertThat(ctx.getSockets().size(), is(1));
 
@@ -120,7 +119,7 @@ public class TestZContext
     public void testShadow()
     {
         ZContext ctx = new ZContext();
-        Socket s = ctx.createSocket(ZMQ.PUB);
+        Socket s = ctx.createSocket(SocketType.PUB);
         assertThat(s, notNullValue());
         assertThat(ctx.getSockets().size(), is(1));
 
@@ -128,7 +127,7 @@ public class TestZContext
         shadowCtx.setMain(false);
         assertThat(shadowCtx.getSockets().size(), is(0));
         @SuppressWarnings("unused")
-        Socket s1 = shadowCtx.createSocket(ZMQ.SUB);
+        Socket s1 = shadowCtx.createSocket(SocketType.SUB);
         assertThat(shadowCtx.getSockets().size(), is(1));
         assertThat(ctx.getSockets().size(), is(1));
 

--- a/src/test/java/org/zeromq/TestZLoop.java
+++ b/src/test/java/org/zeromq/TestZLoop.java
@@ -34,10 +34,10 @@ public class TestZLoop
         ctx = new ZContext();
         assert (ctx != null);
 
-        output = ctx.createSocket(ZMQ.PAIR);
+        output = ctx.createSocket(SocketType.PAIR);
         assert (output != null);
         output.bind("inproc://zloop.test");
-        input = ctx.createSocket(ZMQ.PAIR);
+        input = ctx.createSocket(SocketType.PAIR);
         assert (input != null);
         input.connect("inproc://zloop.test");
 

--- a/src/test/java/org/zeromq/TestZMQ.java
+++ b/src/test/java/org/zeromq/TestZMQ.java
@@ -45,7 +45,7 @@ public class TestZMQ
     @Test
     public void testErrno()
     {
-        Socket socket = ctx.socket(ZMQ.DEALER);
+        Socket socket = ctx.socket(SocketType.DEALER);
         assertThat(socket.errno(), is(0));
 
         socket.close();
@@ -57,8 +57,8 @@ public class TestZMQ
         int port = Utils.findOpenPort();
         ZMQ.Context context = ZMQ.context(1);
 
-        ZMQ.Socket socket1 = context.socket(ZMQ.REQ);
-        ZMQ.Socket socket2 = context.socket(ZMQ.REQ);
+        ZMQ.Socket socket1 = context.socket(SocketType.REQ);
+        ZMQ.Socket socket2 = context.socket(SocketType.REQ);
         socket1.bind("tcp://*:" + port);
         try {
             socket2.bind("tcp://*:" + port);
@@ -81,8 +81,8 @@ public class TestZMQ
     {
         ZMQ.Context context = ZMQ.context(1);
 
-        ZMQ.Socket socket1 = context.socket(ZMQ.REQ);
-        ZMQ.Socket socket2 = context.socket(ZMQ.REQ);
+        ZMQ.Socket socket1 = context.socket(SocketType.REQ);
+        ZMQ.Socket socket2 = context.socket(SocketType.REQ);
         socket1.bind("inproc://address.already.in.use");
 
         socket2.bind("inproc://address.already.in.use");
@@ -99,8 +99,8 @@ public class TestZMQ
     {
         Context context = ZMQ.context(1);
 
-        Socket push = context.socket(ZMQ.PUSH);
-        Socket pull = context.socket(ZMQ.PULL);
+        Socket push = context.socket(SocketType.PUSH);
+        Socket pull = context.socket(SocketType.PULL);
 
         boolean rc = pull.setReceiveTimeOut(50);
         assertThat(rc, is(true));
@@ -136,8 +136,8 @@ public class TestZMQ
     {
         Context context = ZMQ.context(1);
 
-        Socket push = context.socket(ZMQ.PUSH);
-        Socket pull = context.socket(ZMQ.PULL);
+        Socket push = context.socket(SocketType.PUSH);
+        Socket pull = context.socket(SocketType.PULL);
 
         boolean rc = pull.setReceiveTimeOut(50);
         assertThat(rc, is(true));
@@ -168,14 +168,14 @@ public class TestZMQ
     @Test
     public void testContextBlocky()
     {
-        Socket router = ctx.socket(ZMQ.ROUTER);
+        Socket router = ctx.socket(SocketType.ROUTER);
         long rc = router.getLinger();
         assertThat(rc, is(-1L));
 
         router.close();
         ctx.setBlocky(false);
 
-        router = ctx.socket(ZMQ.ROUTER);
+        router = ctx.socket(SocketType.ROUTER);
 
         rc = router.getLinger();
         assertThat(rc, is(0L));
@@ -186,7 +186,7 @@ public class TestZMQ
     @Test(timeout = 1000)
     public void testSocketDoubleClose()
     {
-        Socket socket = ctx.socket(ZMQ.PUSH);
+        Socket socket = ctx.socket(SocketType.PUSH);
         socket.close();
         socket.close();
     }
@@ -194,7 +194,7 @@ public class TestZMQ
     @Test
     public void testSubscribe()
     {
-        ZMQ.Socket socket = ctx.socket(ZMQ.SUB);
+        ZMQ.Socket socket = ctx.socket(SocketType.SUB);
 
         boolean rc = socket.subscribe("abc");
         assertThat(rc, is(true));
@@ -211,7 +211,7 @@ public class TestZMQ
     @Test
     public void testSocketAffinity()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
         socket.setAffinity(42);
         long rc = socket.getAffinity();
@@ -224,7 +224,7 @@ public class TestZMQ
     @Test
     public void testSocketBacklog()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         boolean set = socket.setBacklog(42L);
@@ -238,7 +238,7 @@ public class TestZMQ
     @Test
     public void testSocketConflate()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         boolean set = socket.setConflate(true);
@@ -257,7 +257,7 @@ public class TestZMQ
     @Test
     public void testSocketConnectRid()
     {
-        final Socket socket = ctx.socket(ZMQ.ROUTER);
+        final Socket socket = ctx.socket(SocketType.ROUTER);
         assertThat(socket, notNullValue());
 
         boolean set = socket.setConnectRid("rid");
@@ -273,7 +273,7 @@ public class TestZMQ
     @Test
     public void testSocketCurveAsServer()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
         boolean rc = socket.setCurveServer(true);
         assertThat(rc, is(true));
@@ -296,7 +296,7 @@ public class TestZMQ
     @Test
     public void testSocketCurveSecret()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         byte[] key = new byte[32];
@@ -320,7 +320,7 @@ public class TestZMQ
     @Test
     public void testSocketCurvePublic()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         Mechanism mechanism = socket.getMechanism();
@@ -346,7 +346,7 @@ public class TestZMQ
     @Test
     public void testSocketCurveServer()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         byte[] key = new byte[32];
@@ -370,7 +370,7 @@ public class TestZMQ
     @Test
     public void testSocketHandshake()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         boolean set = socket.setHandshakeIvl(42);
@@ -384,7 +384,7 @@ public class TestZMQ
     @Test
     public void testSocketHeartbeatIvl()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         boolean set = socket.setHeartbeatIvl(42);
@@ -398,7 +398,7 @@ public class TestZMQ
     @Test
     public void testSocketHeartbeatTtl()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         boolean set = socket.setHeartbeatTtl(420);
@@ -412,7 +412,7 @@ public class TestZMQ
     @Test
     public void testSocketHeartbeatTimeout()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         boolean set = socket.setHeartbeatTimeout(42);
@@ -426,7 +426,7 @@ public class TestZMQ
     @Test
     public void testSocketHeartbeatContext()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         byte[] context = new byte[3];
@@ -445,7 +445,7 @@ public class TestZMQ
     @Test
     public void testSocketHWM()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         boolean set = socket.setHWM(42);
@@ -473,7 +473,7 @@ public class TestZMQ
     @Test
     public void testSocketIdentity()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         byte[] identity = new byte[42];
@@ -490,7 +490,7 @@ public class TestZMQ
     @Test
     public void testSocketImmediate()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         boolean set = socket.setImmediate(false);
@@ -532,7 +532,7 @@ public class TestZMQ
     @Test
     public void testSocketIPv6()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         boolean set = socket.setIPv6(true);
@@ -570,7 +570,7 @@ public class TestZMQ
     @Test
     public void testSocketLinger()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         boolean set = socket.setLinger(42);
@@ -589,7 +589,7 @@ public class TestZMQ
     @Test
     public void testSocketMaxMsgSize()
     {
-        final Socket socket = ctx.socket(ZMQ.STREAM);
+        final Socket socket = ctx.socket(SocketType.STREAM);
         assertThat(socket, notNullValue());
 
         boolean set = socket.setMaxMsgSize(42);
@@ -603,7 +603,7 @@ public class TestZMQ
     @Test
     public void testSocketMsgAllocationThreshold()
     {
-        final Socket socket = ctx.socket(ZMQ.STREAM);
+        final Socket socket = ctx.socket(SocketType.STREAM);
         assertThat(socket, notNullValue());
 
         boolean set = socket.setMsgAllocationHeapThreshold(42);
@@ -617,7 +617,7 @@ public class TestZMQ
     @Test
     public void testSocketMsgAllocator()
     {
-        final Socket socket = ctx.socket(ZMQ.STREAM);
+        final Socket socket = ctx.socket(SocketType.STREAM);
         assertThat(socket, notNullValue());
 
         MsgAllocator allocator = new MsgAllocatorDirect();
@@ -631,7 +631,7 @@ public class TestZMQ
     @Test(expected = UnsupportedOperationException.class)
     public void testSocketMulticastHops()
     {
-        final Socket socket = ctx.socket(ZMQ.STREAM);
+        final Socket socket = ctx.socket(SocketType.STREAM);
         assertThat(socket, notNullValue());
 
         try {
@@ -645,7 +645,7 @@ public class TestZMQ
     @Test
     public void testSocketGetMulticastHops()
     {
-        final Socket socket = ctx.socket(ZMQ.STREAM);
+        final Socket socket = ctx.socket(SocketType.STREAM);
         assertThat(socket, notNullValue());
 
         long rc = socket.getMulticastHops();
@@ -658,7 +658,7 @@ public class TestZMQ
     @Test(expected = UnsupportedOperationException.class)
     public void testSocketMulticastLoop()
     {
-        final Socket socket = ctx.socket(ZMQ.STREAM);
+        final Socket socket = ctx.socket(SocketType.STREAM);
         assertThat(socket, notNullValue());
 
         try {
@@ -673,7 +673,7 @@ public class TestZMQ
     @Test
     public void testSocketHasMulticastLoop()
     {
-        final Socket socket = ctx.socket(ZMQ.STREAM);
+        final Socket socket = ctx.socket(SocketType.STREAM);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.hasMulticastLoop();
@@ -684,7 +684,7 @@ public class TestZMQ
     @Test
     public void testSocketPlainPassword()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setPlainPassword("password");
@@ -705,7 +705,7 @@ public class TestZMQ
     @Test
     public void testSocketPlainUsername()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setPlainUsername("username");
@@ -727,7 +727,7 @@ public class TestZMQ
     @Test
     public void testSocketPlainServer()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setPlainServer(true);
@@ -751,7 +751,7 @@ public class TestZMQ
     @Test
     public void testSocketProbeRouter()
     {
-        final Socket socket = ctx.socket(ZMQ.ROUTER);
+        final Socket socket = ctx.socket(SocketType.ROUTER);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setProbeRouter(true);
@@ -763,7 +763,7 @@ public class TestZMQ
     @Test(expected = UnsupportedOperationException.class)
     public void testSocketRate()
     {
-        final Socket socket = ctx.socket(ZMQ.ROUTER);
+        final Socket socket = ctx.socket(SocketType.ROUTER);
         assertThat(socket, notNullValue());
 
         try {
@@ -777,7 +777,7 @@ public class TestZMQ
     @Test
     public void testSocketGetRate()
     {
-        final Socket socket = ctx.socket(ZMQ.ROUTER);
+        final Socket socket = ctx.socket(SocketType.ROUTER);
         assertThat(socket, notNullValue());
 
         long rate = socket.getRate();
@@ -789,7 +789,7 @@ public class TestZMQ
     @Test
     public void testSocketRcvHwm()
     {
-        final Socket socket = ctx.socket(ZMQ.DEALER);
+        final Socket socket = ctx.socket(SocketType.DEALER);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setRcvHWM(42L);
@@ -808,7 +808,7 @@ public class TestZMQ
     @Test
     public void testSocketSndHwm()
     {
-        final Socket socket = ctx.socket(ZMQ.DEALER);
+        final Socket socket = ctx.socket(SocketType.DEALER);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setSndHWM(42L);
@@ -827,7 +827,7 @@ public class TestZMQ
     @Test
     public void testSocketReceiveBufferSize()
     {
-        final Socket socket = ctx.socket(ZMQ.DEALER);
+        final Socket socket = ctx.socket(SocketType.DEALER);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setReceiveBufferSize(42L);
@@ -846,7 +846,7 @@ public class TestZMQ
     @Test
     public void testSocketSendBufferSize()
     {
-        final Socket socket = ctx.socket(ZMQ.DEALER);
+        final Socket socket = ctx.socket(SocketType.DEALER);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setSendBufferSize(42L);
@@ -864,7 +864,7 @@ public class TestZMQ
     @Test
     public void testSocketReceiveTimeOut()
     {
-        final Socket socket = ctx.socket(ZMQ.PAIR);
+        final Socket socket = ctx.socket(SocketType.PAIR);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setReceiveTimeOut(42);
@@ -882,7 +882,7 @@ public class TestZMQ
     @Test
     public void testSocketSendTimeOut()
     {
-        final Socket socket = ctx.socket(ZMQ.PAIR);
+        final Socket socket = ctx.socket(SocketType.PAIR);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setSendTimeOut(42);
@@ -901,7 +901,7 @@ public class TestZMQ
     @Test
     public void testSocketReconnectIVL()
     {
-        final Socket socket = ctx.socket(ZMQ.REP);
+        final Socket socket = ctx.socket(SocketType.REP);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setReconnectIVL(42L);
@@ -917,7 +917,7 @@ public class TestZMQ
     @Test
     public void testSocketReconnectIVLMax()
     {
-        final Socket socket = ctx.socket(ZMQ.REP);
+        final Socket socket = ctx.socket(SocketType.REP);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setReconnectIVLMax(42L);
@@ -932,7 +932,7 @@ public class TestZMQ
     @Test(expected = UnsupportedOperationException.class)
     public void testSocketRecoveryInterval()
     {
-        final Socket socket = ctx.socket(ZMQ.REP);
+        final Socket socket = ctx.socket(SocketType.REP);
         assertThat(socket, notNullValue());
 
         try {
@@ -946,7 +946,7 @@ public class TestZMQ
     @Test
     public void testSocketgetRecoveryInterval()
     {
-        final Socket socket = ctx.socket(ZMQ.REP);
+        final Socket socket = ctx.socket(SocketType.REP);
         assertThat(socket, notNullValue());
 
         long reconnect = socket.getRecoveryInterval();
@@ -958,7 +958,7 @@ public class TestZMQ
     @Test
     public void testSocketReqCorrelate()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setReqCorrelate(true);
@@ -973,7 +973,7 @@ public class TestZMQ
     @Test(expected = UnsupportedOperationException.class)
     public void testSocketGetReqCorrelate()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         try {
@@ -987,7 +987,7 @@ public class TestZMQ
     @Test
     public void testSocketReqRelaxed()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setReqRelaxed(true);
@@ -1002,7 +1002,7 @@ public class TestZMQ
     @Test(expected = UnsupportedOperationException.class)
     public void testSocketGetReqRelaxed()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         try {
@@ -1016,7 +1016,7 @@ public class TestZMQ
     @Test
     public void testSocketRouterHandover()
     {
-        final Socket socket = ctx.socket(ZMQ.ROUTER);
+        final Socket socket = ctx.socket(SocketType.ROUTER);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setRouterHandover(true);
@@ -1028,7 +1028,7 @@ public class TestZMQ
     @Test
     public void testSocketRouterMandatory()
     {
-        final Socket socket = ctx.socket(ZMQ.ROUTER);
+        final Socket socket = ctx.socket(SocketType.ROUTER);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setRouterMandatory(true);
@@ -1040,7 +1040,7 @@ public class TestZMQ
     @Test
     public void testSocketRouterRaw()
     {
-        final Socket socket = ctx.socket(ZMQ.ROUTER);
+        final Socket socket = ctx.socket(SocketType.ROUTER);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setRouterRaw(true);
@@ -1052,7 +1052,7 @@ public class TestZMQ
     @Test
     public void testSocketSocksProxy()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setSocksProxy("abc");
@@ -1074,7 +1074,7 @@ public class TestZMQ
     @Test(expected = UnsupportedOperationException.class)
     public void testSocketSwap()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         try {
@@ -1089,7 +1089,7 @@ public class TestZMQ
     @Test
     public void testSocketGetSwap()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         long rc = socket.getSwap();
@@ -1102,7 +1102,7 @@ public class TestZMQ
     @Test
     public void testSocketTCPKeepAlive()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setTCPKeepAlive(1L);
@@ -1120,7 +1120,7 @@ public class TestZMQ
     @Test
     public void testSocketTCPKeepAliveCount()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setTCPKeepAliveCount(42);
@@ -1135,7 +1135,7 @@ public class TestZMQ
     @Test
     public void testSocketTCPKeepAliveInterval()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setTCPKeepAliveInterval(42);
@@ -1150,7 +1150,7 @@ public class TestZMQ
     @Test
     public void testSocketTCPKeepAliveIdle()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setTCPKeepAliveIdle(42);
@@ -1165,7 +1165,7 @@ public class TestZMQ
     @Test
     public void testSocketTos()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setTos(42);
@@ -1180,11 +1180,11 @@ public class TestZMQ
     @Test
     public void testSocketType()
     {
-        final Socket socket = ctx.socket(ZMQ.REQ);
+        final Socket socket = ctx.socket(SocketType.REQ);
         assertThat(socket, notNullValue());
 
-        int rc = socket.getType();
-        assertThat(rc, is(ZMQ.REQ));
+        SocketType rc = socket.getType();
+        assertThat(rc, is(SocketType.REQ));
 
         socket.close();
     }
@@ -1192,7 +1192,7 @@ public class TestZMQ
     @Test
     public void testSocketXpubNoDrop()
     {
-        final Socket socket = ctx.socket(ZMQ.XPUB);
+        final Socket socket = ctx.socket(SocketType.XPUB);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setXpubNoDrop(true);
@@ -1204,7 +1204,7 @@ public class TestZMQ
     @Test
     public void testSocketXpubVerbose()
     {
-        final Socket socket = ctx.socket(ZMQ.XPUB);
+        final Socket socket = ctx.socket(SocketType.XPUB);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setXpubVerbose(true);
@@ -1216,7 +1216,7 @@ public class TestZMQ
     @Test
     public void testSocketZAPDomain()
     {
-        final Socket socket = ctx.socket(ZMQ.XPUB);
+        final Socket socket = ctx.socket(SocketType.XPUB);
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setZAPDomain("abc");

--- a/src/test/java/org/zeromq/TestZPoller.java
+++ b/src/test/java/org/zeromq/TestZPoller.java
@@ -46,7 +46,7 @@ public class TestZPoller
         public Server(ZContext context, int port)
         {
             this.port = port;
-            socket = context.createSocket(ZMQ.PUSH);
+            socket = context.createSocket(SocketType.PUSH);
             poller = new ZPoller(context);
         }
 
@@ -88,7 +88,7 @@ public class TestZPoller
 
         final ZContext context = new ZContext();
         final ZPoller poller = new ZPoller(context.createSelector());
-        final ZMQ.Socket receiver = context.createSocket(ZMQ.PULL);
+        final ZMQ.Socket receiver = context.createSocket(SocketType.PULL);
 
         final Server client = new Server(context, port);
         client.start();
@@ -220,7 +220,7 @@ public class TestZPoller
         ZPoller poller = new ZPoller(itemCreator, ctx);
 
         try {
-            Socket socket = ctx.createSocket(ZMQ.ROUTER);
+            Socket socket = ctx.createSocket(SocketType.ROUTER);
             ItemHolder holder = itemCreator.create(socket, null, 0);
 
             assertThat(holder, is(holder));
@@ -242,7 +242,7 @@ public class TestZPoller
         ZPoller poller = new ZPoller(itemCreator, ctx);
 
         try {
-            Socket socket = ctx.createSocket(ZMQ.ROUTER);
+            Socket socket = ctx.createSocket(SocketType.ROUTER);
             ItemHolder holder = poller.create(socket, null, 0);
 
             ItemHolder other = new ZPoller.ZPollItem(socket, null, 0);
@@ -251,7 +251,7 @@ public class TestZPoller
             other = new ZPoller.ZPollItem(socket, new EventsHandlerAdapter(), 0);
             assertThat(other, is(not(equalTo(holder))));
 
-            socket = ctx.createSocket(ZMQ.ROUTER);
+            socket = ctx.createSocket(SocketType.ROUTER);
             other = new ZPoller.ZPollItem(socket, null, 0);
             assertThat(other, is(not(equalTo(holder))));
 
@@ -274,7 +274,7 @@ public class TestZPoller
         ZContext ctx = new ZContext();
         ZPoller poller = new ZPoller(ctx);
         try {
-            Socket socket = ctx.createSocket(ZMQ.XPUB);
+            Socket socket = ctx.createSocket(SocketType.XPUB);
             poller.register(socket, new EventsHandlerAdapter());
 
             boolean rc = poller.readable(socket);
@@ -298,7 +298,7 @@ public class TestZPoller
         ZContext ctx = new ZContext();
         ZPoller poller = new ZPoller(ctx);
         try {
-            Socket socket = ctx.createSocket(ZMQ.XPUB);
+            Socket socket = ctx.createSocket(SocketType.XPUB);
             poller.register(socket, ZPoller.OUT);
 
             boolean rc = poller.writable(socket);
@@ -322,7 +322,7 @@ public class TestZPoller
         ZContext ctx = new ZContext();
         ZPoller poller = new ZPoller(ctx);
         try {
-            Socket socket = ctx.createSocket(ZMQ.XPUB);
+            Socket socket = ctx.createSocket(SocketType.XPUB);
             poller.register(socket, ZPoller.ERR);
 
             boolean rc = poller.error(socket);
@@ -346,7 +346,7 @@ public class TestZPoller
         ZContext ctx = new ZContext();
         ZPoller poller = new ZPoller(ctx);
         try {
-            Socket socket = ctx.createSocket(ZMQ.XPUB);
+            Socket socket = ctx.createSocket(SocketType.XPUB);
             ItemHolder holder = poller.create(socket, null, 0);
             boolean rc = poller.register(holder);
             assertThat(rc, is(true));
@@ -363,7 +363,7 @@ public class TestZPoller
         ZContext ctx = new ZContext();
         ZPoller poller = new ZPoller(ctx);
         try {
-            Socket socket = ctx.createSocket(ZMQ.XPUB);
+            Socket socket = ctx.createSocket(SocketType.XPUB);
             Iterable<ItemHolder> items = poller.items(null);
             assertThat(items, notNullValue());
 

--- a/src/test/java/org/zeromq/TestZProxy.java
+++ b/src/test/java/org/zeromq/TestZProxy.java
@@ -27,10 +27,10 @@ public class TestZProxy
         {
             Socket socket = null;
             if (place == ZProxy.Plug.FRONT) {
-                socket = ctx.createSocket(ZMQ.ROUTER);
+                socket = ctx.createSocket(SocketType.ROUTER);
             }
             if (place == ZProxy.Plug.BACK) {
-                socket = ctx.createSocket(ZMQ.DEALER);
+                socket = ctx.createSocket(SocketType.DEALER);
             }
             return socket;
         }

--- a/src/test/java/org/zeromq/TestZThread.java
+++ b/src/test/java/org/zeromq/TestZThread.java
@@ -26,7 +26,7 @@ public class TestZThread
             {
                 ZContext ctx = new ZContext();
 
-                Socket push = ctx.createSocket(ZMQ.PUSH);
+                Socket push = ctx.createSocket(SocketType.PUSH);
                 assertThat(push, notNullValue());
 
                 ctx.close();
@@ -55,7 +55,7 @@ public class TestZThread
             public void run(Object[] args, ZContext ctx, Socket pipe)
             {
                 //  Create a socket to check it'll be automatically deleted
-                ctx.createSocket(ZMQ.PUSH);
+                ctx.createSocket(SocketType.PUSH);
                 pipe.recvStr();
                 pipe.send("pong");
             }

--- a/src/test/java/org/zeromq/TooManyOpenFilesTester.java
+++ b/src/test/java/org/zeromq/TooManyOpenFilesTester.java
@@ -50,7 +50,7 @@ public class TooManyOpenFilesTester
         {
             ZContext ctx = new ZContext(1);
 
-            Socket server = ctx.createSocket(ZMQ.ROUTER);
+            Socket server = ctx.createSocket(SocketType.ROUTER);
 
             server.bind("tcp://localhost:" + port);
 
@@ -106,7 +106,7 @@ public class TooManyOpenFilesTester
         {
             ZContext ctx = new ZContext(1);
 
-            Socket client = ctx.createSocket(ZMQ.REQ);
+            Socket client = ctx.createSocket(SocketType.REQ);
 
             client.setIdentity("ID".getBytes());
             client.connect("tcp://localhost:" + port);

--- a/src/test/java/org/zeromq/XpubXsubZTest.java
+++ b/src/test/java/org/zeromq/XpubXsubZTest.java
@@ -38,7 +38,7 @@ public class XpubXsubZTest
                 Thread.currentThread().setName("Subscriber");
                 final ZContext ctx = new ZContext();
                 try {
-                    final ZMQ.Socket requester = ctx.createSocket(ZMQ.SUB);
+                    final ZMQ.Socket requester = ctx.createSocket(SocketType.SUB);
                     requester.connect("tcp://localhost:" + back);
                     requester.subscribe("hello".getBytes(ZMQ.CHARSET));
 
@@ -61,7 +61,7 @@ public class XpubXsubZTest
             {
                 Thread.currentThread().setName("Publisher");
                 try {
-                    ZMQ.Socket pub = ctx.createSocket(ZMQ.PUB);
+                    ZMQ.Socket pub = ctx.createSocket(SocketType.PUB);
                     pub.connect("tcp://localhost:" + front);
                     while (numberReceived.get() < max) {
                         ZMsg message = ZMsg.newStringMsg("hello", "world");
@@ -108,17 +108,17 @@ public class XpubXsubZTest
             public void run()
             {
                 Thread.currentThread().setName("Proxy");
-                ZMQ.Socket xpub = ctx.createSocket(ZMQ.XPUB);
+                ZMQ.Socket xpub = ctx.createSocket(SocketType.XPUB);
                 xpub.bind("tcp://*:" + back);
-                ZMQ.Socket xsub = ctx.createSocket(ZMQ.XSUB);
+                ZMQ.Socket xsub = ctx.createSocket(SocketType.XSUB);
                 xsub.bind("tcp://*:" + front);
-                ZMQ.Socket ctrl = ctx.createSocket(ZMQ.PAIR);
+                ZMQ.Socket ctrl = ctx.createSocket(SocketType.PAIR);
                 ctrl.bind("inproc://ctrl-proxy");
                 ZMQ.proxy(xpub, xsub, null, ctrl);
             }
         });
         final AtomicReference<Throwable> error = testIssue476(front, back, max, service, ctx);
-        ZMQ.Socket ctrl = ctx.createSocket(ZMQ.PAIR);
+        ZMQ.Socket ctrl = ctx.createSocket(SocketType.PAIR);
         ctrl.connect("inproc://ctrl-proxy");
         ctrl.send(ZMQ.PROXY_TERMINATE);
         ctrl.close();
@@ -149,13 +149,13 @@ public class XpubXsubZTest
             public Socket create(ZContext ctx, Plug place, Object... args)
             {
                 if (place == Plug.FRONT) {
-                    return ctx.createSocket(ZMQ.XSUB);
+                    return ctx.createSocket(SocketType.XSUB);
                 }
                 if (place == Plug.BACK) {
-                    return ctx.createSocket(ZMQ.XPUB);
+                    return ctx.createSocket(SocketType.XPUB);
                 }
                 if (place == Plug.CAPTURE) {
-                    return ctx.createSocket(ZMQ.PUB);
+                    return ctx.createSocket(SocketType.PUB);
                 }
                 return null;
             }
@@ -204,13 +204,13 @@ public class XpubXsubZTest
             public Socket create(ZContext ctx, Plug place, Object... args)
             {
                 if (place == Plug.FRONT) {
-                    return ctx.createSocket(ZMQ.XSUB);
+                    return ctx.createSocket(SocketType.XSUB);
                 }
                 if (place == Plug.BACK) {
-                    return ctx.createSocket(ZMQ.XPUB);
+                    return ctx.createSocket(SocketType.XPUB);
                 }
                 if (place == Plug.CAPTURE) {
-                    return ctx.createSocket(ZMQ.PUB);
+                    return ctx.createSocket(SocketType.PUB);
                 }
                 return null;
             }

--- a/src/test/java/org/zeromq/ZFrameTest.java
+++ b/src/test/java/org/zeromq/ZFrameTest.java
@@ -36,9 +36,9 @@ public class ZFrameTest
     public void testSending()
     {
         ZContext ctx = new ZContext();
-        Socket output = ctx.createSocket(ZMQ.PAIR);
+        Socket output = ctx.createSocket(SocketType.PAIR);
         output.bind("inproc://zframe.test");
-        Socket input = ctx.createSocket(ZMQ.PAIR);
+        Socket input = ctx.createSocket(SocketType.PAIR);
         input.connect("inproc://zframe.test");
 
         // Send five different frames, test ZFRAME_MORE
@@ -72,9 +72,9 @@ public class ZFrameTest
     public void testReceiving()
     {
         ZContext ctx = new ZContext();
-        Socket output = ctx.createSocket(ZMQ.PAIR);
+        Socket output = ctx.createSocket(SocketType.PAIR);
         output.bind("inproc://zframe.test");
-        Socket input = ctx.createSocket(ZMQ.PAIR);
+        Socket input = ctx.createSocket(SocketType.PAIR);
         input.connect("inproc://zframe.test");
 
         // Send same frame five times
@@ -110,9 +110,9 @@ public class ZFrameTest
     public void testStringFrames()
     {
         ZContext ctx = new ZContext();
-        Socket output = ctx.createSocket(ZMQ.PAIR);
+        Socket output = ctx.createSocket(SocketType.PAIR);
         output.bind("inproc://zframe.test");
-        Socket input = ctx.createSocket(ZMQ.PAIR);
+        Socket input = ctx.createSocket(SocketType.PAIR);
         input.connect("inproc://zframe.test");
 
         ZFrame f1 = new ZFrame("Hello");

--- a/src/test/java/org/zeromq/ZLoopTest.java
+++ b/src/test/java/org/zeromq/ZLoopTest.java
@@ -25,10 +25,10 @@ public class ZLoopTest
         ctx = new ZContext();
         assertThat(ctx, notNullValue());
 
-        output = ctx.createSocket(ZMQ.PAIR);
+        output = ctx.createSocket(SocketType.PAIR);
         assertThat(output, notNullValue());
         output.bind("inproc://zloop.test");
-        input = ctx.createSocket(ZMQ.PAIR);
+        input = ctx.createSocket(SocketType.PAIR);
         assertThat(input, notNullValue());
         input.connect("inproc://zloop.test");
 

--- a/src/test/java/org/zeromq/ZMonitorTest.java
+++ b/src/test/java/org/zeromq/ZMonitorTest.java
@@ -17,7 +17,7 @@ public class ZMonitorTest
     public void testZMonitorImpossibleWorkflows() throws IOException
     {
         final ZContext ctx = new ZContext();
-        final Socket socket = ctx.createSocket(ZMQ.DEALER);
+        final Socket socket = ctx.createSocket(SocketType.DEALER);
 
         final ZMonitor monitor = new ZMonitor(ctx, socket);
 
@@ -41,8 +41,8 @@ public class ZMonitorTest
     public void testZMonitor() throws IOException
     {
         final ZContext ctx = new ZContext();
-        final Socket client = ctx.createSocket(ZMQ.DEALER);
-        final Socket server = ctx.createSocket(ZMQ.DEALER);
+        final Socket client = ctx.createSocket(SocketType.DEALER);
+        final Socket server = ctx.createSocket(SocketType.DEALER);
 
         final ZMonitor clientMonitor = new ZMonitor(ctx, client);
         clientMonitor.verbose(true);

--- a/src/test/java/org/zeromq/ZMsgTest.java
+++ b/src/test/java/org/zeromq/ZMsgTest.java
@@ -34,7 +34,7 @@ public class ZMsgTest
     public void testRecvFrame() throws Exception
     {
         ZMQ.Context ctx = ZMQ.context(0);
-        ZMQ.Socket socket = ctx.socket(ZMQ.PULL);
+        ZMQ.Socket socket = ctx.socket(SocketType.PULL);
 
         ZFrame frame = ZFrame.recvFrame(socket, ZMQ.NOBLOCK);
         assertThat(frame, nullValue());
@@ -47,7 +47,7 @@ public class ZMsgTest
     public void testRecvMsg() throws Exception
     {
         ZMQ.Context ctx = ZMQ.context(0);
-        ZMQ.Socket socket = ctx.socket(ZMQ.PULL);
+        ZMQ.Socket socket = ctx.socket(SocketType.PULL);
 
         ZMsg msg = ZMsg.recvMsg(socket, ZMQ.NOBLOCK);
         assertThat(msg, nullValue());
@@ -60,8 +60,8 @@ public class ZMsgTest
     public void testRecvNullByteMsg() throws Exception
     {
         ZMQ.Context ctx = ZMQ.context(0);
-        ZMQ.Socket sender = ctx.socket(ZMQ.PUSH);
-        ZMQ.Socket receiver = ctx.socket(ZMQ.PULL);
+        ZMQ.Socket sender = ctx.socket(SocketType.PUSH);
+        ZMQ.Socket receiver = ctx.socket(SocketType.PULL);
 
         receiver.bind("inproc://" + this.hashCode());
         sender.connect("inproc://" + this.hashCode());
@@ -253,9 +253,9 @@ public class ZMsgTest
     {
         ZContext ctx = new ZContext();
 
-        Socket output = ctx.createSocket(ZMQ.PAIR);
+        Socket output = ctx.createSocket(SocketType.PAIR);
         output.bind("inproc://zmsg.test");
-        Socket input = ctx.createSocket(ZMQ.PAIR);
+        Socket input = ctx.createSocket(SocketType.PAIR);
         input.connect("inproc://zmsg.test");
 
         // Test send and receive of a single ZMsg
@@ -281,9 +281,9 @@ public class ZMsgTest
     {
         ZContext ctx = new ZContext();
 
-        Socket output = ctx.createSocket(ZMQ.PAIR);
+        Socket output = ctx.createSocket(SocketType.PAIR);
         output.bind("inproc://zmsg.test2");
-        Socket input = ctx.createSocket(ZMQ.PAIR);
+        Socket input = ctx.createSocket(SocketType.PAIR);
         input.connect("inproc://zmsg.test2");
 
         ZMsg msg = new ZMsg();
@@ -436,9 +436,9 @@ public class ZMsgTest
     {
         ZContext ctx = new ZContext();
 
-        Socket output = ctx.createSocket(ZMQ.PAIR);
+        Socket output = ctx.createSocket(SocketType.PAIR);
         output.bind("inproc://zmsg.test");
-        Socket input = ctx.createSocket(ZMQ.PAIR);
+        Socket input = ctx.createSocket(SocketType.PAIR);
         input.connect("inproc://zmsg.test");
 
         ZMsg msg = ZMsg.newStringMsg("Foo", "Bar");

--- a/src/test/java/org/zeromq/auth/ZAuthTest.java
+++ b/src/test/java/org/zeromq/auth/ZAuthTest.java
@@ -11,11 +11,7 @@ import java.io.IOException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.zeromq.ZAuth;
-import org.zeromq.ZCert;
-import org.zeromq.ZCertStore;
-import org.zeromq.ZContext;
-import org.zeromq.ZMQ;
+import org.zeromq.*;
 
 /**
  * Test are basically the java-ports based on <a href="http://hintjens.com/blog:49">Using ZeroMQ Security (part 2)</a>
@@ -56,12 +52,12 @@ public class ZAuthTest
             auth.replies(true);
 
             //  Create and bind server socket
-            ZMQ.Socket server = ctx.createSocket(ZMQ.PUSH);
+            ZMQ.Socket server = ctx.createSocket(SocketType.PUSH);
             server.setZapDomain("test");
             final int port = server.bindToRandomPort("tcp://*");
 
             //  Create and connect client socket
-            ZMQ.Socket client = ctx.createSocket(ZMQ.PULL);
+            ZMQ.Socket client = ctx.createSocket(SocketType.PULL);
             boolean rc = client.connect("tcp://127.0.0.1:" + port);
             assertThat(rc, is(true));
 
@@ -98,12 +94,12 @@ public class ZAuthTest
             auth.allow("127.0.0.1");
 
             //  Create and bind server socket
-            ZMQ.Socket server = ctx.createSocket(ZMQ.PUSH);
+            ZMQ.Socket server = ctx.createSocket(SocketType.PUSH);
             server.setZapDomain("test");
             final int port = server.bindToRandomPort("tcp://*");
 
             //  Create and connect client socket
-            ZMQ.Socket client = ctx.createSocket(ZMQ.PULL);
+            ZMQ.Socket client = ctx.createSocket(SocketType.PULL);
             boolean rc = client.connect("tcp://127.0.0.1:" + port);
             assertThat(rc, is(true));
 
@@ -140,12 +136,12 @@ public class ZAuthTest
             auth.allow("127.0.0.1");
 
             //  Create and bind server socket
-            ZMQ.Socket server = ctx.createSocket(ZMQ.PUSH);
+            ZMQ.Socket server = ctx.createSocket(SocketType.PUSH);
             //            server.setZapDomain("test"); // no domain, so no NULL authentication mechanism
             final int port = server.bindToRandomPort("tcp://*");
 
             //  Create and connect client socket
-            ZMQ.Socket client = ctx.createSocket(ZMQ.PULL);
+            ZMQ.Socket client = ctx.createSocket(SocketType.PULL);
             boolean rc = client.connect("tcp://127.0.0.1:" + port);
             assertThat(rc, is(true));
 
@@ -185,13 +181,13 @@ public class ZAuthTest
             auth.configurePlain("*", PASSWORDS_FILE);
 
             //  Create and bind server socket
-            ZMQ.Socket server = ctx.createSocket(ZMQ.PUSH);
+            ZMQ.Socket server = ctx.createSocket(SocketType.PUSH);
             server.setPlainServer(true);
             server.setZapDomain("global".getBytes());
             final int port = server.bindToRandomPort("tcp://*");
 
             //  Create and connect client socket
-            ZMQ.Socket client = ctx.createSocket(ZMQ.PULL);
+            ZMQ.Socket client = ctx.createSocket(SocketType.PULL);
             client.setPlainUsername("admin".getBytes());
             client.setPlainPassword("secret".getBytes());
             boolean rc = client.connect("tcp://127.0.0.1:" + port);
@@ -234,13 +230,13 @@ public class ZAuthTest
             auth.configurePlain("*", PASSWORDS_FILE);
 
             //  Create and bind server socket
-            ZMQ.Socket server = ctx.createSocket(ZMQ.PUSH);
+            ZMQ.Socket server = ctx.createSocket(SocketType.PUSH);
             server.setPlainServer(true);
             server.setZapDomain("global".getBytes());
             final int port = server.bindToRandomPort("tcp://*");
 
             //  Create and connect client socket
-            ZMQ.Socket client = ctx.createSocket(ZMQ.PULL);
+            ZMQ.Socket client = ctx.createSocket(SocketType.PULL);
             client.setPlainUsername("admin".getBytes());
             client.setPlainPassword("wrong".getBytes());
             boolean rc = client.connect("tcp://127.0.0.1:" + port);
@@ -285,14 +281,14 @@ public class ZAuthTest
             ZCert serverCert = new ZCert();
 
             //  Create and bind server socket
-            ZMQ.Socket server = ctx.createSocket(ZMQ.PUSH);
+            ZMQ.Socket server = ctx.createSocket(SocketType.PUSH);
             server.setZapDomain("global".getBytes());
             server.setCurveServer(true);
             serverCert.apply(server);
             final int port = server.bindToRandomPort("tcp://*");
 
             //  Create and connect client socket
-            ZMQ.Socket client = ctx.createSocket(ZMQ.PULL);
+            ZMQ.Socket client = ctx.createSocket(SocketType.PULL);
             clientCert.apply(client);
             client.setCurveServerKey(serverCert.getPublicKey());
             boolean rc = client.connect("tcp://127.0.0.1:" + port);
@@ -351,7 +347,7 @@ public class ZAuthTest
             ZCert serverCert = new ZCert();
 
             //  Create and bind server socket
-            ZMQ.Socket server = ctx.createSocket(ZMQ.PUSH);
+            ZMQ.Socket server = ctx.createSocket(SocketType.PUSH);
             server.setZapDomain("global".getBytes());
             server.setCurveServer(true);
             server.setCurvePublicKey(serverCert.getPublicKey());
@@ -359,7 +355,7 @@ public class ZAuthTest
             final int port = server.bindToRandomPort("tcp://*");
 
             //  Create and connect client socket
-            ZMQ.Socket client = ctx.createSocket(ZMQ.PULL);
+            ZMQ.Socket client = ctx.createSocket(SocketType.PULL);
             client.setCurvePublicKey(clientCert.getPublicKey());
             client.setCurveSecretKey(clientCert.getSecretKey());
             client.setCurveServerKey(serverCert.getPublicKey());
@@ -404,12 +400,12 @@ public class ZAuthTest
             auth.deny("127.0.0.1");
 
             //  Create and bind server socket
-            ZMQ.Socket server = ctx.createSocket(ZMQ.PUSH);
+            ZMQ.Socket server = ctx.createSocket(SocketType.PUSH);
             server.setZapDomain("global".getBytes());
             final int port = server.bindToRandomPort("tcp://*");
 
             //  Create and connect client socket
-            ZMQ.Socket client = ctx.createSocket(ZMQ.PULL);
+            ZMQ.Socket client = ctx.createSocket(SocketType.PULL);
             boolean rc = client.connect("tcp://127.0.0.1:" + port);
             assertThat(rc, is(true));
 
@@ -447,12 +443,12 @@ public class ZAuthTest
             auth.deny("127.0.0.2");
 
             //  Create and bind server socket
-            ZMQ.Socket server = ctx.createSocket(ZMQ.PUSH);
+            ZMQ.Socket server = ctx.createSocket(SocketType.PUSH);
             server.setZapDomain("global".getBytes());
             final int port = server.bindToRandomPort("tcp://*");
 
             //  Create and connect client socket
-            ZMQ.Socket client = ctx.createSocket(ZMQ.PULL);
+            ZMQ.Socket client = ctx.createSocket(SocketType.PULL);
             boolean rc = client.connect("tcp://127.0.0.1:" + port);
             assertThat(rc, is(true));
 
@@ -490,12 +486,12 @@ public class ZAuthTest
             auth.allow("127.0.0.2");
 
             //  Create and bind server socket
-            ZMQ.Socket server = ctx.createSocket(ZMQ.PUSH);
+            ZMQ.Socket server = ctx.createSocket(SocketType.PUSH);
             server.setZapDomain("global".getBytes());
             final int port = server.bindToRandomPort("tcp://*");
 
             //  Create and connect client socket
-            ZMQ.Socket client = ctx.createSocket(ZMQ.PULL);
+            ZMQ.Socket client = ctx.createSocket(SocketType.PULL);
             boolean rc = client.connect("tcp://127.0.0.1:" + port);
             assertThat(rc, is(true));
 
@@ -533,12 +529,12 @@ public class ZAuthTest
             auth.allow("127.0.0.1");
 
             //  Create and bind server socket
-            ZMQ.Socket server = ctx.createSocket(ZMQ.PUSH);
+            ZMQ.Socket server = ctx.createSocket(SocketType.PUSH);
             server.setZapDomain("global".getBytes());
             final int port = server.bindToRandomPort("tcp://*");
 
             //  Create and connect client socket
-            ZMQ.Socket client = ctx.createSocket(ZMQ.PULL);
+            ZMQ.Socket client = ctx.createSocket(SocketType.PULL);
             boolean rc = client.connect("tcp://127.0.0.1:" + port);
             assertThat(rc, is(true));
 
@@ -585,14 +581,14 @@ public class ZAuthTest
             ZCert serverCert = new ZCert();
 
             //  Create and bind server socket
-            ZMQ.Socket server = ctx.createSocket(ZMQ.PUSH);
+            ZMQ.Socket server = ctx.createSocket(SocketType.PUSH);
             server.setZapDomain("global".getBytes());
             server.setCurveServer(true);
             serverCert.apply(server);
             final int port = server.bindToRandomPort("tcp://*");
 
             //  Create and connect client socket
-            ZMQ.Socket client = ctx.createSocket(ZMQ.PULL);
+            ZMQ.Socket client = ctx.createSocket(SocketType.PULL);
             clientCert.apply(client);
             client.setCurveServerKey(serverCert.getPublicKey());
             boolean rc = client.connect("tcp://127.0.0.1:" + port);


### PR DESCRIPTION
Solution: create a SocketType enum and use it instead of int flags
also mark int flag and their methods with Deprecated annotation 