### PR TITLE
Remove incorrect release date from unreleased version in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.5.0 (2018-10-27)
+## v0.5.0 (unreleased)
 
 ### Added
 


### PR DESCRIPTION
The changelog says that v0.5.0 was released 2018-10-27, but it actually hasn't been released yet. This PR updates the changelog to reflect that.