### PR TITLE
A SelectorProvider

### DIFF
--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -18,6 +18,7 @@ import zmq.ZError.CtxTerminatedException;
 import zmq.io.coder.IDecoder;
 import zmq.io.coder.IEncoder;
 import zmq.io.mechanism.Mechanisms;
+import zmq.io.net.SelectorProviderChooser;
 import zmq.msg.MsgAllocator;
 import zmq.util.Draft;
 import zmq.util.Z85;
@@ -2141,6 +2142,27 @@ public class ZMQ
         public boolean setMsgAllocator(MsgAllocator allocator)
         {
             return setSocketOpt(zmq.ZMQ.ZMQ_MSG_ALLOCATOR, allocator);
+        }
+
+        /**
+         * Set a custom {@link java.nio.channels.spi.SelectorProvider} chooser.
+         *
+         * @param chooser, the custom chooser.
+         * @return true if the option was set, otherwise false.
+         */
+        public boolean setSelectorChooser(SelectorProviderChooser chooser)
+        {
+            return base.setSocketOpt(zmq.ZMQ.ZMQ_SELECTOR_PROVIDERCHOOSER, chooser);
+        }
+
+        /**
+         * Return the custom {@link java.nio.channels.spi.SelectorProvider} chooser.
+         *
+         * @return the {@link java.nio.channels.spi.SelectorProvider} chooser.
+         */
+        public SelectorProviderChooser getSelectorProviderChooser()
+        {
+            return (SelectorProviderChooser) base.getSocketOptx(zmq.ZMQ.ZMQ_SELECTOR_PROVIDERCHOOSER);
         }
 
         /**

--- a/src/main/java/zmq/ZMQ.java
+++ b/src/main/java/zmq/ZMQ.java
@@ -136,6 +136,7 @@ public class ZMQ
     public static final int ZMQ_MSG_ALLOCATOR                 = ZMQ_CUSTOM_OPTION + 3;
     public static final int ZMQ_MSG_ALLOCATION_HEAP_THRESHOLD = ZMQ_CUSTOM_OPTION + 4;
     public static final int ZMQ_HEARTBEAT_CONTEXT             = ZMQ_CUSTOM_OPTION + 5;
+    public static final int ZMQ_SELECTOR_PROVIDERCHOOSER      = ZMQ_CUSTOM_OPTION + 6;
 
     /*  Message options                                                           */
     public static final int ZMQ_MORE = 1;

--- a/src/main/java/zmq/io/net/SelectorProviderChooser.java
+++ b/src/main/java/zmq/io/net/SelectorProviderChooser.java
@@ -1,0 +1,17 @@
+package zmq.io.net;
+
+import java.nio.channels.spi.SelectorProvider;
+
+import zmq.Options;
+
+/**
+ * By implementing this class, it's possible to change the kind of channel used in tcp connections.<p>
+ * It allows to easily wrap ZMQ socket in custom socket for TLS protection or other kind of trick.
+ *
+ * @author Fabrice Bacchella
+ *
+ */
+public interface SelectorProviderChooser
+{
+    public SelectorProvider choose(Address.IZAddress addr, Options options);
+}

--- a/src/main/java/zmq/io/net/tcp/TcpConnecter.java
+++ b/src/main/java/zmq/io/net/tcp/TcpConnecter.java
@@ -265,6 +265,12 @@ public class TcpConnecter extends Own implements IPollEvents
 
         //  Create the socket.
         fd = SocketChannel.open();
+        if (options.selectorChooser == null) {
+            fd = SocketChannel.open();
+        }
+        else {
+            fd = options.selectorChooser.choose(resolved, options).openSocketChannel();
+        }
 
         //  IPv6 address family not supported, try automatic downgrade to IPv4.
         if (fd == null && resolved.family() == StandardProtocolFamily.INET6 && options.ipv6) {

--- a/src/main/java/zmq/io/net/tcp/TcpListener.java
+++ b/src/main/java/zmq/io/net/tcp/TcpListener.java
@@ -167,7 +167,12 @@ public class TcpListener extends Own implements IPollEvents
 
         //  Create a listening socket.
         try {
-            fd = ServerSocketChannel.open();
+            if (options.selectorChooser == null) {
+                fd = ServerSocketChannel.open();
+            }
+            else {
+                fd = options.selectorChooser.choose(address, options).openServerSocketChannel();
+            }
 
             //  IPv6 address family not supported, try automatic downgrade to IPv4.
             if (fd == null && address.family() == StandardProtocolFamily.INET6 && options.ipv6) {

--- a/src/test/java/org/zeromq/SelectorProviderTest.java
+++ b/src/test/java/org/zeromq/SelectorProviderTest.java
@@ -1,0 +1,54 @@
+package org.zeromq;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.nio.channels.spi.SelectorProvider;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+import org.zeromq.ZMQ.Socket;
+
+import zmq.Options;
+import zmq.io.net.Address.IZAddress;
+import zmq.io.net.SelectorProviderChooser;
+import zmq.util.Utils;
+
+public class SelectorProviderTest
+{
+    public static class DefaultSelectorProviderChooser implements SelectorProviderChooser
+    {
+        public AtomicInteger choosen = new AtomicInteger(0);
+        @Override
+        public SelectorProvider choose(IZAddress addr, Options options)
+        {
+            choosen.addAndGet(1);
+            return SelectorProvider.provider();
+        }
+    }
+
+    @Test
+    public void test() throws IOException
+    {
+        int port = Utils.findOpenPort();
+
+        try (
+             ZContext ctx = new ZContext();
+             Socket pull = ctx.createSocket(SocketType.PULL);
+             Socket push = ctx.createSocket(SocketType.PUSH);) {
+            DefaultSelectorProviderChooser chooser = new DefaultSelectorProviderChooser();
+            pull.setSelectorChooser(chooser);
+            push.setSelectorChooser(chooser);
+            pull.bind("tcp://*:" + port);
+            push.connect("tcp://127.0.0.1:" + port);
+
+            String expected = "hello";
+            push.send(expected);
+            String actual = new String(pull.recv());
+
+            assertEquals(expected, actual);
+            // Ensure that the choose method was indeed called for each socket.
+            assertEquals(2, chooser.choosen.get());
+        }
+    }
+}

--- a/src/test/java/zmq/OptionsTest.java
+++ b/src/test/java/zmq/OptionsTest.java
@@ -8,10 +8,16 @@ import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.zeromq.SocketType;
+import org.zeromq.ZContext;
+import org.zeromq.SelectorProviderTest.DefaultSelectorProviderChooser;
+import org.zeromq.ZMQ.Socket;
 
 import zmq.io.mechanism.Mechanisms;
+import zmq.io.net.SelectorProviderChooser;
 import zmq.msg.MsgAllocatorDirect;
 import zmq.msg.MsgAllocatorThreshold;
 
@@ -237,6 +243,50 @@ public class OptionsTest
     }
 
     @Test
+    public void testSelectorObject()
+    {
+        try (ZContext ctx = new ZContext();
+             Socket socket = ctx.createSocket(SocketType.PUB);
+            ) {
+            SelectorProviderChooser chooser = new DefaultSelectorProviderChooser();
+            socket.setSelectorChooser(chooser);
+            Assert.assertEquals(chooser, socket.getSelectorProviderChooser());
+        }
+    }
+
+    @Test
+    public void testSelectorClass()
+    {
+        Options opt = new Options();
+        Class<DefaultSelectorProviderChooser> chooser = DefaultSelectorProviderChooser.class;
+        opt.setSocketOpt(ZMQ.ZMQ_SELECTOR_PROVIDERCHOOSER, chooser);
+        Assert.assertTrue(opt.getSocketOpt(ZMQ.ZMQ_SELECTOR_PROVIDERCHOOSER) instanceof SelectorProviderChooser);
+    }
+
+    @Test
+    public void testSelectorClassName()
+    {
+        Options opt = new Options();
+        Class<DefaultSelectorProviderChooser> chooser = DefaultSelectorProviderChooser.class;
+        opt.setSocketOpt(ZMQ.ZMQ_SELECTOR_PROVIDERCHOOSER, chooser.getName());
+        Assert.assertTrue(opt.getSocketOpt(ZMQ.ZMQ_SELECTOR_PROVIDERCHOOSER) instanceof SelectorProviderChooser);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSelectorClassNameFailed()
+    {
+        Options opt = new Options();
+        opt.setSocketOpt(ZMQ.ZMQ_SELECTOR_PROVIDERCHOOSER, String.class.getName());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSelectorFailed()
+    {
+        Options opt = new Options();
+        Assert.assertFalse(opt.setSocketOpt(ZMQ.ZMQ_SELECTOR_PROVIDERCHOOSER, ""));
+    }
+
+    @Test
     public void testDefaultValue()
     {
         //        assertThat(options.getSocketOpt(ZMQ.ZMQ_DECODER), is((Object)options.decoder));
@@ -278,5 +328,6 @@ public class OptionsTest
         assertThat(options.getSocketOpt(ZMQ.ZMQ_HEARTBEAT_IVL), is((Object) options.heartbeatInterval));
         assertThat(options.getSocketOpt(ZMQ.ZMQ_HEARTBEAT_TIMEOUT), is((Object) options.heartbeatTimeout));
         assertThat(options.getSocketOpt(ZMQ.ZMQ_HEARTBEAT_TTL), is((Object) options.heartbeatTtl));
+        assertThat(options.getSocketOpt(ZMQ.ZMQ_SELECTOR_PROVIDERCHOOSER), nullValue());
     }
 }


### PR DESCRIPTION
I added a way to define custom SelectorProvider (https://docs.oracle.com/javase/8/docs/api/java/nio/channels/spi/SelectorProvider.html). It should allow to wrap socket with custom code, like flow compression or TLS, using for example https://github.com/marianobarrios/tls-channel.
Any feedback is welcome.