### PR TITLE
Speed up Travis build by caching Maven dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ matrix:
           - tools
           - platform-tools
 
+cache:
+  directories:
+    - $HOME/.m2
+
 install: mvn install --quiet -DskipTests=true -Dgpg.skip=true
 
 after_success:


### PR DESCRIPTION
This should make our Travis builds faster -- should be interesting to see by how much.