### PR TITLE
Removing a really redundant stack trace, as the exception is returned.

### DIFF
--- a/src/main/java/zmq/Signaler.java
+++ b/src/main/java/zmq/Signaler.java
@@ -98,7 +98,6 @@ final class Signaler implements Closeable
                 nbytes = w.write(wdummy);
             }
             catch (IOException e) {
-                e.printStackTrace();
                 throw new ZError.IOException(e);
             }
             if (nbytes == 0) {


### PR DESCRIPTION
This stack trace is never lost, it's stored in a wrapping exception.
All the other one I found in this class needs special handling.