### PR TITLE
Problem: Utils.findOpenPort() is not the most reliable method in the world (#563)

### DIFF
--- a/src/main/java/zmq/SocketBase.java
+++ b/src/main/java/zmq/SocketBase.java
@@ -370,7 +370,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
             // Save last endpoint URI
             options.lastEndpoint = listener.getAddress();
 
-            addEndpoint(addr, listener, null);
+            addEndpoint(options.lastEndpoint, listener, null);
             return true;
         }
 
@@ -386,7 +386,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
             // Save last endpoint URI
             options.lastEndpoint = listener.getAddress();
 
-            addEndpoint(addr, listener, null);
+            addEndpoint(options.lastEndpoint, listener, null);
             return true;
         }
 

--- a/src/main/java/zmq/io/net/Address.java
+++ b/src/main/java/zmq/io/net/Address.java
@@ -12,8 +12,7 @@ public class Address
     {
         ProtocolFamily family();
 
-        @Override
-        String toString();
+        String toString(int port);
 
         InetSocketAddress resolve(String name, boolean ipv6, boolean local);
 

--- a/src/main/java/zmq/io/net/ipc/IpcAddress.java
+++ b/src/main/java/zmq/io/net/ipc/IpcAddress.java
@@ -9,6 +9,7 @@ import zmq.io.net.Address;
 import zmq.io.net.ProtocolFamily;
 import zmq.io.net.StandardProtocolFamily;
 import zmq.io.net.tcp.TcpAddress;
+import zmq.util.Utils;
 
 public class IpcAddress implements Address.IZAddress
 {
@@ -53,16 +54,31 @@ public class IpcAddress implements Address.IZAddress
     }
 
     @Override
+    public String toString(int port)
+    {
+        if ("*".equals(name)) {
+            String suffix = Utils.unhash(port - 10000);
+            return "ipc://" + suffix;
+        }
+        return toString();
+    }
+
+    @Override
     public InetSocketAddress resolve(String name, boolean ipv6, boolean local)
     {
         this.name = name;
 
         int hash = name.hashCode();
-        if (hash < 0) {
-            hash = -hash;
+        if ("*".equals(name)) {
+            hash = 0;
         }
-        hash = hash % 55536;
-        hash += 10000;
+        else {
+            if (hash < 0) {
+                hash = -hash;
+            }
+            hash = hash % 55536;
+            hash += 10000;
+        }
 
         try {
             return new InetSocketAddress(InetAddress.getByName(null), hash);

--- a/src/main/java/zmq/io/net/ipc/IpcListener.java
+++ b/src/main/java/zmq/io/net/ipc/IpcListener.java
@@ -22,6 +22,9 @@ public class IpcListener extends TcpListener
     @Override
     public String getAddress()
     {
+        if (((InetSocketAddress) address.address()).getPort() == 0) {
+            return address(address);
+        }
         return address.toString();
     }
 

--- a/src/main/java/zmq/io/net/tcp/TcpAddress.java
+++ b/src/main/java/zmq/io/net/tcp/TcpAddress.java
@@ -58,6 +58,7 @@ public class TcpAddress implements Address.IZAddress
     }
 
     // The opposite to resolve()
+    @Override
     public String toString(int port)
     {
         if (address == null) {

--- a/src/main/java/zmq/io/net/tcp/TcpAddress.java
+++ b/src/main/java/zmq/io/net/tcp/TcpAddress.java
@@ -54,15 +54,25 @@ public class TcpAddress implements Address.IZAddress
     @Override
     public String toString()
     {
+        return toString(address.getPort());
+    }
+
+    // The opposite to resolve()
+    public String toString(int port)
+    {
         if (address == null) {
             return "";
         }
 
+        int addressPort = address.getPort();
+        if (addressPort == 0) {
+            addressPort = port;
+        }
         if (address.getAddress() instanceof Inet6Address) {
-            return "tcp://[" + address.getAddress().getHostAddress() + "]:" + address.getPort();
+            return "tcp://[" + address.getAddress().getHostAddress() + "]:" + addressPort;
         }
         else {
-            return "tcp://" + address.getAddress().getHostAddress() + ":" + address.getPort();
+            return "tcp://" + address.getAddress().getHostAddress() + ":" + addressPort;
         }
     }
 

--- a/src/main/java/zmq/io/net/tcp/TcpListener.java
+++ b/src/main/java/zmq/io/net/tcp/TcpListener.java
@@ -148,7 +148,8 @@ public class TcpListener extends Own implements IPollEvents
 
     public String getAddress()
     {
-        return address.toString();
+        int port = fd.socket().getLocalPort();
+        return address.toString(port);
     }
 
     //  Set address to listen on.

--- a/src/main/java/zmq/io/net/tcp/TcpListener.java
+++ b/src/main/java/zmq/io/net/tcp/TcpListener.java
@@ -12,6 +12,7 @@ import zmq.io.IOObject;
 import zmq.io.IOThread;
 import zmq.io.SessionBase;
 import zmq.io.StreamEngine;
+import zmq.io.net.Address.IZAddress;
 import zmq.io.net.StandardProtocolFamily;
 import zmq.poll.IPollEvents;
 import zmq.poll.Poller;
@@ -148,6 +149,11 @@ public class TcpListener extends Own implements IPollEvents
 
     public String getAddress()
     {
+        return address(address);
+    }
+
+    protected String address(IZAddress address)
+    {
         int port = fd.socket().getLocalPort();
         return address.toString(port);
     }
@@ -192,6 +198,8 @@ public class TcpListener extends Own implements IPollEvents
             //  Bind the socket to the network interface and port.
             // NB: fd.socket().bind(...) for Android environments
             fd.socket().bind(address.address(), options.backlog);
+            // find the address in case of wildcard
+            endpoint = getAddress();
         }
         catch (IOException e) {
             close();

--- a/src/main/java/zmq/util/Utils.java
+++ b/src/main/java/zmq/util/Utils.java
@@ -33,6 +33,33 @@ public class Utils
         return bytes;
     }
 
+    /**
+     * Finds a string whose hashcode is the number in input.
+     *
+     * @param port the port to find String hashcode-equivalent of. Has to be positive or 0.
+     * @return a String whose hashcode is the number in input.
+     */
+    public static String unhash(int port)
+    {
+        return unhash(new StringBuilder(), port, 'z').toString();
+    }
+
+    private static StringBuilder unhash(StringBuilder builder, int port, char boundary)
+    {
+        int div = port / 31;
+        int remainder = port % 31;
+        if (div <= boundary) {
+            if (div != 0) {
+                builder.append((char) div);
+            }
+        }
+        else {
+            unhash(builder, div, boundary);
+        }
+        builder.append((char) remainder);
+        return builder;
+    }
+
     public static int findOpenPort() throws IOException
     {
         final ServerSocket tmpSocket = new ServerSocket(0, 0);

--- a/src/test/java/zmq/TermEndpointIpcTest.java
+++ b/src/test/java/zmq/TermEndpointIpcTest.java
@@ -1,0 +1,19 @@
+package zmq;
+
+import java.io.IOException;
+import java.util.UUID;
+
+public class TermEndpointIpcTest extends TestTermEndpoint
+{
+    @Override
+    protected String endpointWildcard()
+    {
+        return "ipc://*";
+    }
+
+    @Override
+    protected String endpointNormal() throws IOException
+    {
+        return "ipc://" + UUID.randomUUID().toString();
+    }
+}

--- a/src/test/java/zmq/TestLastEndpoint.java
+++ b/src/test/java/zmq/TestLastEndpoint.java
@@ -6,7 +6,8 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
-import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.junit.Test;
 
@@ -38,14 +39,38 @@ public class TestLastEndpoint
 
         bindAndVerify(sb, "tcp://127.0.0.1:" + port1);
         bindAndVerify(sb, "tcp://127.0.0.1:" + port2);
-        bindAndVerify(sb, "ipc:///tmp/test-" + UUID.randomUUID().toString());
 
         sb.close();
         ctx.terminate();
     }
 
     @Test
-    public void testLastEndpointWildcard() throws IOException
+    public void testLastEndpointWildcardIpc() throws IOException
+    {
+        //  Create the infrastructure
+        Ctx ctx = ZMQ.init(1);
+        assertThat(ctx, notNullValue());
+
+        SocketBase socket = ZMQ.socket(ctx, ZMQ.ZMQ_ROUTER);
+        assertThat(socket, notNullValue());
+
+        boolean brc = ZMQ.bind(socket, "ipc://*");
+        assertThat(brc, is(true));
+
+        String stest = (String) ZMQ.getSocketOptionExt(socket, ZMQ.ZMQ_LAST_ENDPOINT);
+        assertThat(stest, is(not("ipc://*")));
+        assertThat(stest, is(not("ipc://localhost:0")));
+
+        Pattern pattern = Pattern.compile("ipc://.*", Pattern.DOTALL);
+        Matcher matcher = pattern.matcher(stest);
+        assertThat(stest, matcher.matches(), is(true));
+
+        socket.close();
+        ctx.terminate();
+    }
+
+    @Test
+    public void testLastEndpointWildcardTcp() throws IOException
     {
         //  Create the infrastructure
         Ctx ctx = ZMQ.init(1);

--- a/src/test/java/zmq/util/TestUtils.java
+++ b/src/test/java/zmq/util/TestUtils.java
@@ -1,6 +1,7 @@
 package zmq.util;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
@@ -8,6 +9,17 @@ import org.junit.Test;
 
 public class TestUtils
 {
+    @Test
+    public void testUnhash()
+    {
+        // theoretically up to 65535 but let's be greedy and waste 10 ms
+        for (int port = 0; port < 100_000; ++port) {
+            String hash = Utils.unhash(port);
+            assertThat(hash, notNullValue());
+            assertThat(hash.hashCode(), is(port));
+        }
+    }
+
     @Test
     public void testRealloc()
     {


### PR DESCRIPTION
Solution: implement wildcard binding for ipc and tcp protocol, using LAST_ENDPOINT to retrieve the dynamically allocated endpoint.