### PR TITLE
Upgrade maven-javadoc-plugin; fix a few javadoc warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,13 +203,13 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.1.1</version>
           <configuration>
             <keywords>true</keywords>
             <source>1.8</source>
             <tags>
               <tag>
-                <name>apiNote</name>
+                <name>api.note</name>
                 <placement>a</placement>
                 <head>API Note</head>
               </tag>

--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -2207,7 +2207,7 @@ public class ZMQ
         /**
          * Set a custom {@link java.nio.channels.spi.SelectorProvider} chooser.
          *
-         * @param chooser, the custom chooser.
+         * @param chooser the custom chooser.
          * @return true if the option was set, otherwise false.
          */
         public boolean setSelectorChooser(SelectorProviderChooser chooser)
@@ -3334,7 +3334,7 @@ public class ZMQ
          * @param args    Arguments according to the picture
          * @return true when it has been queued on the socket and ØMQ has assumed responsibility for the message.
          * This does not indicate that the message has been transmitted to the network.
-         * @apiNote Does not change or take ownership of any arguments.
+         * @api.note Does not change or take ownership of any arguments.
          */
         @Draft
         public boolean sendBinaryPicture(String picture, Object... args)

--- a/src/main/java/org/zeromq/proto/ZPicture.java
+++ b/src/main/java/org/zeromq/proto/ZPicture.java
@@ -46,7 +46,7 @@ public class ZPicture
      * @param args    Arguments according to the picture
      * @return true when it has been queued on the socket and ØMQ has assumed responsibility for the message.
      * This does not indicate that the message has been transmitted to the network.
-     * @apiNote Does not change or take ownership of any arguments.
+     * @api.note Does not change or take ownership of any arguments.
      */
     @Draft
     public ZMsg msgBinaryPicture(String picture, Object... args)

--- a/src/main/java/zmq/io/net/tcp/TcpAddress.java
+++ b/src/main/java/zmq/io/net/tcp/TcpAddress.java
@@ -85,7 +85,7 @@ public class TcpAddress implements Address.IZAddress
      * @param name
      * @param ipv6
      * @param local ignored
-     * @return
+     * @return the resolved address
      * @see zmq.io.net.Address.IZAddress#resolve(java.lang.String, boolean, boolean)
      */
     @Override


### PR DESCRIPTION
As I was releasing 0.5.2, I noticed some javadoc warnings:

```
[INFO] Note: Custom tags that could override future standard tags:  @apiNote. To avoid potential overrides, use at least one period character (.) in custom tag names.
[INFO] 7 warnings
[INFO] [WARNING] Javadoc Warnings
[INFO] [WARNING] /home/dave/code/jeromq/target/checkout/src/main/java/org/zeromq/ZMQ.java:833: warning - Tag @link: can't find Socket(Context, SocketType) in org.zeromq.ZMQ.Socket
[INFO] [WARNING] /home/dave/code/jeromq/target/checkout/src/main/java/org/zeromq/ZMQ.java:2213: warning - @param argument "chooser," is not a parameter name.
[INFO] [WARNING] /home/dave/code/jeromq/target/checkout/src/main/java/org/zeromq/ZStar.java:169: warning - Tag @link: can't find create(ZContext, Socket, int, Star, Object...) in org.zeromq.ZStar.Fortune
[INFO] [WARNING] /home/dave/code/jeromq/target/checkout/src/main/java/org/zeromq/proto/ZPicture.java:183: warning - Tag @link: can't find sendBinaryPicture(Socket, String, Object...) in org.zeromq.proto.ZPicture
[INFO] [WARNING] /home/dave/code/jeromq/target/checkout/src/main/java/org/zeromq/proto/ZPicture.java:280: warning - Tag @link: can't find recvPicture(Socket, String) in org.zeromq.proto.ZPicture
[INFO] [WARNING] /home/dave/code/jeromq/target/checkout/src/main/java/org/zeromq/proto/ZPicture.java:370: warning - Tag @link: can't find sendPicture(Socket, String, Object...) in org.zeromq.proto.ZPicture
[INFO] [WARNING] /home/dave/code/jeromq/target/checkout/src/main/java/zmq/io/net/tcp/TcpAddress.java:92: warning - @return tag has no arguments.
```

This fixes a few of those.

I wasn't able to make sense of the `@link` warnings. I tried a bunch of different syntaxes, and nothing seems to get rid of the warning. I barely understand what I'm doing, so maybe someone else will have more luck. :)