### PR TITLE
Simplify the method restartInput() in the class StreamEngine

### DIFF
--- a/src/main/java/zmq/io/StreamEngine.java
+++ b/src/main/java/zmq/io/StreamEngine.java
@@ -572,9 +572,6 @@ public class StreamEngine implements IEngine, IPollEvents
             }
             msg = decoder.msg();
             rc = processMsg.apply(msg);
-            if (!rc) {
-                break;
-            }
         }
         if (!rc && errno.is(ZError.EAGAIN)) {
             session.flush();

--- a/src/main/java/zmq/io/StreamEngine.java
+++ b/src/main/java/zmq/io/StreamEngine.java
@@ -575,7 +575,8 @@ public class StreamEngine implements IEngine, IPollEvents
         }
     }
 
-    private boolean decodeInputsGetRC() {
+    private boolean decodeInputsGetRC()
+    {
         boolean rc = true;
         while (insize > 0 && rc) {
             ValueReference<Integer> processed = new ValueReference<>(0);

--- a/src/main/java/zmq/io/StreamEngine.java
+++ b/src/main/java/zmq/io/StreamEngine.java
@@ -546,8 +546,7 @@ public class StreamEngine implements IEngine, IPollEvents
         assert (decoder != null);
 
         Msg msg = decoder.msg();
-        boolean rc = processMsg.apply(msg);
-        if (!rc) {
+        if (!processMsg.apply(msg)) {
             if (errno.is(ZError.EAGAIN)) {
                 session.flush();
             }
@@ -556,7 +555,7 @@ public class StreamEngine implements IEngine, IPollEvents
             }
             return;
         }
-        // rc is true at this point
+        boolean rc = true;
         while (insize > 0 && rc) {
             ValueReference<Integer> processed = new ValueReference<>(0);
             Step.Result result = decoder.decode(inpos, insize, processed);

--- a/src/main/java/zmq/io/StreamEngine.java
+++ b/src/main/java/zmq/io/StreamEngine.java
@@ -576,7 +576,6 @@ public class StreamEngine implements IEngine, IPollEvents
     }
 
     private boolean decodeInputsGetRC() {
-        Msg msg;
         boolean rc = true;
         while (insize > 0 && rc) {
             ValueReference<Integer> processed = new ValueReference<>(0);
@@ -591,8 +590,7 @@ public class StreamEngine implements IEngine, IPollEvents
                 rc = false;
                 break;
             }
-            msg = decoder.msg();
-            rc = processMsg.apply(msg);
+            rc = processMsg.apply(decoder.msg());
         }
         return rc;
     }

--- a/src/main/java/zmq/io/StreamEngine.java
+++ b/src/main/java/zmq/io/StreamEngine.java
@@ -545,9 +545,8 @@ public class StreamEngine implements IEngine, IPollEvents
         assert (session != null);
         assert (decoder != null);
 
-        boolean rc;
         Msg msg = decoder.msg();
-        rc = processMsg.apply(msg);
+        boolean rc = processMsg.apply(msg);
         if (!rc) {
             if (errno.is(ZError.EAGAIN)) {
                 session.flush();
@@ -557,8 +556,8 @@ public class StreamEngine implements IEngine, IPollEvents
             }
             return;
         }
-
-        while (insize > 0) {
+        // rc is true at this point
+        while (insize > 0 && rc) {
             ValueReference<Integer> processed = new ValueReference<>(0);
             Step.Result result = decoder.decode(inpos, insize, processed);
             assert (processed.get() <= insize);

--- a/src/main/java/zmq/io/StreamEngine.java
+++ b/src/main/java/zmq/io/StreamEngine.java
@@ -555,14 +555,14 @@ public class StreamEngine implements IEngine, IPollEvents
             }
             return;
         }
-        boolean rc = decodeInputsGetRC();
-        if (!rc && errno.is(ZError.EAGAIN)) {
+        boolean decodingSuccess = decodeCurrentInputs();
+        if (!decodingSuccess && errno.is(ZError.EAGAIN)) {
             session.flush();
         }
         else if (ioError) {
             error(ErrorReason.CONNECTION);
         }
-        else if (!rc) {
+        else if (!decodingSuccess) {
             error(ErrorReason.PROTOCOL);
         }
         else {
@@ -575,7 +575,7 @@ public class StreamEngine implements IEngine, IPollEvents
         }
     }
 
-    private boolean decodeInputsGetRC()
+    private boolean decodeCurrentInputs()
     {
         while (insize > 0) {
             ValueReference<Integer> processed = new ValueReference<>(0);

--- a/src/main/java/zmq/io/StreamEngine.java
+++ b/src/main/java/zmq/io/StreamEngine.java
@@ -583,12 +583,10 @@ public class StreamEngine implements IEngine, IPollEvents
             assert (processed.get() <= insize);
             insize -= processed.get();
             if (result == Step.Result.MORE_DATA) {
-                rc = true;
-                break;
+                return true;
             }
             if (result == Step.Result.ERROR) {
-                rc = false;
-                break;
+                return false;
             }
             rc = processMsg.apply(decoder.msg());
         }

--- a/src/main/java/zmq/io/StreamEngine.java
+++ b/src/main/java/zmq/io/StreamEngine.java
@@ -577,8 +577,7 @@ public class StreamEngine implements IEngine, IPollEvents
 
     private boolean decodeInputsGetRC()
     {
-        boolean rc = true;
-        while (insize > 0 && rc) {
+        while (insize > 0) {
             ValueReference<Integer> processed = new ValueReference<>(0);
             Step.Result result = decoder.decode(inpos, insize, processed);
             assert (processed.get() <= insize);
@@ -589,9 +588,11 @@ public class StreamEngine implements IEngine, IPollEvents
             if (result == Step.Result.ERROR) {
                 return false;
             }
-            rc = processMsg.apply(decoder.msg());
+            if (!processMsg.apply(decoder.msg())) {
+                return false;
+            }
         }
-        return rc;
+        return true;
     }
 
     //  Detects the protocol used by the peer.


### PR DESCRIPTION
Problem: the method `StreamEngine::restartInput(). issue #604

Solution:: Simplify the method - 
by inlining temp variables and extracting another decoding helper method.

I work on semi-automatic refactoring pull requests.
If you think this project will benefit from refactoring PRs, please click the link below.
[![Yes - I want a refactoring service](http://box2110.temp.domains/~refacto3/wp-content/uploads/2018/09/yes-e1537456577294.jpeg)](http://box2110.temp.domains/~refacto3/refactoring-pull-requests-yes/)
If this PR annoys you, please click on the link below, so I will stop doing it in other repos as well
[![No please - it annoys me](http://box2110.temp.domains/~refacto3/wp-content/uploads/2018/09/no-e1537456561421.jpeg)](http://box2110.temp.domains/~refacto3/free-refactoring-pull-requests-service-no/)
Assaf
