### PR TITLE
Removed the tag field in zmq.Ctx and zmq.SocketBase

### DIFF
--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -553,7 +553,7 @@ public class ZMQ
          */
         public boolean isTerminated()
         {
-            return !ctx.checkTag();
+            return !ctx.isActive();
         }
 
         /**

--- a/src/main/java/zmq/Ctx.java
+++ b/src/main/java/zmq/Ctx.java
@@ -70,7 +70,7 @@ public class Ctx
     }
 
     //  Used to check whether the object is a context.
-    private int tag;
+    private boolean active;
 
     //  Sockets belonging to this context. We need the list so that
     //  we can notify the sockets when zmq_term() is called. The sockets
@@ -146,7 +146,7 @@ public class Ctx
 
     public Ctx()
     {
-        tag = 0xabadcafe;
+        active = true;
         terminating = false;
         reaper = null;
         slotCount = 0;
@@ -202,15 +202,25 @@ public class Ctx
         //  corresponding io_thread/socket objects.
         termMailbox.close();
 
-        tag = 0xdeadbeef;
+        active = false;
     }
 
-    //  Returns false if object is not a context.
-    //
-    //  This will also return false if terminate() has been called.
+    /**
+     * @return false if {@link #terminate()}terminate() has been called.
+     */
+    public boolean isActive()
+    {
+        return active;
+    }
+
+    /**
+     * @return false if {@link #terminate()}terminate() has been called.
+     * @deprecated use {@link #isActive()} instead
+     */
+    @Deprecated
     public boolean checkTag()
     {
-        return tag == 0xabadcafe;
+        return active;
     }
 
     //  This function is called when user invokes zmq_term. If there are
@@ -711,7 +721,7 @@ public class Ctx
         // in waiting_for_delimiter state, which means no more writes can be done
         // and the identity write fails and causes an assert. Check if the socket
         // is open before sending.
-        if (pendingConnection.endpoint.options.recvIdentity && pendingConnection.endpoint.socket.checkTag()) {
+        if (pendingConnection.endpoint.options.recvIdentity && pendingConnection.endpoint.socket.isActive()) {
             Msg id = new Msg(bindOptions.identitySize);
             id.put(bindOptions.identity, 0, bindOptions.identitySize);
             id.setFlags(Msg.IDENTITY);

--- a/src/main/java/zmq/SocketBase.java
+++ b/src/main/java/zmq/SocketBase.java
@@ -53,7 +53,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
     private final MultiMap<String, Pipe> inprocs;
 
     //  Used to check whether the object is a socket.
-    private int tag;
+    private boolean active;
 
     //  If true, associated context was already terminated.
     private boolean ctxTerminated;
@@ -99,7 +99,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
     protected SocketBase(Ctx parent, int tid, int sid)
     {
         super(parent, tid);
-        tag = 0xbaddecaf;
+        active = true;
         ctxTerminated = false;
         destroyed = false;
         lastTsc = 0;
@@ -125,10 +125,12 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
 
     protected abstract void xpipeTerminated(Pipe pipe);
 
-    //  Returns false if object is not a socket.
-    final boolean checkTag()
+    /**
+     * @return false if object is not a socket.
+     */
+    boolean isActive()
     {
-        return tag == 0xbaddecaf;
+        return active;
     }
 
     @Override
@@ -861,7 +863,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
     public final void close()
     {
         //  Mark the socket as dead
-        tag = 0xdeadbeef;
+        active = false;
 
         //  Transfer the ownership of the socket from this application thread
         //  to the reaper thread which will take care of the rest of shutdown

--- a/src/main/java/zmq/ZMQ.java
+++ b/src/main/java/zmq/ZMQ.java
@@ -285,7 +285,7 @@ public class ZMQ
 
     private static void checkContext(Ctx ctx)
     {
-        if (ctx == null || !ctx.checkTag()) {
+        if (ctx == null || !ctx.isActive()) {
             throw new IllegalStateException();
         }
     }
@@ -331,7 +331,7 @@ public class ZMQ
 
     private static void checkSocket(SocketBase s)
     {
-        if (s == null || !s.checkTag()) {
+        if (s == null || !s.isActive()) {
             throw new IllegalStateException();
         }
     }


### PR DESCRIPTION
It's should be a boolean and it's really a flag that they object is active instead.