### PR TITLE
Fix #638: remove data field from zmq.Msg

### DIFF
--- a/src/main/java/zmq/Msg.java
+++ b/src/main/java/zmq/Msg.java
@@ -228,7 +228,8 @@ public class Msg
             if (buf.arrayOffset() == 0 && array.length == size) {
                 // If the backing array is exactly what we need, return it without copy.
                 return array;
-            } else {
+            }
+            else {
                 // Else use it to make an efficient copy.
                 return Arrays.copyOfRange(array, offset, offset + size);
             }
@@ -355,7 +356,8 @@ public class Msg
 
         if (buf.hasArray()) {
             System.arraycopy(buf.array(), buf.arrayOffset() + index, dst, off, count);
-        } else {
+        }
+        else {
             ByteBuffer dup = buf.duplicate();
             dup.position(index);
             dup.get(dst, off, count);

--- a/src/main/java/zmq/Msg.java
+++ b/src/main/java/zmq/Msg.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.SocketChannel;
+import java.util.Arrays;
 
 import zmq.io.Metadata;
 import zmq.util.Utils;
@@ -104,7 +105,6 @@ public class Msg
     private SocketChannel fileDesc;
 
     private final int        size;
-    private byte[]           data;
     private final ByteBuffer buf;
     // keep track of relative write position
     private int writeIndex = 0;
@@ -122,7 +122,6 @@ public class Msg
         this.flags = 0;
         this.size = capacity;
         this.buf = ByteBuffer.wrap(new byte[capacity]).order(ByteOrder.BIG_ENDIAN);
-        this.data = buf.array();
     }
 
     public Msg(byte[] src)
@@ -133,7 +132,6 @@ public class Msg
         this.type = Type.DATA;
         this.flags = 0;
         this.size = src.length;
-        this.data = src;
         this.buf = ByteBuffer.wrap(src).order(ByteOrder.BIG_ENDIAN);
     }
 
@@ -145,12 +143,6 @@ public class Msg
         this.type = Type.DATA;
         this.flags = 0;
         this.buf = src.duplicate();
-        if (buf.hasArray() && buf.position() == 0 && buf.limit() == buf.capacity()) {
-            this.data = buf.array();
-        }
-        else {
-            this.data = null;
-        }
         this.size = buf.remaining();
     }
 
@@ -163,10 +155,6 @@ public class Msg
         this.flags = m.flags;
         this.size = m.size;
         this.buf = m.buf != null ? m.buf.duplicate() : null;
-        if (m.data != null) {
-            this.data = new byte[this.size];
-            System.arraycopy(m.data, 0, this.data, 0, m.size);
-        }
     }
 
     private Msg(Msg src, ByteArrayOutputStream out)
@@ -223,13 +211,35 @@ public class Msg
         flags = 0;
     }
 
+    /**
+     * Returns the message data.
+     *
+     * If possible, a reference to the data is returned, without copy.
+     * Otherwise a new byte array will be allocated and the data will be copied.
+     *
+     * @return the message data.
+     */
     public byte[] data()
     {
-        if (data == null) {
-            data = new byte[buf.remaining()];
-            buf.duplicate().get(data);
+        if (buf.hasArray()) {
+            byte[] array = buf.array();
+            int offset = buf.arrayOffset();
+
+            if (buf.arrayOffset() == 0 && array.length == size) {
+                // If the backing array is exactly what we need, return it without copy.
+                return array;
+            } else {
+                // Else use it to make an efficient copy.
+                return Arrays.copyOfRange(array, offset, offset + size);
+            }
         }
-        return data;
+
+        // No backing array -> use ByteBuffer#get().
+        byte[] array = new byte[size];
+        ByteBuffer dup = buf.duplicate();
+        dup.position(0);
+        dup.get(array);
+        return array;
     }
 
     public ByteBuffer buf()
@@ -342,13 +352,13 @@ public class Msg
     public int getBytes(int index, byte[] dst, int off, int len)
     {
         int count = Math.min(len, size - index);
-        if (data == null) {
+
+        if (buf.hasArray()) {
+            System.arraycopy(buf.array(), buf.arrayOffset() + index, dst, off, count);
+        } else {
             ByteBuffer dup = buf.duplicate();
             dup.position(index);
             dup.get(dst, off, count);
-        }
-        else {
-            System.arraycopy(data, index, dst, off, count);
         }
 
         return count;

--- a/src/test/java/zmq/TestMsg.java
+++ b/src/test/java/zmq/TestMsg.java
@@ -1,6 +1,7 @@
 package zmq;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 
 import java.nio.ByteBuffer;
@@ -142,5 +143,84 @@ public class TestMsg
         buffer.position(0);
         final Msg msg = new Msg(buffer);
         return msg;
+    }
+
+    // Check that data returned by Msg#getBytes(int, byte[], int, int) and Msg#get(int) are
+    // consistent.
+    @Test
+    public void testGetBytesSameAsGet() {
+        Msg msg1 = new Msg(new byte[] {42});
+        Msg msg2 = new Msg(msg1);
+
+        msg2.put(5);
+
+        byte firstByte = msg2.get(0);
+
+        byte[] data = new byte[1];
+        msg2.getBytes(0, data, 0, 1);
+
+        assertThat(data[0], is(firstByte));
+    }
+
+    // Check that Msg#data() is correct when the backing array has an offset.
+    @Test
+    public void testDataNonZeroOffset() {
+        byte[] data = new byte[]{10, 11, 12};
+
+        ByteBuffer buffer = ByteBuffer.wrap(data, 1, 2).slice();
+        Msg msg = new Msg(buffer);
+
+        assertThat(msg.data(), is(new byte[]{11, 12}));
+    }
+
+    // Check that Msg#data() is correct when the end of the backing array is not used by the buffer.
+    @Test
+    public void testDataArrayExtendsFurther() {
+        byte[] data = new byte[]{10, 11, 12};
+
+        ByteBuffer buffer = ByteBuffer.wrap(data, 0, 2).slice();
+        Msg msg = new Msg(buffer);
+
+        assertThat(msg.data(), is(new byte[]{10, 11}));
+    }
+
+    // Check that data returned by Msg#getBytes(int, byte[], int, int) is correct when the backing
+    // array has an offset.
+    @Test
+    public void testGetBytesNonZeroOffset() {
+        byte[] data = new byte[]{10, 11, 12};
+
+        ByteBuffer buffer = ByteBuffer.wrap(data, 1, 2).slice();
+        Msg msg = new Msg(buffer);
+
+        byte[] gotData = new byte[2];
+        msg.getBytes(0, gotData, 0, 2);
+
+        assertThat(msg.data(), is(new byte[]{11, 12}));
+    }
+
+    // Check that data returned by Msg#getBytes(int, byte[], int, int) is correct when the end of
+    // the backing array is not used by the buffer.
+    @Test
+    public void testGetBytesArrayExtendsFurther() {
+        byte[] data = new byte[]{10, 11, 12};
+
+        ByteBuffer buffer = ByteBuffer.wrap(data, 0, 2).slice();
+        Msg msg = new Msg(buffer);
+
+        byte[] gotData = new byte[2];
+        msg.getBytes(0, gotData, 0, 2);
+
+        assertThat(msg.data(), is(new byte[]{10, 11}));
+    }
+
+    // Check that Msg#data() doesn't make unnecessary copies.
+    @Test
+    public void testDataNoCopy() {
+        byte[] data = new byte[]{10, 11, 12};
+
+        Msg msg = new Msg(data);
+
+        assertThat(msg.data(), sameInstance(data));
     }
 }

--- a/src/test/java/zmq/TestMsg.java
+++ b/src/test/java/zmq/TestMsg.java
@@ -148,7 +148,8 @@ public class TestMsg
     // Check that data returned by Msg#getBytes(int, byte[], int, int) and Msg#get(int) are
     // consistent.
     @Test
-    public void testGetBytesSameAsGet() {
+    public void testGetBytesSameAsGet()
+    {
         Msg msg1 = new Msg(new byte[] {42});
         Msg msg2 = new Msg(msg1);
 
@@ -164,7 +165,8 @@ public class TestMsg
 
     // Check that Msg#data() is correct when the backing array has an offset.
     @Test
-    public void testDataNonZeroOffset() {
+    public void testDataNonZeroOffset()
+    {
         byte[] data = new byte[]{10, 11, 12};
 
         ByteBuffer buffer = ByteBuffer.wrap(data, 1, 2).slice();
@@ -175,7 +177,8 @@ public class TestMsg
 
     // Check that Msg#data() is correct when the end of the backing array is not used by the buffer.
     @Test
-    public void testDataArrayExtendsFurther() {
+    public void testDataArrayExtendsFurther()
+    {
         byte[] data = new byte[]{10, 11, 12};
 
         ByteBuffer buffer = ByteBuffer.wrap(data, 0, 2).slice();
@@ -187,7 +190,8 @@ public class TestMsg
     // Check that data returned by Msg#getBytes(int, byte[], int, int) is correct when the backing
     // array has an offset.
     @Test
-    public void testGetBytesNonZeroOffset() {
+    public void testGetBytesNonZeroOffset()
+    {
         byte[] data = new byte[]{10, 11, 12};
 
         ByteBuffer buffer = ByteBuffer.wrap(data, 1, 2).slice();
@@ -202,7 +206,8 @@ public class TestMsg
     // Check that data returned by Msg#getBytes(int, byte[], int, int) is correct when the end of
     // the backing array is not used by the buffer.
     @Test
-    public void testGetBytesArrayExtendsFurther() {
+    public void testGetBytesArrayExtendsFurther()
+    {
         byte[] data = new byte[]{10, 11, 12};
 
         ByteBuffer buffer = ByteBuffer.wrap(data, 0, 2).slice();
@@ -216,7 +221,8 @@ public class TestMsg
 
     // Check that Msg#data() doesn't make unnecessary copies.
     @Test
-    public void testDataNoCopy() {
+    public void testDataNoCopy()
+    {
         byte[] data = new byte[]{10, 11, 12};
 
         Msg msg = new Msg(data);


### PR DESCRIPTION
As discussed in https://github.com/zeromq/jeromq/issues/638#issuecomment-508792276 the bug of wrong buffers returned by `Msg#recv` can be fixed by removing the (mostly redundant) `data` field from the `Msg` class.

The bug was found with buffers allocated through `ByteBuffer.allocateDirect()` on Android, but the same problems occur with regular buffers obtained from `ByteBuffer#slice()` (any buffer that doesn't fully use its backing array can cause problem). The proposed change includes 5 tests that fail in the current version but are fixed here (the `slice()` method is used to emulate the Android buffer allocation).

This also fixes the bug where `Msg#get()` and `Msg#getBytes()` give inconsistent results (see https://github.com/zeromq/jeromq/issues/638#issuecomment-508792276 ).

Note that the `Msg(final Msg) m` constructor copies the ByteBuffer of the `m` instance without copying the underlying data (so both messages will share the same data). It seems strange to me, but maybe it is the desired behavior? (I didn't change it.)