### PR TITLE
Improve sad path address resolution tests

### DIFF
--- a/src/test/java/zmq/io/net/TestAddress.java
+++ b/src/test/java/zmq/io/net/TestAddress.java
@@ -29,6 +29,6 @@ public class TestAddress
     @Test(expected = ZMQException.class)
     public void testInvalid()
     {
-        new Address("tcp", "ggglocalhostxxx:90").resolve(false);
+        new Address("tcp", "ggglocalhostxxx.google.com:80").resolve(false);
     }
 }

--- a/src/test/java/zmq/io/net/TestAddress.java
+++ b/src/test/java/zmq/io/net/TestAddress.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+import org.zeromq.ZMQException;
 
 public class TestAddress
 {
@@ -23,5 +24,11 @@ public class TestAddress
         addr.resolve(false);
         String resolved = addr.toString();
         assertTrue(resolved.matches("tcp://\\d+\\.\\d+\\.\\d+\\.\\d+:90"));
+    }
+
+    @Test(expected = ZMQException.class)
+    public void testInvalid()
+    {
+        new Address("tcp", "ggglocalhostxxx:90").resolve(false);
     }
 }

--- a/src/test/java/zmq/io/net/tcp/TcpAddressTest.java
+++ b/src/test/java/zmq/io/net/tcp/TcpAddressTest.java
@@ -97,6 +97,21 @@ public class TcpAddressTest
     }
 
     @Test
+    public void testBad()
+    {
+        try {
+            Address addr = new Address(NetProtocol.tcp.name(), "lclhost.:80");
+            addr.resolve(true);
+            addr.resolved();
+            Assert.fail();
+        }
+        catch (ZMQException e) {
+            Assert.assertEquals(ZError.EADDRNOTAVAIL, e.getErrorCode());
+            Assert.assertEquals(e.getCause().getMessage(), e.getMessage());
+        }
+    }
+
+    @Test
     public void testUnspecifiedIPv6DoubleColon() throws IOException
     {
         int port = Utils.findOpenPort();

--- a/src/test/java/zmq/io/net/tcp/TcpAddressTest.java
+++ b/src/test/java/zmq/io/net/tcp/TcpAddressTest.java
@@ -100,7 +100,7 @@ public class TcpAddressTest
     public void testBad()
     {
         try {
-            Address addr = new Address(NetProtocol.tcp.name(), "lclhost.:80");
+            Address addr = new Address(NetProtocol.tcp.name(), "ggglocalhostxxx.google.com:80");
             addr.resolve(true);
             addr.resolved();
             Assert.fail();


### PR DESCRIPTION
This is a follow up to #706 based on @fbacchella 's comment on https://github.com/zeromq/jeromq/issues/704#issuecomment-479560401

I was able to get both of the problematic tests passing by using a known valid domain and known invalid subdomain. So, I think we can re-add the tests with this improvement.