### PR TITLE
Problem: ZCert can only be saved on a file.

### DIFF
--- a/src/main/java/org/zeromq/ZCert.java
+++ b/src/main/java/org/zeromq/ZCert.java
@@ -2,6 +2,7 @@ package org.zeromq;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Writer;
 
 import org.zeromq.ZMQ.Curve.KeyPair;
 import org.zeromq.util.ZMetadata;
@@ -116,11 +117,29 @@ public class ZCert
     }
 
     /**
-     * Saves the public  key to a file.
+     * Saves the public key to a file.
+     * <p>
+     * <strong>This method will overwrite contents of existing file</strong>
      * @param filename the path of the file to save the certificate into.
+     * @return the saved file or null if dumped to the standard output
      * @throws IOException if unable to save the file.
      */
     public File savePublic(String filename) throws IOException
+    {
+        return publicConfig().save(filename);
+    }
+
+    /**
+     * Saves the public key to a writer.
+     * @param writer the writer to save the certificate into.
+     * @throws IOException if unable to dump the public configuration.
+     */
+    public void savePublic(Writer writer) throws IOException
+    {
+        publicConfig().save(writer);
+    }
+
+    private ZConfig publicConfig()
     {
         ZConfig conf = new ZConfig("root", null);
         add(metadata, conf);
@@ -129,15 +148,33 @@ public class ZCert
         conf.addComment("   of this file after exchange. Store public certificates in your home");
         conf.addComment("   directory, in the .curve subdirectory.");
         conf.putValue("/curve/public-key", publicTxt);
-        return conf.save(filename);
+        return conf;
     }
 
     /**
      * Saves the public and secret keys to a file.
+     * <p>
+     * <strong>This method will overwrite contents of existing file</strong>
      * @param filename the path of the file to save the certificate into.
+     * @return the saved file or null if dumped to the standard output
      * @throws IOException if unable to save the file.
      */
     public File saveSecret(String filename) throws IOException
+    {
+        return secretConfig().save(filename);
+    }
+
+    /**
+     * Saves the public and secret keys to a writer.
+     * @param writer the writer to save the certificate into.
+     * @throws IOException if unable to dump the configuration.
+     */
+    public void saveSecret(Writer writer) throws IOException
+    {
+        secretConfig().save(writer);
+    }
+
+    private ZConfig secretConfig()
     {
         ZConfig conf = new ZConfig("root", null);
         add(metadata, conf);
@@ -145,6 +182,6 @@ public class ZCert
         conf.addComment("   DO NOT PROVIDE THIS FILE TO OTHER USERS nor change its permissions.");
         conf.putValue("/curve/public-key", publicTxt);
         conf.putValue("/curve/secret-key", secretTxt);
-        return conf.save(filename);
+        return conf;
     }
 }

--- a/src/main/java/org/zeromq/ZConfig.java
+++ b/src/main/java/org/zeromq/ZConfig.java
@@ -210,16 +210,20 @@ public class ZConfig
         }
     }
 
+    /**
+     * Saves the configuration to a file.
+     * <p>
+     * <strong>This method will overwrite contents of existing file</strong>
+     * @param filename the path of the file to save the configuration into, or "-" to dump it to standard output
+     * @return the saved file or null if dumped to the standard output
+     * @throws IOException if unable to save the file.
+     */
     public File save(String filename) throws IOException
     {
-        if (filename.equals("-")) {
+        if ("-".equals(filename)) {
             // print to console
-            Writer writer = new PrintWriter(System.out);
-            try {
+            try (Writer writer = new PrintWriter(System.out)) {
                 save(writer);
-            }
-            finally {
-                writer.close();
             }
             return null;
         }


### PR DESCRIPTION
Solution: provide a save method with a writer in input.

Fixes #690