### PR TITLE
Fixed #577 - "ZMQException: Address already in use"

### DIFF
--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -2907,6 +2907,7 @@ public class ZMQ
             for (int i = 0; i < 100; i++) { // hardcoded to 100 tries. should this be parametrised
                 port = rand.nextInt(max - min + 1) + min;
                 if (base.bind(String.format("%s:%s", addr, port))) {
+                    base.errno.set(0);
                     return port;
                 }
                 //                port++;


### PR DESCRIPTION
The errno was set to 48 while trying to connect to a port in use. Additional usage of that socket causes an exception being raised if this errno is not set back to 0.