### PR TITLE
Resolve #776.

### DIFF
--- a/src/main/java/org/zeromq/ZContext.java
+++ b/src/main/java/org/zeromq/ZContext.java
@@ -162,8 +162,12 @@ public class ZContext implements Closeable
             return;
         }
         s.setLinger(linger);
-        s.close();
-        this.sockets.remove(s);
+        try {
+            s.close();
+        }
+        finally {
+            sockets.remove(s);
+        }
     }
 
     /**


### PR DESCRIPTION
If a socket failed during close, it's not removed from ZContext, even
if it should.