### PR TITLE
problem: ZMQ_HEARTBEAT is not useful without sending an hello message

### DIFF
--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -2989,6 +2989,20 @@ public class ZMQ
         }
 
         /**
+         * When set, the socket will automatically send a hello message when a new connection is made or accepted.
+         * You may set this on DEALER or ROUTER sockets.
+         * The combination with ZMQ_HEARTBEAT_IVL is powerful and simplify protocols,
+         * as now heartbeat and sending the hello message can be left out of protocols and be handled by zeromq.
+         *
+         * @param helloMsg
+         * @return true if the option was set, otherwise false
+         */
+        public boolean setHelloMsg(byte[] helloMsg)
+        {
+            return setSocketOpt(zmq.ZMQ.ZMQ_HELLO_MSG, helloMsg);
+        }
+
+        /**
          * Bind to network interface. Start listening for new connections.
          *
          * @param addr the endpoint to bind to.

--- a/src/main/java/zmq/Ctx.java
+++ b/src/main/java/zmq/Ctx.java
@@ -729,6 +729,13 @@ public class Ctx
             assert (written);
             pendingConnection.bindPipe.flush();
         }
+
+        //  If set, send the hello msg of the peer to the local socket.
+        if (bindOptions.canSendHelloMsg && bindOptions.helloMsg != null) {
+            boolean written = pendingConnection.bindPipe.write(bindOptions.helloMsg);
+            assert (written);
+            pendingConnection.bindPipe.flush();
+        }
     }
 
     public Errno errno()

--- a/src/main/java/zmq/Options.java
+++ b/src/main/java/zmq/Options.java
@@ -166,6 +166,10 @@ public class Options
 
     public SelectorProviderChooser selectorChooser;
 
+    // Hello msg to send to peer upon connecting
+    public Msg helloMsg;
+    public boolean canSendHelloMsg;
+
     public final Errno errno = new Errno();
 
     public Options()
@@ -220,6 +224,9 @@ public class Options
         allocator = new MsgAllocatorThreshold(Config.MSG_ALLOCATION_HEAP_THRESHOLD.getValue());
 
         selectorChooser = null;
+
+        canSendHelloMsg = false;
+        helloMsg = null;
     }
 
     @SuppressWarnings("deprecation")
@@ -542,6 +549,21 @@ public class Options
                 return true;
             }
             return false;
+
+        case ZMQ.ZMQ_HELLO_MSG:
+            if (optval == null) {
+                helloMsg = null;
+            }
+            else {
+                byte[] bytes = parseBytes(option, optval);
+                if (bytes.length == 0) {
+                    helloMsg = null;
+                }
+                else {
+                    helloMsg = new Msg(Arrays.copyOf(bytes, bytes.length));
+                }
+            }
+            return true;
 
         default:
             throw new IllegalArgumentException("Unknown Option " + option);

--- a/src/main/java/zmq/SocketBase.java
+++ b/src/main/java/zmq/SocketBase.java
@@ -486,6 +486,13 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
                 assert (written);
                 pipes[0].flush();
 
+                //  If set, send the hello msg of the local socket to the peer.
+                if (options.canSendHelloMsg && options.helloMsg != null) {
+                    written = pipes[0].write(options.helloMsg);
+                    assert (written);
+                    pipes[0].flush();
+                }
+
                 pendConnection(addr, new Ctx.Endpoint(this, options), pipes);
             }
             else {
@@ -505,6 +512,20 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
                     id.put(peer.options.identity, 0, peer.options.identitySize);
                     id.setFlags(Msg.IDENTITY);
                     boolean written = pipes[1].write(id);
+                    assert (written);
+                    pipes[1].flush();
+                }
+
+                //  If set, send the hello msg of the local socket to the peer.
+                if (options.canSendHelloMsg && options.helloMsg != null) {
+                    boolean written = pipes[0].write(options.helloMsg);
+                    assert (written);
+                    pipes[0].flush();
+                }
+
+                //  If set, send the hello msg of the peer to the local socket.
+                if (peer.options.canSendHelloMsg && peer.options.helloMsg != null) {
+                    boolean written = pipes[1].write(peer.options.helloMsg);
                     assert (written);
                     pipes[1].flush();
                 }

--- a/src/main/java/zmq/ZMQ.java
+++ b/src/main/java/zmq/ZMQ.java
@@ -128,6 +128,7 @@ public class ZMQ
     public static final int ZMQ_XPUB_VERBOSER            = 78;
     @Deprecated
     public static final int ZMQ_XPUB_VERBOSE_UNSUBSCRIBE = 78;
+    public static final int ZMQ_HELLO_MSG                = 79;
 
     /* Custom options */
     @Deprecated

--- a/src/main/java/zmq/io/HelloMsgSession.java
+++ b/src/main/java/zmq/io/HelloMsgSession.java
@@ -1,0 +1,35 @@
+package zmq.io;
+
+import zmq.Msg;
+import zmq.Options;
+import zmq.SocketBase;
+import zmq.io.net.Address;
+
+public class HelloMsgSession extends SessionBase
+{
+    boolean newPipe;
+
+    public HelloMsgSession(IOThread ioThread, boolean connect, SocketBase socket, Options options, Address addr)
+    {
+        super(ioThread, connect, socket, options, addr);
+        newPipe = true;
+    }
+
+    @Override
+    protected Msg pullMsg()
+    {
+        if (newPipe) {
+            newPipe = false;
+            return options.helloMsg;
+        }
+
+        return super.pullMsg();
+    }
+
+    @Override
+    protected void reset()
+    {
+        super.reset();
+        newPipe = true;
+    }
+}

--- a/src/main/java/zmq/socket/Sockets.java
+++ b/src/main/java/zmq/socket/Sockets.java
@@ -6,6 +6,7 @@ import java.util.List;
 import zmq.Ctx;
 import zmq.Options;
 import zmq.SocketBase;
+import zmq.io.HelloMsgSession;
 import zmq.io.IOThread;
 import zmq.io.SessionBase;
 import zmq.io.net.Address;
@@ -125,7 +126,12 @@ public enum Sockets
 
     public SessionBase create(IOThread ioThread, boolean connect, SocketBase socket, Options options, Address addr)
     {
-        return new SessionBase(ioThread, connect, socket, options, addr);
+        if (options.canSendHelloMsg && options.helloMsg != null) {
+            return new HelloMsgSession(ioThread, connect, socket, options, addr);
+        }
+        else {
+            return new SessionBase(ioThread, connect, socket, options, addr);
+        }
     }
 
     public static SessionBase createSession(IOThread ioThread, boolean connect, SocketBase socket, Options options,

--- a/src/main/java/zmq/socket/reqrep/Dealer.java
+++ b/src/main/java/zmq/socket/reqrep/Dealer.java
@@ -28,6 +28,7 @@ public class Dealer extends SocketBase
         super(parent, tid, sid);
 
         options.type = ZMQ.ZMQ_DEALER;
+        options.canSendHelloMsg = true;
 
         fq = new FQ();
         lb = new LB();

--- a/src/main/java/zmq/socket/reqrep/Rep.java
+++ b/src/main/java/zmq/socket/reqrep/Rep.java
@@ -22,6 +22,7 @@ public class Rep extends Router
         requestBegins = true;
 
         options.type = ZMQ.ZMQ_REP;
+        options.canSendHelloMsg = false;
     }
 
     @Override

--- a/src/main/java/zmq/socket/reqrep/Req.java
+++ b/src/main/java/zmq/socket/reqrep/Req.java
@@ -45,6 +45,7 @@ public class Req extends Dealer
         receivingReply = false;
         messageBegins = true;
         options.type = ZMQ.ZMQ_REQ;
+        options.canSendHelloMsg = false;
         requestIdFramesEnabled = false;
         requestId = Utils.randomInt();
         strict = true;

--- a/src/main/java/zmq/socket/reqrep/Router.java
+++ b/src/main/java/zmq/socket/reqrep/Router.java
@@ -100,6 +100,7 @@ public class Router extends SocketBase
         options.type = ZMQ.ZMQ_ROUTER;
         options.recvIdentity = true;
         options.rawSocket = false;
+        options.canSendHelloMsg = true;
 
         fq = new FQ();
         prefetchedId = new Msg();

--- a/src/test/java/zmq/TestHelloMsg.java
+++ b/src/test/java/zmq/TestHelloMsg.java
@@ -1,0 +1,128 @@
+package zmq;
+
+import org.junit.Test;
+import zmq.util.Utils;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class TestHelloMsg
+{
+    @Test
+    public void testTcp() throws Exception
+    {
+        System.out.println("Scenario 1");
+
+        int port = Utils.findOpenPort();
+
+        Ctx context = ZMQ.createContext();
+        assertThat(context, notNullValue());
+
+        // Create a routergit s
+        SocketBase router = ZMQ.socket(context, ZMQ.ZMQ_ROUTER);
+        assertThat(router, notNullValue());
+
+        // set router socket options
+        boolean rc = ZMQ.setSocketOption(router, ZMQ.ZMQ_HELLO_MSG, "H");
+        assertThat(rc, is(true));
+
+        // bind router
+        rc = ZMQ.bind(router, "tcp://*:" + port);
+        assertThat(rc, is(true));
+
+        // create a dealer
+        SocketBase dealer = ZMQ.socket(context, ZMQ.ZMQ_DEALER);
+        assertThat(dealer, notNullValue());
+        rc = ZMQ.connect(dealer, "tcp://localhost:" + port);
+        assertThat(rc, is(true));
+
+        // receive hello message from router
+        Msg msg = ZMQ.recv(dealer, 0);
+        assertThat(new String(msg.data()), is("H"));
+
+        ZMQ.close(dealer);
+        ZMQ.close(router);
+        ZMQ.term(context);
+    }
+
+    @Test
+    public void testInproc() throws Exception
+    {
+        System.out.println("Scenario 2");
+
+        String address = "inproc://hello-msg";
+
+        Ctx context = ZMQ.createContext();
+        assertThat(context, notNullValue());
+
+        // Create a router
+        SocketBase router = ZMQ.socket(context, ZMQ.ZMQ_ROUTER);
+        assertThat(router, notNullValue());
+
+        // set router socket options
+        boolean rc = ZMQ.setSocketOption(router, ZMQ.ZMQ_HELLO_MSG, "H");
+        assertThat(rc, is(true));
+
+        // bind router
+        rc = ZMQ.bind(router, address);
+        assertThat(rc, is(true));
+
+        // create a dealer
+        SocketBase dealer = ZMQ.socket(context, ZMQ.ZMQ_DEALER);
+        assertThat(dealer, notNullValue());
+        rc = ZMQ.connect(dealer, address);
+        assertThat(rc, is(true));
+
+        // receive hello message from router
+        Msg msg = ZMQ.recv(dealer, 0);
+        assertThat(new String(msg.data()), is("H"));
+
+        ZMQ.close(dealer);
+        ZMQ.close(router);
+        ZMQ.term(context);
+    }
+
+    @Test
+    public void testInprocLateBind() throws Exception
+    {
+        System.out.println("Scenario 3");
+
+        String address = "inproc://hello-msg";
+
+        Ctx context = ZMQ.createContext();
+        assertThat(context, notNullValue());
+
+        // Create a server
+        SocketBase server = ZMQ.socket(context, ZMQ.ZMQ_DEALER);
+        assertThat(server, notNullValue());
+
+        // set server socket options
+        boolean rc = ZMQ.setSocketOption(server, ZMQ.ZMQ_HELLO_MSG, "W");
+        assertThat(rc, is(true));
+
+        // create a client
+        SocketBase client = ZMQ.socket(context, ZMQ.ZMQ_DEALER);
+        assertThat(client, notNullValue());
+        rc = ZMQ.setSocketOption(client, ZMQ.ZMQ_HELLO_MSG, "H");
+        assertThat(rc, is(true));
+        rc = ZMQ.connect(client, address);
+        assertThat(rc, is(true));
+
+        // bind server after the client
+        rc = ZMQ.bind(server, address);
+        assertThat(rc, is(true));
+
+        // Receive the welcome message from server
+        Msg msg = ZMQ.recv(client, 0);
+        assertThat(new String(msg.data()), is("W"));
+
+        // Receive the hello message from client
+        msg = ZMQ.recv(server, 0);
+        assertThat(new String(msg.data()), is("H"));
+
+        ZMQ.close(client);
+        ZMQ.close(server);
+        ZMQ.term(context);
+    }
+}


### PR DESCRIPTION
When using ZMQ_HEARTBEAT one still needs to implement application-level heartbeat in order to know when to send a hello message.
For example, with the majordomo protocol, the worker needs to send a READY message when connecting to a broker. If the connection to the broker drops, and the heartbeat recognizes it the worker won't know about it and won't send the READY msg.
To solve that, the majordomo worker still has to implement heartbeat. With this new option, whenever the connection drops and reconnects the hello message will be sent, greatly simplify the majordomo protocol, as now READY and HEARTBEAT can be handled by zeromq.

Port of https://github.com/zeromq/libzmq/pull/3870