### PR TITLE
Improving usage of charset UTF-8

### DIFF
--- a/src/main/java/org/zeromq/ZSocket.java
+++ b/src/main/java/org/zeromq/ZSocket.java
@@ -1,6 +1,5 @@
 package org.zeromq;
 
-import java.nio.charset.Charset;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import zmq.Msg;
@@ -20,7 +19,6 @@ import zmq.ZMQ;
  */
 public class ZSocket implements AutoCloseable
 {
-    public static final Charset UTF8 = Charset.forName("UTF-8");
     private final SocketBase    socketBase;
 
     private final AtomicBoolean isClosed = new AtomicBoolean(false);
@@ -131,7 +129,7 @@ public class ZSocket implements AutoCloseable
 
     public void subscribe(String topic)
     {
-        setOption(ZMQ.ZMQ_SUBSCRIBE, topic.getBytes(UTF8));
+        setOption(ZMQ.ZMQ_SUBSCRIBE, topic.getBytes(ZMQ.CHARSET));
     }
 
     public void unsubscribe(byte[] topic)
@@ -141,7 +139,7 @@ public class ZSocket implements AutoCloseable
 
     public void unsubscribe(String topic)
     {
-        setOption(ZMQ.ZMQ_UNSUBSCRIBE, topic.getBytes(UTF8));
+        setOption(ZMQ.ZMQ_UNSUBSCRIBE, topic.getBytes(ZMQ.CHARSET));
     }
 
     public int send(byte[] b)
@@ -198,7 +196,7 @@ public class ZSocket implements AutoCloseable
 
     public int sendStringUtf8(String str, int flags)
     {
-        final byte[] b = str.getBytes(UTF8);
+        final byte[] b = str.getBytes(ZMQ.CHARSET);
         return send(b, flags);
     }
 
@@ -224,7 +222,7 @@ public class ZSocket implements AutoCloseable
     public String receiveStringUtf8(int flags)
     {
         final byte[] b = receive(flags);
-        return new String(b, UTF8);
+        return new String(b, ZMQ.CHARSET);
     }
 
     private void mayRaise()

--- a/src/main/java/zmq/ZMQ.java
+++ b/src/main/java/zmq/ZMQ.java
@@ -9,6 +9,7 @@ import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
@@ -193,7 +194,7 @@ public class ZMQ
 
     public static final byte[] SUBSCRIPTION_ALL = new byte[0];
 
-    public static final Charset CHARSET = Charset.forName("UTF-8");
+    public static final Charset CHARSET = StandardCharsets.UTF_8;
 
     public static final byte[] PROXY_PAUSE     = "PAUSE".getBytes(ZMQ.CHARSET);
     public static final byte[] PROXY_RESUME    = "RESUME".getBytes(ZMQ.CHARSET);


### PR DESCRIPTION
Since java 1.7, Charset.forName is clunky for a few standards charsets
like UTF-8. This patch uses StandardCharsets.UTF_8 instead and reuse ZMQ.CHARSET.