### PR TITLE
Fault injection test demonstrating infinite loop in iopoller thread

### DIFF
--- a/src/main/java/org/zeromq/ZPoller.java
+++ b/src/main/java/org/zeromq/ZPoller.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.zeromq.ZMQ.Poller;
 import org.zeromq.ZMQ.Socket;
@@ -489,11 +490,7 @@ public class ZPoller implements Closeable
     protected int poll(final long timeout, final boolean dispatchEvents)
     {
         // get all the raw items
-        final Collection<ItemHolder> all = items();
-        final Set<zmq.poll.PollItem> pollItems = new HashSet<>(all.size());
-        for (ItemHolder holder : all) {
-            pollItems.add(holder.item());
-        }
+        final Set<zmq.poll.PollItem> pollItems = all.stream().map(ItemHolder::item).collect(Collectors.toSet());
         // polling time
         final int rc = poll(selector, timeout, pollItems);
 
@@ -802,11 +799,7 @@ public class ZPoller implements Closeable
         }
         assert (socketOrChannel != null);
 
-        Set<ItemHolder> holders = items.get(socketOrChannel);
-        if (holders == null) {
-            holders = createContainer(1);
-            items.put(socketOrChannel, holders);
-        }
+        Set<ItemHolder> holders = items.computeIfAbsent(socketOrChannel, i -> createContainer(1));
         final boolean rc = holders.add(holder);
         if (rc) {
             all.add(holder);

--- a/src/main/java/zmq/Signaler.java
+++ b/src/main/java/zmq/Signaler.java
@@ -9,7 +9,7 @@ import java.nio.channels.Pipe;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import zmq.util.Errno;
 import zmq.util.Utils;
@@ -28,8 +28,8 @@ final class Signaler implements Closeable
     private final ByteBuffer         rdummy = ByteBuffer.allocate(1);
 
     // Selector.selectNow at every sending message doesn't show enough performance
-    private final AtomicInteger wcursor = new AtomicInteger(0);
-    private int                 rcursor = 0;
+    private final AtomicLong wcursor = new AtomicLong(0);
+    private long             rcursor = 0;
 
     private final Errno errno;
     private final int   pid;

--- a/src/main/java/zmq/Signaler.java
+++ b/src/main/java/zmq/Signaler.java
@@ -98,7 +98,6 @@ final class Signaler implements Closeable
                 nbytes = w.write(wdummy);
             }
             catch (IOException e) {
-                e.printStackTrace();
                 throw new ZError.IOException(e);
             }
             if (nbytes == 0) {

--- a/src/main/java/zmq/SocketBase.java
+++ b/src/main/java/zmq/SocketBase.java
@@ -314,6 +314,8 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
             return false;
         }
 
+        options.mechanism.check(options);
+
         //  Process pending commands, if any.
         boolean brc = processCommands(0, false);
         if (!brc) {
@@ -415,6 +417,8 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
             errno.set(ZError.ETERM);
             return false;
         }
+
+        options.mechanism.check(options);
 
         //  Process pending commands, if any.
         boolean brc = processCommands(0, false);

--- a/src/main/java/zmq/io/mechanism/Mechanism.java
+++ b/src/main/java/zmq/io/mechanism/Mechanism.java
@@ -285,8 +285,6 @@ public abstract class Mechanism
                 return session.errno.get();
             }
             if ((msg.flags() & Msg.MORE) == (idx < 6 ? 0 : Msg.MORE)) {
-                //  Temporary support for security debugging
-                puts("NULL I: ZAP handler sent incomplete reply message " + msg);
                 return ZError.EPROTO;
             }
             msgs.add(msg);
@@ -294,29 +292,21 @@ public abstract class Mechanism
 
         //  Address delimiter frame
         if (msgs.get(0).size() > 0) {
-            //  Temporary support for security debugging
-            puts("NULL I: ZAP handler sent malformed reply message in address delimiter frame " + msgs.get(0));
             return ZError.EPROTO;
         }
 
         //  Version frame
         if (msgs.get(1).size() != 3 || !compare(msgs.get(1), "1.0", false)) {
-            //  Temporary support for security debugging
-            puts("NULL I: ZAP handler sent bad version number " + msgs.get(1));
             return ZError.EPROTO;
         }
 
         //  Request id frame
         if (msgs.get(2).size() != 1 || !compare(msgs.get(2), "1", false)) {
-            //  Temporary support for security debugging
-            puts("NULL I: ZAP handler sent bad request ID " + msgs.get(2));
             return ZError.EPROTO;
         }
 
         //  Status code frame
         if (msgs.get(3).size() != 3) {
-            //  Temporary support for security debugging
-            puts("NULL I: ZAP handler rejected client authentication " + msgs.get(3));
             return ZError.EPROTO;
         }
 
@@ -329,12 +319,6 @@ public abstract class Mechanism
         //  Process metadata frame
 
         return parseMetadata(msgs.get(6), 0, true);
-    }
-
-    protected final void puts(String msg)
-    {
-        //  Temporary support for security debugging
-        System.out.println(session + " " + msg);
     }
 
     protected final void appendData(Msg msg, String data)

--- a/src/main/java/zmq/io/mechanism/NullMechanism.java
+++ b/src/main/java/zmq/io/mechanism/NullMechanism.java
@@ -87,7 +87,6 @@ class NullMechanism extends Mechanism
     public int processHandshakeCommand(Msg msg)
     {
         if (readyCommandReceived || errorCommandReceived) {
-            puts("NULL I: client sent invalid NULL handshake (duplicate READY)");
             return ZError.EPROTO;
         }
         int dataSize = msg.size();
@@ -100,7 +99,6 @@ class NullMechanism extends Mechanism
             rc = processErrorCommand(msg);
         }
         else {
-            puts("NULL I: client sent invalid NULL handshake (not READY) ");
             return ZError.EPROTO;
         }
         return rc;

--- a/src/main/java/zmq/io/mechanism/curve/CurveClientMechanism.java
+++ b/src/main/java/zmq/io/mechanism/curve/CurveClientMechanism.java
@@ -163,15 +163,11 @@ public class CurveClientMechanism extends Mechanism
         assert (state == State.CONNECTED);
 
         if (msg.size() < 33) {
-            //  Temporary support for security debugging
-            puts("CURVE I: invalid CURVE server, sent malformed command");
             errno.set(ZError.EPROTO);
             return null;
         }
 
         if (!compare(msg, "MESSAGE", true)) {
-            //  Temporary support for security debugging
-            puts("CURVE I: invalid CURVE server, did not send MESSAGE");
             errno.set(ZError.EPROTO);
             return null;
         }
@@ -210,8 +206,6 @@ public class CurveClientMechanism extends Mechanism
             return decoded;
         }
         else {
-            //  Temporary support for security debugging
-            puts("CURVE I: connection key used for MESSAGE is wrong");
             errno.set(ZError.EPROTO);
             return null;
         }
@@ -274,8 +268,6 @@ public class CurveClientMechanism extends Mechanism
     private int processWelcome(Msg msg)
     {
         if (msg.size() != 168) {
-            //  Temporary support for security debugging
-            puts("CURVE I: server HELLO is not correct size");
             return ZError.EPROTO;
         }
 

--- a/src/main/java/zmq/io/mechanism/curve/CurveServerMechanism.java
+++ b/src/main/java/zmq/io/mechanism/curve/CurveServerMechanism.java
@@ -115,8 +115,6 @@ public class CurveServerMechanism extends Mechanism
             rc = processInitiate(msg);
             break;
         default:
-            //  Temporary support for security debugging
-            puts("CURVE I: invalid handshake command");
             rc = ZError.EPROTO;
             break;
 
@@ -165,15 +163,11 @@ public class CurveServerMechanism extends Mechanism
         assert (state == State.CONNECTED);
 
         if (msg.size() < 33) {
-            //  Temporary support for security debugging
-            puts("CURVE I: invalid CURVE client, sent malformed command");
             errno.set(ZError.EPROTO);
             return null;
         }
 
         if (!compare(msg, "MESSAGE", true)) {
-            //  Temporary support for security debugging
-            puts("CURVE I: invalid CURVE client, did not send MESSAGE");
             errno.set(ZError.EPROTO);
             return null;
         }
@@ -212,8 +206,6 @@ public class CurveServerMechanism extends Mechanism
             return decoded;
         }
         else {
-            //  Temporary support for security debugging
-            puts("CURVE I: connection key used for MESSAGE is wrong");
             errno.set(ZError.EPROTO);
             return null;
         }
@@ -250,14 +242,10 @@ public class CurveServerMechanism extends Mechanism
     private int processHello(Msg msg)
     {
         if (msg.size() != 200) {
-            //  Temporary support for security debugging
-            puts("CURVE I: client HELLO is not correct size");
             return ZError.EPROTO;
         }
 
         if (!compare(msg, "HELLO", true)) {
-            //  Temporary support for security debugging
-            puts("CURVE I: client HELLO has invalid command name");
             return ZError.EPROTO;
         }
 
@@ -265,8 +253,6 @@ public class CurveServerMechanism extends Mechanism
         byte minor = msg.get(7);
 
         if (major != 1 || minor != 0) {
-            //  Temporary support for security debugging
-            puts("CURVE I: client HELLO has unknown version number");
             return ZError.EPROTO;
         }
 
@@ -287,8 +273,6 @@ public class CurveServerMechanism extends Mechanism
         //  Open Box [64 * %x0](C'->S)
         int rc = cryptoBox.open(helloPlaintext, helloBox, helloBox.capacity(), helloNonce, cnClient, secretKey);
         if (rc != 0) {
-            //  Temporary support for security debugging
-            puts("CURVE I: cannot open client HELLO -- wrong server key?");
             return ZError.EPROTO;
         }
 
@@ -358,14 +342,10 @@ public class CurveServerMechanism extends Mechanism
     private int processInitiate(Msg msg)
     {
         if (msg.size() < 257) {
-            //  Temporary support for security debugging
-            puts("CURVE I: client INITIATE is not correct size");
             return ZError.EPROTO;
         }
 
         if (!compare(msg, "INITIATE", true)) {
-            //  Temporary support for security debugging
-            puts("CURVE I: client INITIATE has invalid command name");
             return ZError.EPROTO;
         }
         ByteBuffer cookieNonce = ByteBuffer.allocate(Curve.Size.NONCE.bytes());
@@ -381,16 +361,12 @@ public class CurveServerMechanism extends Mechanism
 
         int rc = cryptoBox.secretboxOpen(cookiePlaintext, cookieBox, cookieBox.capacity(), cookieNonce, cookieKey);
         if (rc != 0) {
-            //  Temporary support for security debugging
-            puts("CURVE I: cannot open client INITIATE cookie");
             return ZError.EPROTO;
         }
 
         //  Check cookie plain text is as expected [C' + s']
         if (!compare(cookiePlaintext, cnClient, Curve.Size.ZERO.bytes(), 32)
                 || !compare(cookiePlaintext, cnSecret, Curve.Size.ZERO.bytes() + 32, 32)) {
-            //  Temporary support for security debugging
-            puts("CURVE I: client INITIATE cookie is not valid");
             return ZError.EPROTO;
         }
 
@@ -411,8 +387,6 @@ public class CurveServerMechanism extends Mechanism
 
         rc = cryptoBox.open(initiatePlaintext, initiateBox, clen, initiateNonce, cnClient, cnSecret);
         if (rc != 0) {
-            //  Temporary support for security debugging
-            puts("CURVE I: cannot open client INITIATE");
             return ZError.EPROTO;
         }
 
@@ -435,15 +409,11 @@ public class CurveServerMechanism extends Mechanism
 
         rc = cryptoBox.open(vouchPlaintext, vouchBox, vouchBox.capacity(), vouchNonce, clientKey, cnSecret);
         if (rc != 0) {
-            //  Temporary support for security debugging
-            puts("CURVE I: cannot open client INITIATE vouch");
             return ZError.EPROTO;
         }
 
         //  What we decrypted must be the client's short-term public key
         if (!compare(vouchPlaintext, cnClient, Curve.Size.ZERO.bytes(), 32)) {
-            //  Temporary support for security debugging
-            puts("CURVE I: invalid handshake from client (public key)");
             return ZError.EPROTO;
         }
 

--- a/src/main/java/zmq/io/mechanism/plain/PlainServerMechanism.java
+++ b/src/main/java/zmq/io/mechanism/plain/PlainServerMechanism.java
@@ -77,8 +77,6 @@ public class PlainServerMechanism extends Mechanism
             rc = produceInitiate(msg);
             break;
         default:
-            //  Temporary support for security debugging
-            puts("PLAIN Server I: invalid handshake command");
             rc = ZError.EPROTO;
             break;
 
@@ -119,22 +117,16 @@ public class PlainServerMechanism extends Mechanism
         int bytesLeft = msg.size();
         int index = 0;
         if (bytesLeft < 6 || !compare(msg, "HELLO", true)) {
-            //  Temporary support for security debugging
-            puts("PLAIN I: invalid PLAIN client, did not send HELLO");
             return ZError.EPROTO;
         }
         bytesLeft -= 6;
         index += 6;
         if (bytesLeft < 1) {
-            //  Temporary support for security debugging
-            puts("PLAIN I: invalid PLAIN client, did not send username");
             return ZError.EPROTO;
         }
         byte length = msg.get(index);
         bytesLeft -= 1;
         if (bytesLeft < length) {
-            //  Temporary support for security debugging
-            puts("PLAIN I: invalid PLAIN client, sent malformed username");
             return ZError.EPROTO;
         }
         byte[] tmp = new byte[length];
@@ -147,8 +139,6 @@ public class PlainServerMechanism extends Mechanism
         length = msg.get(index);
         bytesLeft -= 1;
         if (bytesLeft < length) {
-            //  Temporary support for security debugging
-            puts("PLAIN I: invalid PLAIN client, sent malformed password");
             return ZError.EPROTO;
         }
         tmp = new byte[length];
@@ -159,8 +149,6 @@ public class PlainServerMechanism extends Mechanism
         //        index += length;
 
         if (bytesLeft > 0) {
-            //  Temporary support for security debugging
-            puts("PLAIN I: invalid PLAIN client, sent extraneous data");
             return ZError.EPROTO;
         }
 
@@ -196,8 +184,6 @@ public class PlainServerMechanism extends Mechanism
     {
         int bytesLeft = msg.size();
         if (bytesLeft < 9 || !compare(msg, "INITIATE", true)) {
-            //  Temporary support for security debugging
-            puts("PLAIN I: invalid PLAIN client, did not send INITIATE");
             return ZError.EPROTO;
         }
 

--- a/src/main/java/zmq/poll/PollItem.java
+++ b/src/main/java/zmq/poll/PollItem.java
@@ -50,32 +50,32 @@ public class PollItem
         return interest;
     }
 
-    public final boolean isReadable()
+    public boolean isReadable()
     {
         return (ready & ZMQ.ZMQ_POLLIN) > 0;
     }
 
-    public final boolean isWritable()
+    public boolean isWritable()
     {
         return (ready & ZMQ.ZMQ_POLLOUT) > 0;
     }
 
-    public final boolean isError()
+    public boolean isError()
     {
         return (ready & ZMQ.ZMQ_POLLERR) > 0;
     }
 
-    public final SocketBase getSocket()
+    public SocketBase getSocket()
     {
         return socket;
     }
 
-    public final SelectableChannel getRawSocket()
+    public SelectableChannel getRawSocket()
     {
         return channel;
     }
 
-    public final SelectableChannel getChannel()
+    public SelectableChannel getChannel()
     {
         if (socket != null) {
             //  If the poll item is a 0MQ socket we are interested in input on the
@@ -89,29 +89,29 @@ public class PollItem
         }
     }
 
-    public final int interestOps()
+    public int interestOps()
     {
         return interest;
     }
 
     @Deprecated
-    public final int zinterestOps()
+    public int zinterestOps()
     {
         return zinterest;
     }
 
-    public final boolean hasEvent(int events)
+    public boolean hasEvent(int events)
     {
         return (zinterest & events) > 0;
     }
 
-    public final int interestOps(int ops)
+    public int interestOps(int ops)
     {
         init(ops);
         return interest;
     }
 
-    public final int readyOps(SelectionKey key, int nevents)
+    public int readyOps(SelectionKey key, int nevents)
     {
         ready = 0;
 
@@ -147,7 +147,7 @@ public class PollItem
         return ready;
     }
 
-    public final int readyOps()
+    public int readyOps()
     {
         return ready;
     }

--- a/src/test/java/zmq/PollTest.java
+++ b/src/test/java/zmq/PollTest.java
@@ -3,104 +3,68 @@ package zmq;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.Pipe;
 import java.nio.channels.Pipe.SinkChannel;
 import java.nio.channels.Pipe.SourceChannel;
+import java.nio.channels.SelectableChannel;
 import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.util.UUID;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import zmq.poll.PollItem;
 
 public class PollTest
 {
-    @Test
-    public void testPollTcp() throws Exception
+    @FunctionalInterface
+    static interface TxRx<R>
     {
-        Ctx context = ZMQ.init(1);
-        assertThat(context, notNullValue());
-
-        Selector selector = context.createSelector();
-        assertThat(selector, notNullValue());
-
-        PollItem[] items = new PollItem[2];
-
-        ServerSocketChannel server = ServerSocketChannel.open();
-        assertThat(server, notNullValue());
-        server.configureBlocking(false);
-        server.bind(null);
-        InetSocketAddress addr = (InetSocketAddress) server.socket().getLocalSocketAddress();
-
-        SocketChannel channelIn = SocketChannel.open();
-        assertThat(channelIn, notNullValue());
-        channelIn.configureBlocking(false);
-        boolean rc = channelIn.connect(addr);
-        assertThat(rc, is(false));
-
-        SocketChannel channelOut = server.accept();
-        channelOut.configureBlocking(false);
-
-        rc = channelIn.finishConnect();
-        assertThat(rc, is(true));
-
-        items[0] = new PollItem(channelOut, ZMQ.ZMQ_POLLOUT);
-        items[1] = new PollItem(channelIn, ZMQ.ZMQ_POLLIN);
-
-        int counter = 0;
-        boolean done = false;
-        boolean sent = false;
-        while (true) {
-            int events = ZMQ.poll(selector, items, 1000);
-            if (events < 0) {
-                break;
-            }
-            counter++;
-
-            if (items[0].isWritable() && !sent) {
-                ByteBuffer bb = ByteBuffer.allocate(3);
-                bb.put("tcp".getBytes());
-                bb.flip();
-                int written = channelOut.write(bb);
-                assertThat(written, is(3));
-                sent = true;
-            }
-            if (items[1].isReadable()) {
-                ByteBuffer bb = ByteBuffer.allocate(3);
-                int read = channelIn.read(bb);
-                String r = new String(bb.array(), 0, read);
-                assertThat(r, is("tcp"));
-                done = true;
-                break;
-            }
-        }
-        assertThat(done, is(true));
-        assertThat(counter, is(2));
-
-        context.closeSelector(selector);
-        ZMQ.term(context);
-
-        channelIn.close();
-        channelOut.close();
-        server.close();
+        R apply(ByteBuffer bb) throws IOException;
     }
 
     @Test
-    public void testPollPipe() throws Exception
+    public void testPollTcp() throws IOException
     {
-        Ctx context = ZMQ.init(1);
-        assertThat(context, notNullValue());
+        ServerSocketChannel server = ServerSocketChannel.open();
+        assertThat(server, notNullValue());
+        server.configureBlocking(true);
+        server.bind(null);
+        InetSocketAddress addr = (InetSocketAddress) server.socket().getLocalSocketAddress();
 
-        Selector selector = context.createSelector();
-        assertThat(selector, notNullValue());
+        SocketChannel in = SocketChannel.open();
+        assertThat(in, notNullValue());
+        in.configureBlocking(false);
+        boolean rc = in.connect(addr);
+        assertThat(rc, is(false));
 
-        PollItem[] items = new PollItem[2];
+        SocketChannel out = server.accept();
+        out.configureBlocking(false);
 
+        rc = in.finishConnect();
+        assertThat(rc, is(true));
+
+        try {
+            assertPoller(in, out, out::write, in::read);
+        }
+        finally {
+            in.close();
+            out.close();
+            server.close();
+        }
+    }
+
+    @Test
+    public void testPollPipe() throws IOException
+    {
         Pipe pipe = Pipe.open();
         assertThat(pipe, notNullValue());
 
@@ -112,48 +76,41 @@ public class PollTest
         assertThat(source, notNullValue());
         source.configureBlocking(false);
 
-        items[0] = new PollItem(sink, ZMQ.ZMQ_POLLOUT);
-        items[1] = new PollItem(source, ZMQ.ZMQ_POLLIN);
-
-        int counter = 0;
-        boolean done = false;
-        boolean sent = false;
-        while (true) {
-            int events = ZMQ.poll(selector, items, 1000);
-            if (events < 0) {
-                break;
-            }
-            counter++;
-
-            if (items[0].isWritable() && !sent) {
-                ByteBuffer bb = ByteBuffer.allocate(4);
-                bb.put("pipe".getBytes());
-                bb.flip();
-                int written = sink.write(bb);
-                assertThat(written, is(4));
-                sent = true;
-            }
-            if (items[1].isReadable()) {
-                ByteBuffer bb = ByteBuffer.allocate(5);
-                int read = source.read(bb);
-                String r = new String(bb.array(), 0, read);
-                assertThat(r, is("pipe"));
-                done = true;
-                break;
-            }
+        try {
+            assertPoller(source, sink, sink::write, source::read);
         }
-        assertThat(done, is(true));
-        assertThat(counter, is(2));
+        finally {
+            sink.close();
+            source.close();
+        }
 
-        context.closeSelector(selector);
-        ZMQ.term(context);
-
-        sink.close();
-        source.close();
     }
 
     @Test
-    public void testPollUdp() throws Exception
+    public void testPollUdp() throws IOException
+    {
+        DatagramChannel in = DatagramChannel.open();
+        assertThat(in, notNullValue());
+        in.configureBlocking(false);
+        in.socket().bind(null);
+        InetSocketAddress addr = (InetSocketAddress) in.socket().getLocalSocketAddress();
+
+        DatagramChannel out = DatagramChannel.open();
+        assertThat(out, notNullValue());
+        out.configureBlocking(false);
+        out.connect(addr);
+
+        try {
+            assertPoller(in, out, bb -> out.send(bb, addr), in::receive);
+        }
+        finally {
+            in.close();
+            out.close();
+        }
+    }
+
+    private <T extends SelectableChannel> void assertPoller(T in, T out, TxRx<Integer> tx, TxRx<Object> rx)
+            throws IOException
     {
         Ctx context = ZMQ.init(1);
         assertThat(context, notNullValue());
@@ -163,54 +120,50 @@ public class PollTest
 
         PollItem[] items = new PollItem[2];
 
-        DatagramChannel udpIn = DatagramChannel.open();
-        assertThat(udpIn, notNullValue());
-        udpIn.configureBlocking(false);
-        udpIn.socket().bind(null);
-        InetSocketAddress addr = (InetSocketAddress) udpIn.socket().getLocalSocketAddress();
+        items[0] = new PollItem(out, ZMQ.ZMQ_POLLOUT);
+        items[1] = new PollItem(in, ZMQ.ZMQ_POLLIN);
 
-        DatagramChannel udpOut = DatagramChannel.open();
-        assertThat(udpOut, notNullValue());
-        udpOut.configureBlocking(false);
-        udpOut.connect(addr);
-
-        items[0] = new PollItem(udpOut, ZMQ.ZMQ_POLLOUT);
-        items[1] = new PollItem(udpIn, ZMQ.ZMQ_POLLIN);
-
-        int counter = 0;
-        boolean done = false;
-        boolean sent = false;
+        String payload = UUID.randomUUID().toString();
+        boolean sending = true;
         while (true) {
             int events = ZMQ.poll(selector, items, 1000);
             if (events < 0) {
-                break;
+                fail("unable to poll events");
             }
-            counter++;
 
-            if (items[0].isWritable() && !sent) {
-                ByteBuffer bb = ByteBuffer.allocate(3);
-                bb.put("udp".getBytes());
+            if (sending && items[0].isWritable()) {
+                sending = false;
+                ByteBuffer bb = ByteBuffer.allocate(payload.length());
+                bb.put(payload.getBytes());
                 bb.flip();
-                int written = udpOut.send(bb, addr);
-                assertThat(written, is(3));
-                sent = true;
+                int written = tx.apply(bb);
+
+                assertThat(written, is(payload.length()));
             }
-            if (items[1].isReadable()) {
-                ByteBuffer bb = ByteBuffer.allocate(3);
-                udpIn.receive(bb);
+            if (!sending && items[1].isReadable()) {
+                ByteBuffer bb = ByteBuffer.allocate(payload.length());
+                rx.apply(bb);
                 String read = new String(bb.array(), 0, bb.limit());
-                assertThat(read, is("udp"));
-                done = true;
+
+                assertThat(read, is(payload));
                 break;
             }
         }
-        assertThat(done, is(true));
-        assertThat(counter, is(2));
 
         context.closeSelector(selector);
         ZMQ.term(context);
+    }
 
-        udpIn.close();
-        udpOut.close();
+    @Ignore
+    @Test
+    public void testRepeated() throws IOException
+    {
+        for (int idx = 0; idx < 10_000_000; ++idx) {
+            if (idx % 10000 == 0) {
+                System.out.println(idx);
+            }
+            testPollTcp();
+            testPollUdp();
+        }
     }
 }

--- a/src/test/java/zmq/faultinjection/FaultInjectionTest.java
+++ b/src/test/java/zmq/faultinjection/FaultInjectionTest.java
@@ -10,8 +10,8 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.channels.SocketChannel;
 
-public class FaultInjectionTest {
-
+public class FaultInjectionTest
+{
     ZMTP3Server testServer;
     ZmqServerEvents events;
     ZContext ctx = new ZContext();
@@ -36,10 +36,12 @@ public class FaultInjectionTest {
     }
 
     @After
-    public void cleanup() {
+    public void cleanup()
+    {
         try {
             testServer.stop();
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             e.printStackTrace();
         }
     }
@@ -47,88 +49,90 @@ public class FaultInjectionTest {
     @Test
     public void testStart()
     {
-        boolean debugger_attached = false;
+        boolean debuggerAttached = false;
 
         StringBuilder sb = new StringBuilder(5);
-        for (int i =0; i < 5; i++ ) {
-            sb.append(i%10);
+        for (int i = 0; i < 5; i++) {
+            sb.append(i % 10);
         }
 
         boolean cont = true;
 
-        for (int i = 0; i < 10; i ++ ) {
+        for (int i = 0; i < 10; i++) {
             brokerSocket.send(sb.toString());
             sleep(100);
         }
 
-        if (debugger_attached) {
+        if (debuggerAttached) {
             sleep(-1);
-        } else {
+        }
+        else {
             sleep(5000);
         }
     }
 
-    private void sleep(int ms) {
+    private void sleep(int ms)
+    {
         try {
             Thread.sleep(ms);
-        } catch (InterruptedException e) {
+        }
+        catch (InterruptedException e) {
             e.printStackTrace();
         }
     }
 
-    static class ZmqServerEvents implements ZMTP3Server.ISocketEvents {
-
+    static class ZmqServerEvents implements ZMTP3Server.ISocketEvents
+    {
         ZMTP3Server testServer;
 
-        public ZmqServerEvents(ZMTP3Server server) {
+        public ZmqServerEvents(ZMTP3Server server)
+        {
             testServer = server;
         }
 
         long start = System.currentTimeMillis();
 
         @Override
-        public void onConnectionReceived(SocketChannel channel) {
-
+        public void onConnectionReceived(SocketChannel channel)
+        {
         }
 
         @Override
-        public void onGreetingReceived(SocketChannel channel) {
+        public void onGreetingReceived(SocketChannel channel)
+        {
             try {
                 channel.close();
                 testServer.stop();
-            } catch (IOException e) {
-
             }
-
-
+            catch (IOException e) {
+            }
         }
 
         @Override
-        public void onHandshakeReceived(SocketChannel channel) {
-
+        public void onHandshakeReceived(SocketChannel channel)
+        {
         }
 
         @Override
-        public void onCommandReceived(SocketChannel channel, String command) {
-
+        public void onCommandReceived(SocketChannel channel, String command)
+        {
         }
 
         @Override
-        public void onMessageReceived(SocketChannel channel, String message) {
-
+        public void onMessageReceived(SocketChannel channel, String message)
+        {
             if (System.currentTimeMillis() - start < 30000) {
                 return;
             }
 
             try {
                 channel.socket().shutdownInput();
-            } catch (IOException e) {
-
+            }
+            catch (IOException e) {
             }
 
             // reset start.
             start = System.currentTimeMillis();
-
         }
     }
 }

--- a/src/test/java/zmq/faultinjection/FaultInjectionTest.java
+++ b/src/test/java/zmq/faultinjection/FaultInjectionTest.java
@@ -1,0 +1,134 @@
+package zmq.faultinjection;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.zeromq.ZContext;
+import org.zeromq.ZMQ;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.channels.SocketChannel;
+
+public class FaultInjectionTest {
+
+    ZMTP3Server testServer;
+    ZmqServerEvents events;
+    ZContext ctx = new ZContext();
+    ZMQ.Socket brokerSocket;
+
+    @Before
+    public void setup() throws IOException
+    {
+        testServer = new ZMTP3Server();
+        testServer.initialize(new InetSocketAddress(4200));
+        events = new ZmqServerEvents(testServer);
+        testServer.setDelegate(events);
+
+        brokerSocket = ctx.createSocket(ZMQ.DEALER);
+        brokerSocket.setHWM(10);
+        brokerSocket.setSendTimeOut(-1);
+        brokerSocket.setDelayAttachOnConnect(true);
+        brokerSocket.setTCPKeepAlive(1);
+
+        brokerSocket.connect("tcp://localhost:4200");
+
+    }
+
+    @After
+    public void cleanup() {
+        try {
+            testServer.stop();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testStart()
+    {
+        boolean debugger_attached = false;
+
+        StringBuilder sb = new StringBuilder(5);
+        for (int i =0; i < 5; i++ ) {
+            sb.append(i%10);
+        }
+
+        boolean cont = true;
+
+        for (int i = 0; i < 10; i ++ ) {
+            brokerSocket.send(sb.toString());
+            sleep(100);
+        }
+
+        if (debugger_attached) {
+            sleep(-1);
+        } else {
+            sleep(5000);
+        }
+    }
+
+    private void sleep(int ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    static class ZmqServerEvents implements ZMTP3Server.ISocketEvents {
+
+        ZMTP3Server testServer;
+
+        public ZmqServerEvents(ZMTP3Server server) {
+            testServer = server;
+        }
+
+        long start = System.currentTimeMillis();
+
+        @Override
+        public void onConnectionReceived(SocketChannel channel) {
+
+        }
+
+        @Override
+        public void onGreetingReceived(SocketChannel channel) {
+            try {
+                channel.close();
+                testServer.stop();
+            } catch (IOException e) {
+
+            }
+
+
+        }
+
+        @Override
+        public void onHandshakeReceived(SocketChannel channel) {
+
+        }
+
+        @Override
+        public void onCommandReceived(SocketChannel channel, String command) {
+
+        }
+
+        @Override
+        public void onMessageReceived(SocketChannel channel, String message) {
+
+            if (System.currentTimeMillis() - start < 30000) {
+                return;
+            }
+
+            try {
+                channel.socket().shutdownInput();
+            } catch (IOException e) {
+
+            }
+
+            // reset start.
+            start = System.currentTimeMillis();
+
+        }
+    }
+}

--- a/src/test/java/zmq/faultinjection/ZMTP3Server.java
+++ b/src/test/java/zmq/faultinjection/ZMTP3Server.java
@@ -1,0 +1,546 @@
+package zmq.faultinjection;
+
+import java.io.*;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.channels.ClosedSelectorException;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+public class ZMTP3Server {
+
+    private static Charset ASCII = Charset.forName("ascii");
+    private AcceptThread worker;
+    private ISocketEvents delegate;
+
+
+    public interface ISocketEvents {
+        public void onConnectionReceived(SocketChannel channel);
+
+        public void onGreetingReceived(SocketChannel channel);
+
+        public void onHandshakeReceived(SocketChannel channel);
+
+        public void onCommandReceived(SocketChannel channel, String command);
+
+        public void onMessageReceived(SocketChannel channel, String message);
+    }
+
+    public void setDelegate(ISocketEvents delegate) {
+        this.delegate = delegate;
+    }
+
+    public void initialize(SocketAddress localAddress) throws IOException {
+        LOG.debug("initialize()");
+        worker = new AcceptThread();
+        worker.initialize(localAddress);
+
+    }
+
+    public void initialize() throws IOException {
+        initialize(null);
+    }
+
+    public void stop() throws IOException {
+        this.worker.stop();
+    }
+
+    class AcceptThread implements Runnable {
+        private ServerSocketChannel channel;
+        private Thread thread;
+        SocketAddress localAddress;
+        Selector selector = null;
+        private ExecutorService executorService;
+
+        public AcceptThread() {
+        }
+
+        @Override
+        public void run() {
+            try {
+                this.selector = Selector.open();
+                channel.register(selector, SelectionKey.OP_ACCEPT);
+
+                while (!Thread.currentThread().isInterrupted()) {
+                    // wait for a connection
+                    selector.select();
+
+                    // get the list of selection keys with pending events
+                    java.util.Iterator<SelectionKey> it = selector.selectedKeys().iterator();
+
+                    while (it.hasNext()) {
+                        // Get the selection key SelectionKey
+                        SelectionKey selKey = (SelectionKey) it.next();
+
+                        // Remove it from the list to indicate that it is being processed
+                        it.remove();
+
+                        // Check if it's a connection request
+                        if (selKey.isAcceptable()) {
+                            // Get channel with connection request
+                            ServerSocketChannel ssChannel = (ServerSocketChannel) selKey.channel();
+
+                            CharsetDecoder decoder = ASCII.newDecoder();
+
+                            // See Accepting a Connection on a ServerSocketChannel
+                            // for an example of accepting a connection request
+                            SocketChannel client = ssChannel.accept();
+
+                            InetSocketAddress inets = (InetSocketAddress) client.socket().getRemoteSocketAddress();
+                            LOG.info("Remote Endpoint: " + inets.getHostName() + ":" + inets.getPort());
+
+                            if (delegate != null) {
+                                delegate.onConnectionReceived(client);
+                            }
+
+                            RequestHandler handler = new RequestHandler(client, delegate);
+                            executorService.submit(handler);
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+        public void initialize(SocketAddress localAddress) throws IOException {
+            LOG.debug("initialize()");
+
+            this.localAddress = localAddress;
+
+            this.channel = ServerSocketChannel.open();
+            this.channel.configureBlocking(false);
+
+            this.channel.socket().bind(localAddress);
+            this.channel.accept();
+
+            final AcceptThread acceptThread = this;
+            executorService = Executors.newCachedThreadPool(new ThreadFactory() {
+                @Override
+                public Thread newThread(Runnable r) {
+                    Thread t = new Thread(r, "AcceptorThread");
+                    return t;
+                }
+            });
+
+            this.thread = new Thread(this, "ZMTP3ServerAcceptor");
+            this.thread.setDaemon(true);
+            this.thread.start();
+        }
+
+        public void stop() throws IOException {
+            LOG.debug("stop()");
+
+            if (this.channel != null) {
+
+                this.channel.close();
+                this.channel.socket().close();
+
+                this.channel = null;
+            }
+
+            if (this.thread != null) {
+
+                try {
+                    this.thread.interrupt();
+                    this.thread.join(5000);
+                    this.thread = null;
+                } catch (InterruptedException e) {
+                    LOG.warn(e.toString());
+                }
+            }
+        }
+    }
+
+
+    class RequestHandler implements Runnable
+    {
+        private static final int TAB_CODE = 9;
+        private boolean stopped;
+        SocketChannel client = null;
+        ISocketEvents delegate;
+
+        private Object notifier = new Object();
+
+        public RequestHandler(SocketChannel client, ISocketEvents delegate) {
+            this.client = client;
+            this.delegate = delegate;
+        }
+
+        public void stop()
+        {
+            LOG.debug("RequestHandler::stop()");
+
+            try {
+                // there might not be a current connection
+                if (this.client != null)
+                {
+                    this.client.close();
+                    this.client = null;
+                }
+            } catch (IOException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+            this.stopped = true;
+        }
+
+
+        public void run()
+        {
+            try
+            {
+                byte [] CLIENT_SIG = { (byte)0xff, (byte)0x0, (byte)0x0, (byte)0x0, (byte)0x0, (byte)0x0, (byte)0x0, (byte)0x0, (byte)0x0, (byte)0x7f  };
+                byte [] VERSION = { (byte)0x03, (byte)0x00 };
+                byte [] MECHANISM = { 'N', 'U', 'L', 'L', (byte)0x00 };
+
+                ByteBuffer greeting = ByteBuffer.allocate(64);
+                greeting.put(CLIENT_SIG);
+                greeting.put(VERSION);
+                greeting.put(MECHANISM);
+                greeting.put((byte)0); // as server
+                greeting.rewind();
+
+                //PushbackInputStream readStream = new PushbackInputStream(client.socket().getInputStream());
+                InputStream inputStream = client.socket().getInputStream();
+                DataInputStream readStream = new DataInputStream(inputStream);
+
+                OutputStream rawOutputStream = client.socket().getOutputStream();
+                DataOutputStream outputStream = new DataOutputStream(rawOutputStream);
+
+                LOG.info("Send greeting");
+
+                outputStream.write(greeting.array());
+
+                int offset = 0;
+                byte [] requestBytes = new byte[1024];
+                byte [] greetings = new byte[64];
+
+                LOG.info("Reading greetings");
+                int read = readStream.read(greetings, 0, greetings.length);
+                LOG.info(String.format("Read: %d Total: %d", read, offset));
+
+                LOG.info("\n" + print_hex(greetings, 0, greetings.length));
+
+                assert (read == 64);
+
+                if (delegate != null) {
+                    delegate.onGreetingReceived(client);
+                }
+
+                // handshake.
+                        /*
+                        ;   The handshake consists of at least one command
+                        ;   The actual grammar depends on the security mechanism
+                        handshake = 1*command
+
+                        ;   A command is a single long or short frame
+                        command = command-size command-body
+                        command-size = %x04 short-size | %x06 long-size
+                        short-size = OCTET          ; Body is 0 to 255 octets
+                        long-size = 8OCTET          ; Body is 0 to 2^63-1 octets
+                        command-body = command-name command-data
+                        command-name = OCTET 1*255command-name-char
+                        command-name-char = ALPHA
+                        command-data = *OCTET
+
+                         */
+                long command_size = 0;
+                read = readStream.read(requestBytes, 0, 1);
+                assert (read == 1);
+                if (requestBytes[0] == 0x04) {
+                    command_size = readStream.readByte();
+                } else if (requestBytes[0] == 0x06) {
+                    // long size. 8 bytes.
+
+                    read = readStream.read(requestBytes, 0, 8);
+                    assert (read == 8);
+                    command_size = readStream.readLong();
+                }
+
+                byte [] command_bytes = new byte[(int)command_size];
+                read = readStream.read(command_bytes, 0, command_bytes.length);
+                assert (read == command_bytes.length);
+
+                LOG.info("ComamndBytes: ");
+                LOG.info("\n" + print_hex(command_bytes, 0, command_bytes.length));
+
+                /*
+                null = ready *message | error
+                ready = command-size %d5 "READY" metadata
+                metadata = *property
+                property = name value
+                name = OCTET 1*255name-char
+                name-char = ALPHA | DIGIT | "-" | "_" | "." | "+"
+                value = 4OCTET *OCTET       ; Size in network byte order
+                error = command-size %d5 "ERROR" error-reason
+                error-reason = OCTET 0*255VCHAR
+                 */
+
+                ByteArrayInputStream bis = new ByteArrayInputStream(command_bytes);
+                DataInputStream dis = new DataInputStream(bis);
+                int command_name_len = dis.readByte();
+                byte [] command_name_bytes = new byte[command_name_len];
+                dis.read(command_name_bytes);
+                String commandName = new String(command_name_bytes,"utf-8");
+
+                assert(Objects.equals(commandName, "READY"));
+
+                if (delegate != null) {
+                    delegate.onHandshakeReceived(client);
+                }
+
+                // we dont care about rest of the READY message from client as part of NULL handshake.
+
+                // this is response to NULL handshake from client.
+                // we will wrap this in a command later.
+                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                DataOutputStream dos = new DataOutputStream(bos);
+                dos.writeByte(5);
+                dos.write("READY".getBytes("utf-8"));
+
+                // metdata for NULL handshake
+                String [][] NULL_HANDSHAKE_METADATA = {
+                        { "Socket-Type", "ROUTER" },
+                        { "Identity", "+tcp://localhost:4300"}
+
+                };
+
+                for(int i = 0; i < NULL_HANDSHAKE_METADATA.length; i++) {
+                    String key= NULL_HANDSHAKE_METADATA[i][0];
+                    String value = NULL_HANDSHAKE_METADATA[i][1];
+
+                    dos.writeByte(key.length());
+                    dos.write(key.getBytes("utf-8"));
+                    dos.writeInt(value.length());
+                    dos.write(value.getBytes("utf-8"));
+                }
+
+                byte [] null_response = bos.toByteArray();
+                if (null_response.length <= 255) {
+                    outputStream.writeByte(0x04);
+                    outputStream.writeByte(null_response.length);
+                } else {
+                    outputStream.writeByte(0x06);
+                    outputStream.writeLong(null_response.length);
+                }
+
+                outputStream.write(null_response);
+
+
+                int max = 10;
+
+
+                while(max > 0)
+                {
+                    // now we are getting traffic
+                            /*
+                            traffic = *command
+                             */
+                    read_frame(readStream);
+
+                    // delegate to the caller.
+                    if (delegate != null)
+                    {
+                        delegate.onConnectionReceived(client);
+                    }
+                    //--max;
+                }
+            }
+            catch(IOException e)
+            {
+                e.printStackTrace();
+            }
+            catch(ClosedSelectorException e)
+            {
+                e.printStackTrace();
+            } finally {
+                try {
+                    client.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+
+            LOG.debug("**** ZMTP3 TEST SERVER EXITING *****");
+        }
+
+        String print_hex(byte [] buffer, int offset, int length) {
+            StringBuilder sb = new StringBuilder(128);
+            StringBuilder hex = new StringBuilder(128);
+            StringBuilder ascii = new StringBuilder(128);
+            for (int i = 0; i < buffer.length; i++) {
+                hex.append(String.format("%02x", buffer[i]));
+                hex.append(" ");
+
+                if (buffer[i] >= 32 && buffer[i] < 128) {
+                    ascii.append(String.format("%c", buffer[i]));
+                } else {
+                    ascii.append("-");
+                }
+                ascii.append(" ");
+
+                if ((i +1) % 8 == 0) {
+                    sb.append(hex.toString()).append(" ").append(ascii.toString()).append("\n");
+                    hex.setLength(0);
+                    ascii.setLength(0);
+                }
+            }
+
+            return sb.toString();
+        }
+
+        void read_command(DataInputStream readStream, byte command_size_type) throws IOException {
+            /*
+            ;   A command is a single long or short frame
+            command = command-size command-body
+            command-size = %x04 short-size | %x06 long-size
+            short-size = OCTET          ; Body is 0 to 255 octets
+            long-size = 8OCTET          ; Body is 0 to 2^63-1 octets
+            command-body = command-name command-data
+            command-name = OCTET 1*255command-name-char
+            command-name-char = ALPHA
+            command-data = *OCTET
+            */
+
+            long command_size = 0;
+
+            if (command_size_type == 0x04) {
+                command_size = readStream.readByte();
+            } else if (command_size_type == 0x06) {
+                // long size. 8 bytes.
+                command_size = readStream.readLong();
+            }
+
+            byte [] command_body_bytes = new byte[(int)command_size];
+            int read = readStream.read(command_body_bytes, 0, command_body_bytes.length);
+            assert (read == command_body_bytes.length);
+
+            LOG.info("COMMAND-BODY: \n" + print_hex(command_body_bytes, 0, command_body_bytes.length));
+
+            // get command name
+            String commandName = readString(readStream);
+
+            if (delegate != null) {
+                delegate.onCommandReceived(client, commandName);
+            }
+
+
+        }
+
+        boolean read_frame(DataInputStream inputStream) throws IOException {
+            /*
+            Following the greeting, which has a fixed size of 64 octets, all further data is sent as frames, which carry commands or messages. Frames consist of a size field, a flags fields, and a body. The frame design is meant to be efficient for small frames but capable of handling extremely large data as well.
+
+            A frame consists of a flags field (1 octet), followed by a size field (one octet or eight octets) and a frame body of size octets. The size does not include the flags field, nor itself, so an empty frame has a size of zero.
+
+            A short frame has a body of 0 to 255 octets. A long frame has a body of 0 to 2^63-1 octets.
+
+            The flags field consists of a single octet containing various control flags. Bit 0 is the least significant bit (rightmost bit):
+
+            Bits 7-3: Reserved. Bits 7-3 are reserved for future use and MUST be zero.
+
+            Bit 2 (COMMAND): Command frame. A value of 1 indicates that the frame is a command frame. A value of 0 indicates that the frame is a message frame.
+
+            Bit 1 (LONG): Long frame. A value of 0 indicates that the frame size is encoded as a single octet. A value of 1 indicates that the frame size is encoded as a 64-bit unsigned integer in network byte order.
+
+            Bit 0 (MORE): More frames to follow. A value of 0 indicates that there are no more frames to follow. A value of 1 indicates that more frames will follow. This bit SHALL be zero on command frames.
+            */
+
+            byte flag = inputStream.readByte();
+
+            boolean more = (flag & 0x01) == 0x01;
+
+            boolean long_frame = (flag & 0x02) == 0x02;
+
+            boolean command_frame = (flag & 0x04) == 0x04;
+
+            if (command_frame) {
+                read_command(inputStream, flag);
+
+            } else {
+                read_message(inputStream, long_frame);
+            }
+
+            return more;
+        }
+
+        void read_message(DataInputStream readStream, boolean long_frame) throws IOException {
+            /*
+                ;   A message is one or more frames
+                message = *message-more message-last
+                message-more = ( %x01 short-size | %x03 long-size ) message-body
+                message-last = ( %x00 short-size | %x02 long-size ) message-body
+                message-body = *OCTET
+            */
+
+            long message_size = 0;
+
+            if (long_frame) {
+                // long size. 8 bytes.
+                message_size = readStream.readLong();
+            } else {
+                message_size = readStream.readByte();
+            }
+
+            byte [] message_body_bytes = new byte[(int)message_size];
+            int read = readStream.read(message_body_bytes, 0, message_body_bytes.length);
+            assert (read == message_body_bytes.length);
+
+            LOG.info(String.format("Read %d message bytes", read));
+            //message body is string from logging system.
+            LOG.info("COMMAND-BODY: \n" + print_hex(message_body_bytes, 0, message_body_bytes.length));
+
+            if (delegate != null) {
+                delegate.onMessageReceived(client, null);
+            }
+
+        }
+
+        String readString(DataInputStream inputStream) throws IOException {
+            // read a size prepended string value
+            byte size = inputStream.readByte();
+            byte [] buffer = new byte[size];
+            int read = inputStream.read(buffer);
+            assert (read == size);
+            String s = new String(buffer, "utf-8");
+            LOG.info("Got command: " + s);
+            return s;
+        }
+    }
+
+    static class LOG {
+        public static void debug(String format, String... args) {
+            print("DEBUG", format, args);
+        }
+
+        public static void info(String format, String... args) {
+            print("INFO", format, args);
+        }
+
+        public static void warn(String format, String... args) {
+            print("WARN", format, args);
+        }
+
+        static void print(String level, String format, String... args) {
+            if (args.length == 0) {
+                System.out.printf("%s %s\n", level, format);
+            } else {
+                System.out.printf(level + " " + format +"\n", args);
+            }
+
+        }
+    }
+}

--- a/src/test/java/zmq/faultinjection/ZMTP3Server.java
+++ b/src/test/java/zmq/faultinjection/ZMTP3Server.java
@@ -369,10 +369,7 @@ public class ZMTP3Server
                     //--max;
                 }
             }
-            catch (IOException e) {
-                e.printStackTrace();
-            }
-            catch (ClosedSelectorException e) {
+            catch (Exception e) {
                 e.printStackTrace();
             }
             finally {

--- a/src/test/java/zmq/faultinjection/ZMTP3Server.java
+++ b/src/test/java/zmq/faultinjection/ZMTP3Server.java
@@ -10,7 +10,6 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
-import java.nio.channels.ClosedSelectorException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;

--- a/src/test/java/zmq/io/mechanism/SecurityCurveTest.java
+++ b/src/test/java/zmq/io/mechanism/SecurityCurveTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import zmq.Ctx;
 import zmq.Helper;
 import zmq.Msg;
+import zmq.Options;
 import zmq.SocketBase;
 import zmq.ZError;
 import zmq.ZMQ;
@@ -333,5 +334,70 @@ public class SecurityCurveTest
         ZMQ.term(ctx);
         //  Wait until ZAP handler terminates
         thread.join();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void inconsistent1()
+    {
+        Options opt = new Options();
+        opt.setSocketOpt(ZMQ.ZMQ_CURVE_PUBLICKEY, new byte[32]);
+        opt.setSocketOpt(ZMQ.ZMQ_CURVE_SECRETKEY, null);
+        Mechanisms.CURVE.check(opt);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void inconsistent2()
+    {
+        Options opt = new Options();
+        opt.setSocketOpt(ZMQ.ZMQ_CURVE_PUBLICKEY, null);
+        opt.setSocketOpt(ZMQ.ZMQ_CURVE_SECRETKEY, new byte[32]);
+        Mechanisms.CURVE.check(opt);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void inconsistent3()
+    {
+        Options opt = new Options();
+        opt.setSocketOpt(ZMQ.ZMQ_CURVE_PUBLICKEY, new byte[32]);
+        opt.setSocketOpt(ZMQ.ZMQ_CURVE_SECRETKEY, new byte[31]);
+        Mechanisms.CURVE.check(opt);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void inconsistent4()
+    {
+        Options opt = new Options();
+        opt.setSocketOpt(ZMQ.ZMQ_CURVE_PUBLICKEY, new byte[31]);
+        opt.setSocketOpt(ZMQ.ZMQ_CURVE_SECRETKEY, new byte[32]);
+        Mechanisms.CURVE.check(opt);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void inconsistent5()
+    {
+        Options opt = new Options();
+        opt.setSocketOpt(ZMQ.ZMQ_CURVE_PUBLICKEY, new byte[32]);
+        opt.setSocketOpt(ZMQ.ZMQ_CURVE_SECRETKEY, new byte[32]);
+        opt.setSocketOpt(ZMQ.ZMQ_CURVE_SERVERKEY, new byte[31]);
+        Mechanisms.CURVE.check(opt);
+    }
+
+    @Test
+    public void consistent1()
+    {
+        Options opt = new Options();
+        opt.setSocketOpt(ZMQ.ZMQ_CURVE_PUBLICKEY, new byte[32]);
+        opt.setSocketOpt(ZMQ.ZMQ_CURVE_SECRETKEY, new byte[32]);
+        Mechanisms.CURVE.check(opt);
+    }
+
+    @Test
+    public void consistent2()
+    {
+        Options opt = new Options();
+        opt.setSocketOpt(ZMQ.ZMQ_CURVE_PUBLICKEY, new byte[32]);
+        opt.setSocketOpt(ZMQ.ZMQ_CURVE_SECRETKEY, new byte[32]);
+        opt.setSocketOpt(ZMQ.ZMQ_CURVE_SERVERKEY, new byte[32]);
+        Mechanisms.CURVE.check(opt);
     }
 }

--- a/src/test/java/zmq/io/mechanism/SecurityPlainTest.java
+++ b/src/test/java/zmq/io/mechanism/SecurityPlainTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import zmq.Ctx;
 import zmq.Helper;
 import zmq.Msg;
+import zmq.Options;
 import zmq.SocketBase;
 import zmq.ZMQ;
 import zmq.util.Utils;
@@ -179,5 +180,50 @@ public class SecurityPlainTest
         ZMQ.term(ctx);
         //  Wait until ZAP handler terminates
         thread.join();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void inconsistent1()
+    {
+        Options opt = new Options();
+        opt.setSocketOpt(ZMQ.ZMQ_PLAIN_USERNAME, null);
+        opt.setSocketOpt(ZMQ.ZMQ_PLAIN_PASSWORD, "plainPassword");
+        Mechanisms.PLAIN.check(opt);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void inconsistent2()
+    {
+        Options opt = new Options();
+        opt.setSocketOpt(ZMQ.ZMQ_PLAIN_PASSWORD, null);
+        opt.setSocketOpt(ZMQ.ZMQ_PLAIN_USERNAME, "plainUsername");
+        Mechanisms.PLAIN.check(opt);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void inconsistent3()
+    {
+        Options opt = new Options();
+        opt.setSocketOpt(ZMQ.ZMQ_PLAIN_USERNAME, String.format("%256d", 1));
+        opt.setSocketOpt(ZMQ.ZMQ_PLAIN_PASSWORD, "plainPassword");
+        Mechanisms.PLAIN.check(opt);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void inconsistent4()
+    {
+        Options opt = new Options();
+        opt.setSocketOpt(ZMQ.ZMQ_PLAIN_USERNAME, "plainUsername");
+        opt.setSocketOpt(ZMQ.ZMQ_PLAIN_PASSWORD, String.format("%256d", 1));
+        Mechanisms.PLAIN.check(opt);
+    }
+
+    @Test
+    public void consistent()
+    {
+        Options opt = new Options();
+        opt.setSocketOpt(ZMQ.ZMQ_PLAIN_USERNAME, "plainUsername");
+        opt.setSocketOpt(ZMQ.ZMQ_PLAIN_PASSWORD, "plainPassword");
+        Mechanisms.PLAIN.check(opt);
     }
 }


### PR DESCRIPTION
We are hitting the nasty jeromq issue where the IOPoller thread consumes 100% cpu ( [Issue#506](https://github.com/zeromq/jeromq/issues/506). Somewhere there is mentioned a link to JDK issue ( purportedly fixed in jdk7 ) that mentions it might be due to a server closing a socket and sending a reset.

So I thought I would repro this. I wrote a simple ZMTP3 server that accepts requests from a client. When it gets the GREETING frame, the socket is closed. After that the `socket.send()` call hangs indefinitely. On attaching a debugger I notice that the Poller thread is spinning infinitely ( however, it does not consume 100% cpu ).

While this does not repro our bug, I still thought I would send this your way for investigation. It is also possible that I am not doing something correctly that causes the `send()` call to hang, even though the server socket is closed.