### PR TITLE
Change cursors in Signaler to long to avoid overflowing

### DIFF
--- a/src/main/java/zmq/Signaler.java
+++ b/src/main/java/zmq/Signaler.java
@@ -9,7 +9,7 @@ import java.nio.channels.Pipe;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import zmq.util.Errno;
 import zmq.util.Utils;
@@ -28,8 +28,8 @@ final class Signaler implements Closeable
     private final ByteBuffer         rdummy = ByteBuffer.allocate(1);
 
     // Selector.selectNow at every sending message doesn't show enough performance
-    private final AtomicInteger wcursor = new AtomicInteger(0);
-    private int                 rcursor = 0;
+    private final AtomicLong wcursor = new AtomicLong(0);
+    private long             rcursor = 0;
 
     private final Errno errno;
     private final int   pid;


### PR DESCRIPTION
32-bit integer cursors in Signaler can overflow within a month or so under high load, and causes serious problems.

When wcursor in Signaler overflows, waitEvent(timeout == 0) cannot return true until recv() is called so that rcursor overflows as well. This condition is particularly harmful to IOThread, as it irreversibly renders IOThread unable to retrieve commands from its mailbox in inEvent(), because mailbox never calls any other methods in Signaler until it gets true from waitEvent() and IOThread always specifies timeout == 0 for mailbox.recv(). This in turn causes serious problems, such as a server being unable to accept new client connections anymore.

This pull request replaces 32-bit integer cursors with 64-bit long cursors. It does not fix the problem 100%, but fixes it within realistic durations.