### PR TITLE
ZMQ.Socket now remember the ZContext that created it

### DIFF
--- a/src/main/java/org/zeromq/ZActor.java
+++ b/src/main/java/org/zeromq/ZActor.java
@@ -589,7 +589,7 @@ public class ZActor extends ZStar
                 iter.remove();
                 if (socket != null) {
                     poller.unregister(socket);
-                    context.destroySocket(socket);
+                    socket.close();
                     // call back the actor to inform that a socket has been closed.
                     actor.closed(socket);
                 }

--- a/src/main/java/org/zeromq/ZContext.java
+++ b/src/main/java/org/zeromq/ZContext.java
@@ -104,7 +104,7 @@ public class ZContext implements Closeable
     public void destroy()
     {
         for (Socket socket : sockets) {
-            destroySocket(socket);
+            socket.internalClose();
         }
         sockets.clear();
 
@@ -130,7 +130,7 @@ public class ZContext implements Closeable
     public Socket createSocket(SocketType type)
     {
         // Create and register socket
-        Socket socket = context.socket(type);
+        Socket socket = new Socket(this, type);
         socket.setRcvHWM(this.rcvhwm);
         socket.setSndHWM(this.sndhwm);
         sockets.add(socket);
@@ -151,11 +151,14 @@ public class ZContext implements Closeable
     }
 
     /**
+     * @deprecated Now the method {@link org.zeromq.ZMQ.Socket#close()} take care of removing
+     *             the socket from this context.
      * Destroys managed socket within this context
      * and remove from sockets list
      * @param s
      *          org.zeromq.Socket object to destroy
      */
+    @Deprecated
     public void destroySocket(Socket s)
     {
         if (s == null) {
@@ -163,7 +166,7 @@ public class ZContext implements Closeable
         }
         s.setLinger(linger);
         try {
-            s.close();
+            s.internalClose();
         }
         finally {
             sockets.remove(s);

--- a/src/main/java/org/zeromq/ZProxy.java
+++ b/src/main/java/org/zeromq/ZProxy.java
@@ -1070,7 +1070,7 @@ public class ZProxy
         public boolean destroyed(ZContext ctx, Socket pipe, ZPoller poller)
         {
             if (capture != null) {
-                ctx.destroySocket(capture);
+                capture.close();
             }
             state.alive = false;
             if (!state.restart) {

--- a/src/test/java/guide/bstarcli.java
+++ b/src/test/java/guide/bstarcli.java
@@ -64,7 +64,7 @@ public class bstarcli
 
                         //  Old socket is confused; close it and open a new one
                         poller.unregister(client);
-                        ctx.destroySocket(client);
+                        client.close();;
                         serverNbr = (serverNbr + 1) % 2;
                         Thread.sleep(SETTLE_DELAY);
                         System.out.printf("I: connecting to server at %s...\n", server[serverNbr]);

--- a/src/test/java/guide/clonesrv6.java
+++ b/src/test/java/guide/clonesrv6.java
@@ -222,7 +222,7 @@ public class clonesrv6
                     msg.store(srv.kvmap);
                 }
                 System.out.printf("I: received snapshot=%d\n", srv.sequence);
-                srv.ctx.destroySocket(snapshot);
+                snapshot.close();
 
             }
 

--- a/src/test/java/guide/espresso.java
+++ b/src/test/java/guide/espresso.java
@@ -31,7 +31,7 @@ public class espresso
                     break; //  Interrupted
                 count++;
             }
-            ctx.destroySocket(subscriber);
+            subscriber.close();
         }
     }
 
@@ -56,7 +56,7 @@ public class espresso
                 catch (InterruptedException e) {
                 }
             }
-            ctx.destroySocket(publisher);
+            publisher.close();
         }
     }
 

--- a/src/test/java/guide/flclient1.java
+++ b/src/test/java/guide/flclient1.java
@@ -34,7 +34,7 @@ public class flclient1
             reply = ZMsg.recvMsg(client);
 
         //  Close socket in any case, we're done with it now
-        ctx.destroySocket(client);
+        client.close();
         poller.close();
         return reply;
     }

--- a/src/test/java/guide/lpclient.java
+++ b/src/test/java/guide/lpclient.java
@@ -79,7 +79,7 @@ public class lpclient
                         );
                         //  Old socket is confused; close it and open a new one
                         poller.unregister(client);
-                        ctx.destroySocket(client);
+                        client.close();;
                         System.out.println("I: reconnecting to server\n");
                         client = ctx.createSocket(SocketType.REQ);
                         client.connect(SERVER_ENDPOINT);

--- a/src/test/java/guide/mdcliapi.java
+++ b/src/test/java/guide/mdcliapi.java
@@ -54,7 +54,7 @@ public class mdcliapi
     void reconnectToBroker()
     {
         if (client != null) {
-            ctx.destroySocket(client);
+            client.close();;
         }
         client = ctx.createSocket(SocketType.REQ);
         client.connect(broker);

--- a/src/test/java/guide/mdcliapi2.java
+++ b/src/test/java/guide/mdcliapi2.java
@@ -42,7 +42,7 @@ public class mdcliapi2
     void reconnectToBroker()
     {
         if (client != null) {
-            ctx.destroySocket(client);
+            client.close();;
         }
         client = ctx.createSocket(SocketType.DEALER);
         client.connect(broker);

--- a/src/test/java/guide/mdwrkapi.java
+++ b/src/test/java/guide/mdwrkapi.java
@@ -76,7 +76,7 @@ public class mdwrkapi
     void reconnectToBroker()
     {
         if (worker != null) {
-            ctx.destroySocket(worker);
+            worker.close();
         }
         worker = ctx.createSocket(SocketType.DEALER);
         worker.connect(broker);

--- a/src/test/java/guide/ppworker.java
+++ b/src/test/java/guide/ppworker.java
@@ -147,7 +147,7 @@ public class ppworker
 
                         if (interval < INTERVAL_MAX)
                             interval *= 2;
-                        ctx.destroySocket(worker);
+                        worker.close();
                         worker = worker_socket(ctx);
                         liveness = HEARTBEAT_LIVENESS;
                     }

--- a/src/test/java/org/zeromq/ParanoidPiratServerWithLazyPiratClientTest.java
+++ b/src/test/java/org/zeromq/ParanoidPiratServerWithLazyPiratClientTest.java
@@ -322,7 +322,7 @@ public class ParanoidPiratServerWithLazyPiratClientTest
                     if (interval < INTERVAL_MAX) {
                         interval *= 2;
                     }
-                    ctx.destroySocket(worker);
+                    worker.close();
                     worker = workerSocket(ctx);
                     liveness = HEARTBEAT_LIVENESS;
                 }
@@ -408,7 +408,7 @@ public class ParanoidPiratServerWithLazyPiratClientTest
                         System.out.println("W: Client - no response from server, retrying");
                         //  Old socket is confused; close it and open a new one
                         poller.unregister(client);
-                        ctx.destroySocket(client);
+                        client.close();
                         System.out.println("I: Client - reconnecting to server");
                         client = ctx.createSocket(SocketType.REQ);
                         client.connect("tcp://localhost:" + portQueue);

--- a/src/test/java/org/zeromq/TestPushPullThreadedTcp.java
+++ b/src/test/java/org/zeromq/TestPushPullThreadedTcp.java
@@ -138,8 +138,8 @@ public class TestPushPullThreadedTcp
         assertThat("Unable to send messages", client.finished.get(), is(true));
         assertThat("Unable to receive messages", worker.finished.get(), is(true));
 
-        ctx.destroySocket(receiver);
-        ctx.destroySocket(sender);
+        receiver.close();
+        sender.close();
         ctx.close();
 
         System.out.println("Test done in " + (end - start) + " millis.");

--- a/src/test/java/org/zeromq/TestReqRouterThreadedTcp.java
+++ b/src/test/java/org/zeromq/TestReqRouterThreadedTcp.java
@@ -57,7 +57,7 @@ public class TestReqRouterThreadedTcp
             msg.destroy();
 
             // Clean up.
-            ctx.destroySocket(server);
+            server.close();
             ctx.close();
         }
     }
@@ -100,7 +100,7 @@ public class TestReqRouterThreadedTcp
             finished.set(true);
 
             // Clean up.
-            ctx.destroySocket(client);
+            client.close();
             ctx.close();
         }
 

--- a/src/test/java/org/zeromq/TestZContext.java
+++ b/src/test/java/org/zeromq/TestZContext.java
@@ -100,15 +100,12 @@ public class TestZContext
     public void testRemovingSockets() throws ZMQException
     {
         ZContext ctx = new ZContext();
-        try {
-            Socket s = ctx.createSocket(SocketType.PUB);
+        try (Socket s = ctx.createSocket(SocketType.PUB)) {
             assertThat(s, notNullValue());
             assertThat(ctx.getSockets().size(), is(1));
-
-            ctx.destroySocket(s);
-            assertThat(ctx.getSockets().size(), is(0));
         }
         finally {
+            assertThat(ctx.getSockets().size(), is(0));
             ctx.close();
         }
     }

--- a/src/test/java/org/zeromq/auth/ZAuthTest.java
+++ b/src/test/java/org/zeromq/auth/ZAuthTest.java
@@ -49,7 +49,7 @@ public class ZAuthTest
         }
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testNull() throws IOException
     {
         System.out.println("testNull");
@@ -90,7 +90,7 @@ public class ZAuthTest
         }
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testNullAllowed() throws IOException
     {
         System.out.println("testNullAllowed");
@@ -132,7 +132,7 @@ public class ZAuthTest
         }
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testNullWithNoDomain() throws IOException
     {
         System.out.println("testNullWithNoDomain");
@@ -174,7 +174,7 @@ public class ZAuthTest
         }
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testPlainWithPassword() throws IOException
     {
         System.out.println("testPlainWithPassword");
@@ -223,7 +223,7 @@ public class ZAuthTest
         }
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testPlainWithPasswordDenied() throws IOException
     {
         System.out.println("testPlainWithPasswordDenied");
@@ -267,7 +267,7 @@ public class ZAuthTest
         }
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testCurveAnyClient() throws IOException
     {
         System.out.println("testCurveAnyClient");
@@ -326,7 +326,7 @@ public class ZAuthTest
 
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testCurveSuccessful() throws IOException
     {
         System.out.println("testCurveSuccessful");
@@ -392,7 +392,7 @@ public class ZAuthTest
         }
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testBlacklistDenied() throws IOException
     {
         System.out.println("testBlacklistDenied");
@@ -435,7 +435,7 @@ public class ZAuthTest
         }
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testBlacklistAllowed() throws IOException
     {
         System.out.println("testBlacklistAllowed");
@@ -478,7 +478,7 @@ public class ZAuthTest
         }
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testWhitelistDenied() throws IOException
     {
         System.out.println("testWhitelistDenied");
@@ -521,7 +521,7 @@ public class ZAuthTest
         }
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testWhitelistAllowed() throws IOException
     {
         System.out.println("testWhitelistAllowed");
@@ -564,7 +564,7 @@ public class ZAuthTest
         }
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testCurveFail() throws IOException
     {
         System.out.println("testCurveFail");
@@ -628,7 +628,7 @@ public class ZAuthTest
         }
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testNoReplies() throws IOException
     {
         System.out.println("testNoReplies");

--- a/src/test/java/zmq/OptionsTest.java
+++ b/src/test/java/zmq/OptionsTest.java
@@ -242,7 +242,7 @@ public class OptionsTest
         options.setSocketOpt(ZMQ.ZMQ_HANDSHAKE_IVL, -1);
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testSelectorObject()
     {
         try (ZContext ctx = new ZContext();


### PR DESCRIPTION
The ZContext used to create a ZMQ.Socket is now stored within the socket. So with this patch, socket.close() is now enough to remove the socket from the internal state of ZContext.

It makes the use of try-with-resources much easier.

It also remove the unused Ctx storage from  ZMQ.Socket.