### PR TITLE
in zmq.Mailbox, a call to Signaler.recv could set errno to EINTR

### DIFF
--- a/src/main/java/zmq/Mailbox.java
+++ b/src/main/java/zmq/Mailbox.java
@@ -95,6 +95,9 @@ public final class Mailbox implements Closeable
 
         //  Receive the signal.
         signaler.recv();
+        if (errno.get() == ZError.EINTR) {
+            return null;
+        }
 
         //  Switch into active state.
         active = true;


### PR DESCRIPTION
This was not checked, cpipe.read will return null, active will be set.
I'm not sure that is a an expected state, and the assert make my tests fails.