### PR TITLE
Update release docs

### DIFF
--- a/doc/development/release.md
+++ b/doc/development/release.md
@@ -43,13 +43,13 @@ You are not required to sign SNAPSHOT builds. Issue the following
 command to deploy a SNAPSHOT.
 
 ```
-$ mvn deploy
+$ mvn clean deploy
 ```
 
 ## Release Commands
 
 ```
-$ mvn release:prepare
+$ mvn release:clean release:prepare
 ```
 
 You will be asked a series of questions regarding version numbers. It
@@ -74,29 +74,10 @@ To perform a release, issue the following command.
 $ mvn release:perform
 ```
 
-This will upload the artifacts to OSS Sonatype and will require you to sign the
-build. There is a list of known keys that have been used to sign tagged JeroMQ
-releases [here](public-keys.md).
+This will upload the artifacts to OSS Sonatype and release to Maven Central in
+one go, and will require you to sign the build. There is a list of known keys
+that have been used to sign tagged JeroMQ releases [here](public-keys.md).
 
-## Build Publishing
+# Making an Announcement on the ZeroMQ Mailing list when it has been successfully synced.
 
-Log into the OSS Nexus Repository located at: [OSS
-NEXUS](https://oss.sonatype.org/).
-
-Click `Staging Repositories` link located on the left
-navigation.
-
- (show picture)
-
-Locate the latest entry with the profile `org.zeromq`. Ensure it's
-from JeroMQ. In order to release the project to the Maven Central, you
-first must close the staging repository.
-
-(show picture)
-
-It will take a minute to reflect that it has been closed. Once you can
-see the status change, you may now queue the build to be mirrored to
-the Maven Central.
-
-Making an Announcement on the ZeroMQ Mailing list when it has been
-successfully synced.
+TODO: more info?

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,10 @@
         <version>2.5.3</version>
         <configuration>
           <tagNameFormat>v@{project.version}</tagNameFormat>
+          <autoVersionSubmodules>true</autoVersionSubmodules>
+          <useReleaseProfile>false</useReleaseProfile>
+          <releaseProfiles>release</releaseProfiles>
+          <goals>deploy</goals>
         </configuration>
       </plugin>
       <plugin>
@@ -282,7 +286,7 @@
       </build>
     </profile>
     <profile>
-      <id>release-sign-artifacts</id>
+      <id>release</id>
       <activation>
         <property>
           <name>performRelease</name>


### PR DESCRIPTION
I think I just succeeded in deploying JeroMQ 0.5.1 to OSSRH and releasing to Maven Central, all from the command line, guided by this [somewhat confusing release plugin documentation](https://central.sonatype.org/pages/apache-maven.html).

Hopefully we'll see version 0.5.1 show up [here](https://mvnrepository.com/artifact/org.zeromq/jeromq) within the next 10 hours or so.

This process has been a little bit confusing. I think I've correctly documented the process that I followed, but I'm only like 90% sure, so take it with a grain of salt.

Whenever we release the next version, I'll follow my own instructions here and fix anything that's wrong.