### PR TITLE
Improving some tests reliability

### DIFF
--- a/src/test/java/org/zeromq/TestZContext.java
+++ b/src/test/java/org/zeromq/TestZContext.java
@@ -9,7 +9,7 @@ import org.zeromq.ZMQ.Socket;
 
 public class TestZContext
 {
-    @Test
+    @Test(timeout = 5000)
     public void testZContext()
     {
         ZContext ctx = new ZContext();
@@ -22,7 +22,7 @@ public class TestZContext
         assertThat(ctx.getSockets().isEmpty(), is(true));
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testZContextSocketCloseBeforeContextClose()
     {
         ZContext ctx = new ZContext();
@@ -33,7 +33,7 @@ public class TestZContext
         ctx.close();
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testZContextLinger()
     {
         ZContext ctx = new ZContext();
@@ -47,7 +47,7 @@ public class TestZContext
         ctx.close();
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testConstruction()
     {
         ZContext ctx = new ZContext();
@@ -60,7 +60,7 @@ public class TestZContext
     }
 
     @SuppressWarnings("deprecation")
-    @Test
+    @Test(timeout = 5000)
     public void testDestruction()
     {
         ZContext ctx = new ZContext();
@@ -78,7 +78,7 @@ public class TestZContext
         assertThat(ctx1.getContext(), notNullValue());
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testAddingSockets() throws ZMQException
     {
         ZContext ctx = new ZContext();
@@ -96,7 +96,7 @@ public class TestZContext
         }
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testRemovingSockets() throws ZMQException
     {
         ZContext ctx = new ZContext();
@@ -114,7 +114,7 @@ public class TestZContext
     }
 
     @SuppressWarnings("deprecation")
-    @Test
+    @Test(timeout = 5000)
     public void testShadow()
     {
         ZContext ctx = new ZContext();
@@ -134,7 +134,7 @@ public class TestZContext
         ctx.close();
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testSeveralPendingInprocSocketsAreClosedIssue595()
     {
         ZContext ctx = new ZContext();

--- a/src/test/java/zmq/ImmediateTest.java
+++ b/src/test/java/zmq/ImmediateTest.java
@@ -151,7 +151,7 @@ public class ImmediateTest
         ZMQ.term(context);
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testImmediateFalseWithBrokenConnection() throws Exception
     {
         System.out.print("Immediate = false with broken connection");
@@ -199,14 +199,12 @@ public class ImmediateTest
         ZMQ.close(backend);
         System.out.print(".");
 
-        //  Give time to process disconnect
-        //  There's no way to do this except with a sleep
-        ZMQ.sleep(2);
-
         System.out.print("Message send fail");
-        // Send a message, should fail
-        sent = ZMQ.send(frontend, "Hello", ZMQ.ZMQ_DONTWAIT);
-        assertThat(sent, is(-1));
+        //  Send a message, should fail
+        //  There's no way to do this except with a sleep and a loop
+        while (ZMQ.send(frontend, "Hello", ZMQ.ZMQ_DONTWAIT) != -1) {
+            ZMQ.sleep(2);
+        }
 
         //  Recreate backend socket
         backend = ZMQ.socket(context, ZMQ.ZMQ_DEALER);

--- a/src/test/java/zmq/TestConnectDelay.java
+++ b/src/test/java/zmq/TestConnectDelay.java
@@ -149,7 +149,7 @@ public class TestConnectDelay
         ZMQ.term(context);
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testConnectDelay3() throws Exception
     {
         System.out.print("Scenario 3");
@@ -197,14 +197,12 @@ public class TestConnectDelay
         ZMQ.close(backend);
         System.out.print(".");
 
-        //  Give time to process disconnect
-        //  There's no way to do this except with a sleep
-        ZMQ.sleep(2);
-
         System.out.print("Message send fail");
-        // Send a message, should fail
-        sent = ZMQ.send(frontend, "Hello", ZMQ.ZMQ_DONTWAIT);
-        assertThat(sent, is(-1));
+        //  Send a message, should fail
+        //  There's no way to do this except with a sleep and a loop
+        while (ZMQ.send(frontend, "Hello", ZMQ.ZMQ_DONTWAIT) != -1) {
+            ZMQ.sleep(2);
+        }
 
         //  Recreate backend socket
         backend = ZMQ.socket(context, ZMQ.ZMQ_DEALER);

--- a/src/test/java/zmq/TestTermEndpoint.java
+++ b/src/test/java/zmq/TestTermEndpoint.java
@@ -23,7 +23,7 @@ public class TestTermEndpoint
         return "tcp://127.0.0.1:" + port;
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testUnbindWildcard()
     {
         String ep = endpointWildcard();
@@ -52,12 +52,11 @@ public class TestTermEndpoint
         rc = ZMQ.unbind(push, ep);
         assertThat(rc, is(true));
 
-        // Let events some time
-        ZMQ.sleep(1);
-
         //  Check that sending would block (there's no outbound connection).
-        r = ZMQ.send(push, "ABC", ZMQ.ZMQ_DONTWAIT);
-        assertThat(r, is(-1));
+        //  There's no way to do this except with a sleep and a loop
+        while (ZMQ.send(push, "ABC", ZMQ.ZMQ_DONTWAIT) != -1) {
+            ZMQ.sleep(2);
+        }
 
         //  Clean up.
         ZMQ.close(pull);
@@ -65,7 +64,7 @@ public class TestTermEndpoint
         ZMQ.term(ctx);
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testDisconnectWildcard()
     {
         String ep = endpointWildcard();
@@ -95,12 +94,11 @@ public class TestTermEndpoint
         rc = ZMQ.disconnect(push, ep);
         assertThat(rc, is(true));
 
-        // Let events some time
-        ZMQ.sleep(1);
-
         //  Check that sending would block (there's no outbound connection).
-        r = ZMQ.send(push, "ABC", ZMQ.ZMQ_DONTWAIT);
-        assertThat(r, is(-1));
+        //  There's no way to do this except with a sleep and a loop
+        while (ZMQ.send(push, "ABC", ZMQ.ZMQ_DONTWAIT) != -1) {
+            ZMQ.sleep(2);
+        }
 
         //  Clean up.
         ZMQ.close(pull);
@@ -153,7 +151,7 @@ public class TestTermEndpoint
         ZMQ.term(ctx);
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testUnbind() throws Exception
     {
         Ctx ctx = ZMQ.init(1);
@@ -186,12 +184,11 @@ public class TestTermEndpoint
         rc = ZMQ.unbind(push, ep);
         assertThat(rc, is(true));
 
-        // Let events some time
-        ZMQ.sleep(1);
-
         //  Check that sending would block (there's no outbound connection).
-        r = ZMQ.send(push, "ABC", ZMQ.ZMQ_DONTWAIT);
-        assertThat(r, is(-1));
+        //  There's no way to do this except with a sleep and a loop
+        while (ZMQ.send(push, "ABC", ZMQ.ZMQ_DONTWAIT) != -1) {
+            ZMQ.sleep(2);
+        }
 
         //  Clean up.
         ZMQ.close(pull);
@@ -199,7 +196,7 @@ public class TestTermEndpoint
         ZMQ.term(ctx);
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testDisconnect() throws Exception
     {
         Ctx ctx = ZMQ.init(1);
@@ -232,12 +229,11 @@ public class TestTermEndpoint
         rc = ZMQ.disconnect(push, ep);
         assertThat(rc, is(true));
 
-        // Let events some time
-        ZMQ.sleep(1);
-
         //  Check that sending would block (there's no outbound connection).
-        r = ZMQ.send(push, "ABC", ZMQ.ZMQ_DONTWAIT);
-        assertThat(r, is(-1));
+        //  There's no way to do this except with a sleep and a loop
+        while (ZMQ.send(push, "ABC", ZMQ.ZMQ_DONTWAIT) != -1) {
+            ZMQ.sleep(2);
+        }
 
         //  Clean up.
         ZMQ.close(pull);


### PR DESCRIPTION
The following tests were failing randomly:
- TestConnectDelay
- ImmediateTest
- test that inherit from TestTermEndpoint
- TestZContext could randomly hang, at least it will timeout
