### PR TITLE
Improved Signaler interrupt handling.

### DIFF
--- a/src/main/java/zmq/Signaler.java
+++ b/src/main/java/zmq/Signaler.java
@@ -141,7 +141,11 @@ final class Signaler implements Closeable
             return false;
         }
 
-        if (rc == 0) {
+        if (rc == 0 && timeout < 0 && ! selector.keys().isEmpty()) {
+            errno.set(ZError.EINTR);
+            return false;
+        }
+        else if (rc == 0) {
             errno.set(ZError.EAGAIN);
             return false;
         }


### PR DESCRIPTION
In Signaler.waitEvent:
When selector.select(0) return 0 and there is indeed keys it means that
this method was interrupted, not to try again. So set errno to EINTR.