### PR TITLE
Race condition with received message causes ZMQ_CONNECT_RID to be assigned to wrong socket

### DIFF
--- a/src/main/java/zmq/SocketBase.java
+++ b/src/main/java/zmq/SocketBase.java
@@ -121,7 +121,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
 
     //  Concrete algorithms for the x- methods are to be defined by
     //  individual socket types.
-    protected abstract void xattachPipe(Pipe pipe, boolean subscribe2all);
+    protected abstract void xattachPipe(Pipe pipe, boolean subscribe2all, boolean isLocallyInitiated);
 
     protected abstract void xpipeTerminated(Pipe pipe);
 
@@ -190,12 +190,12 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
     }
 
     //  Register the pipe with this socket.
-    private void attachPipe(Pipe pipe)
+    private void attachPipe(Pipe pipe, boolean isLocallyInitiated)
     {
-        attachPipe(pipe, false);
+        attachPipe(pipe, false, isLocallyInitiated);
     }
 
-    private void attachPipe(Pipe pipe, boolean subscribe2all)
+    private void attachPipe(Pipe pipe, boolean subscribe2all, boolean isLocallyInitiated)
     {
         assert (pipe != null);
 
@@ -204,7 +204,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
         pipes.add(pipe);
 
         //  Let the derived socket type know about new pipe.
-        xattachPipe(pipe, subscribe2all);
+        xattachPipe(pipe, subscribe2all, isLocallyInitiated);
 
         //  If the socket is already being closed, ask any new pipes to terminate
         //  straight away.
@@ -466,7 +466,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
             Pipe[] pipes = Pipe.pair(parents, hwms, conflates);
 
             //  Attach local end of the pipe to this socket object.
-            attachPipe(pipes[0]);
+            attachPipe(pipes[0], true);
 
             if (peer.socket == null) {
                 //  The peer doesn't exist yet so we don't know whether
@@ -570,7 +570,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
             Pipe[] pipes = Pipe.pair(parents, hwms, conflates);
 
             //  Attach local end of the pipe to the socket object.
-            attachPipe(pipes[0], subscribe2all);
+            attachPipe(pipes[0], subscribe2all, true);
             newpipe = pipes[0];
             //  Attach remote end of the pipe to the session object later on.
             session.attachPipe(pipes[1]);
@@ -972,7 +972,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
     @Override
     protected final void processBind(Pipe pipe)
     {
-        attachPipe(pipe);
+        attachPipe(pipe, false);
     }
 
     @Override

--- a/src/main/java/zmq/socket/Pair.java
+++ b/src/main/java/zmq/socket/Pair.java
@@ -29,7 +29,7 @@ public class Pair extends SocketBase
     }
 
     @Override
-    protected void xattachPipe(Pipe pipe, boolean subscribe2all)
+    protected void xattachPipe(Pipe pipe, boolean subscribe2all, boolean isLocallyInitiated)
     {
         assert (pipe != null);
 

--- a/src/main/java/zmq/socket/Stream.java
+++ b/src/main/java/zmq/socket/Stream.java
@@ -76,11 +76,11 @@ public class Stream extends SocketBase
     }
 
     @Override
-    protected void xattachPipe(Pipe pipe, boolean icanhasall)
+    protected void xattachPipe(Pipe pipe, boolean icanhasall, boolean isLocallyInitiated)
     {
         assert (pipe != null);
 
-        identifyPeer(pipe);
+        identifyPeer(pipe, isLocallyInitiated);
         fq.attach(pipe);
     }
 
@@ -290,12 +290,12 @@ public class Stream extends SocketBase
         return true;
     }
 
-    private void identifyPeer(Pipe pipe)
+    private void identifyPeer(Pipe pipe, boolean isLocallyInitiated)
     {
         //  Always assign identity for raw-socket
 
         Blob identity;
-        if (connectRid != null && !connectRid.isEmpty()) {
+        if (connectRid != null && !connectRid.isEmpty() && isLocallyInitiated) {
             identity = Blob.createBlob(connectRid.getBytes(ZMQ.CHARSET));
             connectRid = null;
 

--- a/src/main/java/zmq/socket/pipeline/Pull.java
+++ b/src/main/java/zmq/socket/pipeline/Pull.java
@@ -22,7 +22,7 @@ public class Pull extends SocketBase
     }
 
     @Override
-    protected void xattachPipe(Pipe pipe, boolean subscribe2all)
+    protected void xattachPipe(Pipe pipe, boolean subscribe2all, boolean isLocallyInitiated)
     {
         assert (pipe != null);
         fq.attach(pipe);

--- a/src/main/java/zmq/socket/pipeline/Push.java
+++ b/src/main/java/zmq/socket/pipeline/Push.java
@@ -21,7 +21,7 @@ public class Push extends SocketBase
     }
 
     @Override
-    protected void xattachPipe(Pipe pipe, boolean subscribe2all)
+    protected void xattachPipe(Pipe pipe, boolean subscribe2all, boolean isLocallyInitiated)
     {
         assert (pipe != null);
 

--- a/src/main/java/zmq/socket/pubsub/Pub.java
+++ b/src/main/java/zmq/socket/pubsub/Pub.java
@@ -15,7 +15,7 @@ public class Pub extends XPub
     }
 
     @Override
-    protected void xattachPipe(Pipe pipe, boolean subscribeToAll)
+    protected void xattachPipe(Pipe pipe, boolean subscribeToAll, boolean isLocallyInitiated)
     {
         assert (pipe != null);
 
@@ -23,7 +23,7 @@ public class Pub extends XPub
         //  to receive the delimiter.
         pipe.setNoDelay();
 
-        super.xattachPipe(pipe, subscribeToAll);
+        super.xattachPipe(pipe, subscribeToAll, isLocallyInitiated);
     }
 
     @Override

--- a/src/main/java/zmq/socket/pubsub/XPub.java
+++ b/src/main/java/zmq/socket/pubsub/XPub.java
@@ -73,7 +73,7 @@ public class XPub extends SocketBase
     }
 
     @Override
-    protected void xattachPipe(Pipe pipe, boolean subscribeToAll)
+    protected void xattachPipe(Pipe pipe, boolean subscribeToAll, boolean isLocallyInitiated)
     {
         assert (pipe != null);
         dist.attach(pipe);

--- a/src/main/java/zmq/socket/pubsub/XSub.java
+++ b/src/main/java/zmq/socket/pubsub/XSub.java
@@ -61,7 +61,7 @@ public class XSub extends SocketBase
     }
 
     @Override
-    protected void xattachPipe(Pipe pipe, boolean subscribe2all)
+    protected void xattachPipe(Pipe pipe, boolean subscribe2all, boolean isLocallyInitiated)
     {
         assert (pipe != null);
         fq.attach(pipe);

--- a/src/main/java/zmq/socket/reqrep/Dealer.java
+++ b/src/main/java/zmq/socket/reqrep/Dealer.java
@@ -34,7 +34,7 @@ public class Dealer extends SocketBase
     }
 
     @Override
-    protected void xattachPipe(Pipe pipe, boolean subscribe2all)
+    protected void xattachPipe(Pipe pipe, boolean subscribe2all, boolean isLocallyInitiated)
     {
         assert (pipe != null);
 

--- a/src/main/java/zmq/socket/reqrep/Router.java
+++ b/src/main/java/zmq/socket/reqrep/Router.java
@@ -119,7 +119,7 @@ public class Router extends SocketBase
     }
 
     @Override
-    public void xattachPipe(Pipe pipe, boolean subscribe2all)
+    public void xattachPipe(Pipe pipe, boolean subscribe2all, boolean isLocallyInitiated)
     {
         assert (pipe != null);
 
@@ -129,7 +129,7 @@ public class Router extends SocketBase
             // assert (rc) is not applicable here, since it is not a bug.
             pipe.flush();
         }
-        boolean identityOk = identifyPeer(pipe);
+        boolean identityOk = identifyPeer(pipe, isLocallyInitiated);
         if (identityOk) {
             fq.attach(pipe);
         }
@@ -190,7 +190,7 @@ public class Router extends SocketBase
             fq.activated(pipe);
         }
         else {
-            boolean identityOk = identifyPeer(pipe);
+            boolean identityOk = identifyPeer(pipe, false);
             if (identityOk) {
                 anonymousPipes.remove(pipe);
                 fq.attach(pipe);
@@ -410,11 +410,11 @@ public class Router extends SocketBase
         return fq.getCredential();
     }
 
-    private boolean identifyPeer(Pipe pipe)
+    private boolean identifyPeer(Pipe pipe, boolean isLocallyInitiated)
     {
         Blob identity;
 
-        if (connectRid != null && !connectRid.isEmpty()) {
+        if (connectRid != null && !connectRid.isEmpty() && isLocallyInitiated) {
             identity = Blob.createBlob(connectRid.getBytes(ZMQ.CHARSET));
             connectRid = null;
             Outpipe outpipe = outpipes.get(identity);

--- a/src/test/java/zmq/ConnectRidTest.java
+++ b/src/test/java/zmq/ConnectRidTest.java
@@ -2,6 +2,7 @@ package zmq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
@@ -180,6 +181,98 @@ public class ConnectRidTest
 
         ZMQ.close(bind);
         ZMQ.close(connect);
+
+        ZMQ.term(ctx);
+    }
+
+    @Test
+    public void testRouter2routerWhileReceiving() throws IOException, InterruptedException
+    {
+        System.out.println("Test Router 2 router while receiving");
+        String wildcardAddress = "tcp://localhost:*";
+
+        Msg msg = new Msg("hi 1".getBytes(ZMQ.CHARSET));
+
+        Ctx ctx = ZMQ.init(1);
+        assert (ctx != null);
+
+        //  Set up the router which both binds and connects
+        SocketBase x = ZMQ.socket(ctx, ZMQ.ZMQ_ROUTER);
+        assert (x != null);
+
+        ZMQ.setSocketOption(x, ZMQ.ZMQ_LINGER, 0);
+        ZMQ.setSocketOption(x, ZMQ.ZMQ_IDENTITY, "X");
+
+        boolean rc = ZMQ.bind(x, wildcardAddress);
+        assert (rc);
+
+        String xaddress = (String) ZMQ.getSocketOptionExt(x, ZMQ.ZMQ_LAST_ENDPOINT);
+        assertThat(xaddress, notNullValue());
+
+        //  Set up the router which binds
+        SocketBase z = ZMQ.socket(ctx, ZMQ.ZMQ_ROUTER);
+        assert (z != null);
+
+        ZMQ.setSocketOption(z, ZMQ.ZMQ_LINGER, 0);
+        ZMQ.setSocketOption(z, ZMQ.ZMQ_IDENTITY, "Z");
+
+        rc = ZMQ.bind(z, wildcardAddress);
+        assert (rc);
+
+        String zaddress = (String) ZMQ.getSocketOptionExt(z, ZMQ.ZMQ_LAST_ENDPOINT);
+        assertThat(zaddress, notNullValue());
+
+        //  Set up connect-only router.
+        SocketBase y = ZMQ.socket(ctx, ZMQ.ZMQ_ROUTER);
+        assert (y != null);
+
+        ZMQ.setSocketOption(y, ZMQ.ZMQ_LINGER, 0);
+        ZMQ.setSocketOption(y, ZMQ.ZMQ_IDENTITY, "Y");
+
+        //  Do the connection.
+        rc = ZMQ.connect(y, xaddress);
+        assert (rc);
+
+        //  Send data from Y to X
+        int ret = ZMQ.send(y, "X", ZMQ.ZMQ_SNDMORE);
+        assertThat(ret, is(1));
+        ret = ZMQ.send(y, msg, 0);
+        assertThat(ret, is(4));
+
+        // wait for the messages to be processed on the io thread
+        ZMQ.msleep(100);
+
+        // try to connect X to Z
+        ZMQ.setSocketOption(x, ZMQ.ZMQ_CONNECT_RID, "Z");
+        rc = ZMQ.connect(x, zaddress);
+        assert (rc);
+
+        //  Send data from X to Z
+        ret = ZMQ.send(x, "Z", ZMQ.ZMQ_SNDMORE);
+        assertThat(ret, is(1));
+        ret = ZMQ.send(x, msg, 0);
+        assertThat(ret, is(4));
+
+        // wait for the messages to be delivered
+        ZMQ.msleep(100);
+
+        // Make sure that Y has not received any messages
+        Msg name = ZMQ.recv(y, ZMQ.ZMQ_DONTWAIT);
+        assertThat(name, nullValue());
+
+        //  Receive the message from Z
+        name = ZMQ.recv(z, 0);
+        assertThat(name, notNullValue());
+        assertThat(name.data()[0], is((byte) 'X'));
+
+        Msg recv = null;
+        recv = ZMQ.recv(z, 0);
+        assertThat(recv, notNullValue());
+        assertThat(recv.data()[0], is((byte) 'h'));
+
+        ZMQ.close(x);
+        ZMQ.close(y);
+        ZMQ.close(z);
 
         ZMQ.term(ctx);
     }

--- a/src/test/java/zmq/Helper.java
+++ b/src/test/java/zmq/Helper.java
@@ -96,7 +96,7 @@ public class Helper
         }
 
         @Override
-        protected void xattachPipe(Pipe pipe, boolean icanhasall)
+        protected void xattachPipe(Pipe pipe, boolean icanhasall, boolean isLocallyInitiated)
         {
         }
 


### PR DESCRIPTION
Due to a race condition between receiving connections on the io thread and the call to socket.connect(), ZMQ_CONNECT_RID can be assigned to the wrong peer socket.

I recently fixed the same bug in the [libzmq](https://github.com/zeromq/libzmq/issues/3191) implementation. You can see more details there.