### PR TITLE
Create a new constructor accepting SocketType enum

### DIFF
--- a/src/main/java/org/zeromq/ZSocket.java
+++ b/src/main/java/org/zeromq/ZSocket.java
@@ -49,6 +49,18 @@ public class ZSocket implements AutoCloseable
      *
      * @return the socket's type.
      */
+    public SocketType getSocketType()
+    {
+        return SocketType.type(getType());
+    }
+
+    /**
+     * Retrieve the socket type for the current 'socket'. The socket type is specified at socket
+     * creation time and cannot be modified afterwards.
+     *
+     * @see ZSocket#getSocketType()
+     * @return the socket's type.
+     */
     public int getType()
     {
         return (int) getOption(ZMQ.ZMQ_TYPE);

--- a/src/main/java/org/zeromq/ZSocket.java
+++ b/src/main/java/org/zeromq/ZSocket.java
@@ -34,6 +34,16 @@ public class ZSocket implements AutoCloseable
     }
 
     /**
+     * Create a ZeroMQ socket
+     *
+     * @param socketType ZeroMQ Socket type
+     */
+    public ZSocket(final SocketType socketType)
+    {
+        this(socketType.type());
+    }
+
+    /**
      * Retrieve the socket type for the current 'socket'. The socket type is specified at socket
      * creation time and cannot be modified afterwards.
      *

--- a/src/test/java/org/zeromq/TestPushPullThreadedTcp.java
+++ b/src/test/java/org/zeromq/TestPushPullThreadedTcp.java
@@ -149,8 +149,8 @@ public class TestPushPullThreadedTcp
     public void testIssue338() throws InterruptedException, IOException
     {
         try (
-             final ZSocket pull = new ZSocket(ZMQ.PULL);
-             final ZSocket push = new ZSocket(ZMQ.PUSH)) {
+             final ZSocket pull = new ZSocket(SocketType.PULL);
+             final ZSocket push = new ZSocket(SocketType.PUSH)) {
             final String host = "tcp://localhost:" + Utils.findOpenPort();
             pull.bind(host);
             push.connect(host);

--- a/src/test/java/org/zeromq/ZSocketTest.java
+++ b/src/test/java/org/zeromq/ZSocketTest.java
@@ -14,8 +14,8 @@ public class ZSocketTest
         int port = Utils.findOpenPort();
 
         try (
-             final ZSocket pull = new ZSocket(ZMQ.PULL);
-             final ZSocket push = new ZSocket(ZMQ.PUSH)) {
+             final ZSocket pull = new ZSocket(SocketType.PULL);
+             final ZSocket push = new ZSocket(SocketType.PUSH)) {
             pull.bind("tcp://*:" + port);
             push.connect("tcp://127.0.0.1:" + port);
 
@@ -24,6 +24,10 @@ public class ZSocketTest
             final String actual = pull.receiveStringUtf8();
 
             assertEquals(expected, actual);
+            assertEquals(SocketType.PULL, pull.getSocketType());
+            assertEquals(ZMQ.PULL, pull.getType());
+            assertEquals(SocketType.PUSH, push.getSocketType());
+            assertEquals(ZMQ.PUSH, push.getType());
         }
     }
 }


### PR DESCRIPTION
Problem: lack of constructor with SocketType enum in ZSocket
Solution: create a new constructor accepting SocketType enum

 it's an improvement on ZSocket API regarding #394.