### PR TITLE
custom decoder check was invalid

### DIFF
--- a/src/main/java/zmq/ZError.java
+++ b/src/main/java/zmq/ZError.java
@@ -29,6 +29,16 @@ public class ZError
         {
             super(cause);
         }
+
+        public InstantiationException(String message, Throwable cause)
+        {
+            super(message, cause);
+        }
+
+        public InstantiationException(String message)
+        {
+            super(message);
+        }
     }
 
     public static class IOException extends RuntimeException

--- a/src/test/java/zmq/io/coder/CustomEncoderTest.java
+++ b/src/test/java/zmq/io/coder/CustomEncoderTest.java
@@ -12,6 +12,7 @@ import zmq.Ctx;
 import zmq.Helper;
 import zmq.Msg;
 import zmq.SocketBase;
+import zmq.ZError;
 import zmq.ZMQ;
 import zmq.util.Errno;
 import zmq.util.ValueReference;
@@ -122,17 +123,18 @@ public class CustomEncoderTest
     }
 
     @SuppressWarnings("deprecation")
-    @Test
+    @Test(expected = ZError.InstantiationException.class)
     public void testAssignWrongCustomEncoder()
     {
         Ctx ctx = ZMQ.createContext();
-
         SocketBase socket = ctx.createSocket(ZMQ.ZMQ_PAIR);
 
-        boolean rc = socket.setSocketOpt(ZMQ.ZMQ_ENCODER, WrongEncoder.class);
-        assertThat(rc, is(false));
-
-        ZMQ.close(socket);
-        ZMQ.term(ctx);
+        try {
+            socket.setSocketOpt(ZMQ.ZMQ_ENCODER, WrongEncoder.class);
+        }
+        finally {
+            ZMQ.close(socket);
+            ZMQ.term(ctx);
+        }
     }
 }


### PR DESCRIPTION
All the check were done using assert, that are disable during runtime,
make the whole method useless. It was printing result to stdout, this is
bad practice. It now use ZError.InstantiationException. The check method
name is more explicit too.
The CustomDecoderTest is updated, and warning removed, because it used
deprecated methods.
It also add a case where ZError.InstantiationException better match the
source exception.