### PR TITLE
Define a common parent class for all ZMQ exceptions

### DIFF
--- a/src/main/java/org/zeromq/UncheckedZMQException.java
+++ b/src/main/java/org/zeromq/UncheckedZMQException.java
@@ -1,0 +1,24 @@
+package org.zeromq;
+
+public abstract class UncheckedZMQException extends RuntimeException
+{
+    public UncheckedZMQException()
+    {
+        super();
+    }
+
+    public UncheckedZMQException(String message)
+    {
+        super(message);
+    }
+
+    public UncheckedZMQException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public UncheckedZMQException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/zeromq/ZMQException.java
+++ b/src/main/java/org/zeromq/ZMQException.java
@@ -2,7 +2,7 @@ package org.zeromq;
 
 import zmq.ZError;
 
-public class ZMQException extends RuntimeException
+public class ZMQException extends UncheckedZMQException
 {
     private static final long serialVersionUID = -978820750094924644L;
 

--- a/src/main/java/zmq/ZError.java
+++ b/src/main/java/zmq/ZError.java
@@ -4,6 +4,7 @@ import java.net.SocketException;
 import java.nio.channels.ClosedChannelException;
 
 import org.zeromq.ZMQ.Error;
+import org.zeromq.UncheckedZMQException;
 
 public class ZError
 {
@@ -11,7 +12,7 @@ public class ZError
     {
     }
 
-    public static class CtxTerminatedException extends RuntimeException
+    public static class CtxTerminatedException extends UncheckedZMQException
     {
         private static final long serialVersionUID = -4404921838608052956L;
 
@@ -21,7 +22,7 @@ public class ZError
         }
     }
 
-    public static class InstantiationException extends RuntimeException
+    public static class InstantiationException extends UncheckedZMQException
     {
         private static final long serialVersionUID = -4404921838608052955L;
 
@@ -41,7 +42,7 @@ public class ZError
         }
     }
 
-    public static class IOException extends RuntimeException
+    public static class IOException extends UncheckedZMQException
     {
         private static final long serialVersionUID = 9202470691157986262L;
 


### PR DESCRIPTION
All exceptions from jeromq are unchecked exception, it's not possible which one will be thrown but a method. So I have all other my code catches like:

```java
catch (ZError.IOException | ZError.CtxTerminatedException | ZError.InstantiationException | ZMQException ex)
```

Having a single exception catched will make code more readable and less error-prone. It will also make possible for jeromq to add exception.

I also wrote some code to transform jeromq's unchecked exception in checkedexception, it make exception handling more robust I think, I don't know if you find it intersting:

```java
import java.io.IOException;
import java.net.SocketException;
import java.nio.channels.ClosedByInterruptException;
import java.nio.channels.ClosedChannelException;

import org.zeromq.ZMQ;
import org.zeromq.ZMQ.Socket;
import org.zeromq.ZMQException;

import zmq.ZError;

public class ZMQCheckedException extends Exception {

    private final ZMQ.Error error;

    /**
     * Transform an unchecked ZMQ exception in checked exception. If it's a real runtime exception, it's not transformed
     * @param ex
     * @throws ZMQCheckedException
     */
    public static void raise(RuntimeException ex) throws ZMQCheckedException {
        ZMQCheckedException checked = new ZMQCheckedException(ex);
        throw checked;
    }

    public static void checkOption(boolean test, Socket s) throws ZMQCheckedException {
        if (! test) {
            throw new ZMQCheckedException(s.errno());
        }
    }

    public ZMQCheckedException(RuntimeException e) {
        super(e);
        if (e instanceof ZError.IOException) {
            IOException cause = (java.io.IOException) e.getCause();
            error = ZMQ.Error.findByCode(exccode(cause));
        } else if (e instanceof ZError.CtxTerminatedException) {
            error = ZMQ.Error.ETERM;
        } else if (e instanceof ZError.InstantiationException) {
            throw e;
        } else if (e instanceof ZMQException) {
            error = ZMQ.Error.findByCode(((ZMQException)e).getErrorCode());
        } else {
            throw e;
        }
        setStackTrace(e.getStackTrace());
    }

    public ZMQCheckedException(int error) {
        this.error = ZMQ.Error.findByCode(error);
    }

    private static int exccode(java.io.IOException e) {
        if (e instanceof SocketException) {
            return ZError.ESOCKET;
        } else if (e instanceof ClosedByInterruptException) {
            return ZError.EINTR;
        } else if (e instanceof ClosedChannelException) {
            return ZError.ENOTCONN;
        } else {
            return ZError.EIOEXC;
        }
    }

    public ZMQ.Error getError() {
        return error;
    }

    @Override
    public String getMessage() {
        return error.getMessage();
    }

}
```