### PR TITLE
Remove unreliable test cases about resolving supposedly invalid addresses

### DIFF
--- a/src/test/java/zmq/io/net/TestAddress.java
+++ b/src/test/java/zmq/io/net/TestAddress.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
-import org.zeromq.ZMQException;
 
 public class TestAddress
 {
@@ -24,11 +23,5 @@ public class TestAddress
         addr.resolve(false);
         String resolved = addr.toString();
         assertTrue(resolved.matches("tcp://\\d+\\.\\d+\\.\\d+\\.\\d+:90"));
-    }
-
-    @Test(expected = ZMQException.class)
-    public void testInvalid()
-    {
-        new Address("tcp", "ggglocalhostxxx:90").resolve(false);
     }
 }

--- a/src/test/java/zmq/io/net/tcp/TcpAddressTest.java
+++ b/src/test/java/zmq/io/net/tcp/TcpAddressTest.java
@@ -97,21 +97,6 @@ public class TcpAddressTest
     }
 
     @Test
-    public void testBad()
-    {
-        try {
-            Address addr = new Address(NetProtocol.tcp.name(), "lclhost.:80");
-            addr.resolve(true);
-            addr.resolved();
-            Assert.fail();
-        }
-        catch (ZMQException e) {
-            Assert.assertEquals(ZError.EADDRNOTAVAIL, e.getErrorCode());
-            Assert.assertEquals(e.getCause().getMessage(), e.getMessage());
-        }
-    }
-
-    @Test
     public void testUnspecifiedIPv6DoubleColon() throws IOException
     {
         int port = Utils.findOpenPort();


### PR DESCRIPTION
As I noted in https://github.com/zeromq/jeromq/issues/704#issuecomment-479505302, these tests are failing on my machine, as presumably my ISP provides a fallback IP when resolving nonexistent addresses.

Since we can't rely on the address resolution available in the environment used to run the tests, I don't think we can really test the "sad path" of attempting to resolve a supposedly invalid address. So, we should just remove these tests, at least for now, to unblock releasing JeroMQ 0.5.1. (see #704)