### PR TITLE
Problem: pending connections are unique per address. (fixes #595)

### DIFF
--- a/src/test/java/org/zeromq/TestZContext.java
+++ b/src/test/java/org/zeromq/TestZContext.java
@@ -9,7 +9,6 @@ import org.zeromq.ZMQ.Socket;
 
 public class TestZContext
 {
-    @SuppressWarnings("deprecation")
     @Test
     public void testZContext()
     {
@@ -133,5 +132,23 @@ public class TestZContext
 
         shadowCtx.close();
         ctx.close();
+    }
+
+    @Test
+    public void testSeveralPendingInprocSocketsAreClosedIssue595()
+    {
+        ZContext ctx = new ZContext();
+
+        for (SocketType type : SocketType.values()) {
+            for (int idx = 0; idx < 3; ++idx) {
+                Socket socket = ctx.createSocket(type);
+                assertThat(socket, notNullValue());
+                boolean rc = socket.connect("inproc://" + type.name());
+                assertThat(rc, is(true));
+            }
+        }
+        ctx.close();
+
+        assertThat(ctx.isClosed(), is(true));
     }
 }

--- a/src/test/java/zmq/CtxTest.java
+++ b/src/test/java/zmq/CtxTest.java
@@ -1,0 +1,38 @@
+package zmq;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import zmq.socket.Sockets;
+
+public class CtxTest
+{
+    @Test
+    public void testSeveralPendingInprocSocketsAreClosedIssue595()
+    {
+        Ctx ctx = ZMQ.init(0);
+        assertThat(ctx, notNullValue());
+
+        List<SocketBase> sockets = new ArrayList<>();
+        for (Sockets type : Sockets.values()) {
+            for (int idx = 0; idx < 3; ++idx) {
+                SocketBase socket = ZMQ.socket(ctx, type.ordinal());
+                assertThat(socket, notNullValue());
+
+                boolean rc = socket.connect("inproc://" + type.name());
+                assertThat(rc, is(true));
+                sockets.add(socket);
+            }
+        }
+        sockets.stream().forEach(ZMQ::close);
+        ZMQ.term(ctx);
+
+        assertThat(ctx.checkTag(), is(false));
+    }
+}


### PR DESCRIPTION
If a second socket connects on the same address, the first one is lost
and cannot be closed thereafter.

Solution: use a MultiMap to store collection of pending connections per address