### PR TITLE
Upgrade checkstyle dependencies to fix vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,12 +125,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
 		<dependencies>
 			<dependency>
 				<groupId>com.puppycrawl.tools</groupId>
 				<artifactId>checkstyle</artifactId>
-				<version>8.18</version>
+				<version>8.29</version>
 			</dependency>
 		</dependencies>
         <executions>


### PR DESCRIPTION
Source: https://snyk.io/vuln/SNYK-JAVA-COMPUPPYCRAWLTOOLS-543266

I found that the maven checkstyle plugin also needed to be upgraded from 3.0.0 => 3.1.0 because of an API incompatibility issue.

`mvn verify` completes successfully with this change.