### PR TITLE
problem: jeromq is not thread-safe

### DIFF
--- a/src/main/java/zmq/Ctx.java
+++ b/src/main/java/zmq/Ctx.java
@@ -106,7 +106,7 @@ public class Ctx
 
     //  Array of pointers to mailboxes for both application and I/O threads.
     private int       slotCount;
-    private Mailbox[] slots;
+    private IMailbox[] slots;
 
     //  Mailbox for zmq_term thread.
     private final Mailbox termMailbox;
@@ -435,7 +435,7 @@ public class Ctx
             finally {
                 optSync.unlock();
             }
-            slots = new Mailbox[slotCount];
+            slots = new IMailbox[slotCount];
 
             //  Initialize the infrastructure for zmq_term thread.
             slots[TERM_TID] = termMailbox;

--- a/src/main/java/zmq/IMailbox.java
+++ b/src/main/java/zmq/IMailbox.java
@@ -1,0 +1,10 @@
+package zmq;
+
+import java.io.Closeable;
+
+public interface IMailbox extends Closeable
+{
+    void send(final Command cmd);
+
+    Command recv(long timeout);
+}

--- a/src/main/java/zmq/Mailbox.java
+++ b/src/main/java/zmq/Mailbox.java
@@ -1,6 +1,5 @@
 package zmq;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.nio.channels.SelectableChannel;
 import java.util.concurrent.locks.Lock;
@@ -9,7 +8,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import zmq.pipe.YPipe;
 import zmq.util.Errno;
 
-public final class Mailbox implements Closeable
+public final class Mailbox implements IMailbox
 {
     //  The pipe to store actual commands.
     private final YPipe<Command> cpipe;
@@ -55,7 +54,8 @@ public final class Mailbox implements Closeable
         return signaler.getFd();
     }
 
-    void send(final Command cmd)
+    @Override
+    public void send(final Command cmd)
     {
         boolean ok = false;
         sync.lock();
@@ -72,6 +72,7 @@ public final class Mailbox implements Closeable
         }
     }
 
+    @Override
     public Command recv(long timeout)
     {
         Command cmd;

--- a/src/main/java/zmq/MailboxSafe.java
+++ b/src/main/java/zmq/MailboxSafe.java
@@ -1,0 +1,134 @@
+package zmq;
+
+import zmq.pipe.YPipe;
+import zmq.util.Errno;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.Condition;
+
+public class MailboxSafe implements IMailbox
+{
+    //  The pipe to store actual commands.
+    private final YPipe<Command> cpipe;
+
+    //  Synchronize access to the mailbox from receivers and senders
+    private final ReentrantLock sync;
+
+    //  Condition variable to pass signals from writer thread to reader thread.
+    private final Condition condition;
+
+    private final ArrayList<Signaler> signalers;
+
+    // mailbox name, for better debugging
+    private final String name;
+
+    private final Errno errno;
+
+    public MailboxSafe(Ctx ctx, ReentrantLock sync, String name)
+    {
+        this.errno = ctx.errno();
+        this.cpipe = new YPipe<>(Config.COMMAND_PIPE_GRANULARITY.getValue());
+        this.sync = sync;
+        this.condition = this.sync.newCondition();
+        this.signalers = new ArrayList<Signaler>(10);
+        this.name = name;
+
+        //  Get the pipe into passive state. That way, if the users starts by
+        //  polling on the associated file descriptor it will get woken up when
+        //  new command is posted.
+        Command cmd = cpipe.read();
+        assert (cmd == null);
+    }
+
+    public void addSignaler(Signaler signaler)
+    {
+        this.signalers.add(signaler);
+    }
+
+    public void removeSignaler(Signaler signaler)
+    {
+        this.signalers.remove(signaler);
+    }
+
+    public void clearSignalers()
+    {
+        this.signalers.clear();
+    }
+
+    @Override
+    public void send(Command cmd)
+    {
+        sync.lock();
+        try {
+            cpipe.write(cmd, false);
+            boolean ok = cpipe.flush();
+
+            if (!ok) {
+                condition.signalAll();
+
+                for (int i = 0; i < signalers.size(); i++) {
+                    signalers.get(i).send();
+                }
+            }
+        }
+        finally {
+            sync.unlock();
+        }
+    }
+
+    @Override
+    public Command recv(long timeout)
+    {
+        Command cmd;
+
+        //  Try to get the command straight away.
+        cmd = cpipe.read();
+        if (cmd != null) {
+            return cmd;
+        }
+
+        //  If the timeout is zero, it will be quicker to release the lock, giving other a chance to send a command
+        //  and immediately relock it.
+        if (timeout == 0) {
+            sync.unlock();
+            sync.lock();
+        }
+        else {
+            try {
+                //  Wait for signal from the command sender.
+                condition.await(timeout, TimeUnit.MILLISECONDS);
+            }
+            catch (InterruptedException e) {
+                errno.set(ZError.EINTR);
+                return null;
+            }
+        }
+
+        //  Another thread may already fetch the command
+        cmd = cpipe.read();
+        if (cmd == null) {
+            errno.set(ZError.EAGAIN);
+            return null;
+        }
+
+        return cmd;
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        // Work around problem that other threads might still be in our
+        // send() method, by waiting on the mutex before disappearing.
+        sync.lock();
+        sync.unlock();
+    }
+
+    @Override
+    public String toString()
+    {
+        return super.toString() + "[" + name + "]";
+    }
+}

--- a/src/main/java/zmq/Msg.java
+++ b/src/main/java/zmq/Msg.java
@@ -111,6 +111,8 @@ public class Msg
     // keep track of relative read position
     private int readIndex = 0;
 
+    private int routingId;
+
     public Msg()
     {
         this(0);
@@ -434,5 +436,36 @@ public class Msg
         dup.position(writeIndex);
         writeIndex += Wire.putShortString(dup, data);
         return this;
+    }
+
+    /**
+    * Return the routing id of a message. The routing id represent the CLIENT socket that sent the message to the
+    * SERVER socket.
+    * @return the routing id
+    * */
+    public int getRoutingId()
+    {
+        return routingId;
+    }
+
+    /**
+     * Set the routing id on a message. The routing id represent the CLIENT socket which the message should be sent to.
+     * Only SERVER socket is currently using the routing id.
+     * @param routingId the routing id
+     * @return true if successfully set the routing id.
+     */
+    public boolean setRoutingId(int routingId)
+    {
+        if (routingId != 0) {
+            this.routingId = routingId;
+            return true;
+        }
+
+        return false;
+    }
+
+    public void resetRoutingId()
+    {
+        routingId = 0;
     }
 }

--- a/src/main/java/zmq/ZMQ.java
+++ b/src/main/java/zmq/ZMQ.java
@@ -54,6 +54,8 @@ public class ZMQ
     public static final int ZMQ_XPUB   = 9;
     public static final int ZMQ_XSUB   = 10;
     public static final int ZMQ_STREAM = 11;
+    public static final int ZMQ_SERVER = 12;
+    public static final int ZMQ_CLIENT = 13;
 
     /*  Deprecated aliases                                                        */
     @Deprecated
@@ -590,6 +592,18 @@ public class ZMQ
             data = metadata.get(property);
         }
         return data;
+    }
+
+    //  Set routing id on a message sent over SERVER socket type
+    public boolean setMessageRoutingId(Msg msg, int routingId)
+    {
+        return msg.setRoutingId(routingId);
+    }
+
+    //  Get the routing id of a message that came from SERVER socket type
+    public int getMessageRoutingId(Msg msg)
+    {
+        return msg.getRoutingId();
     }
 
     public static void sleep(long seconds)

--- a/src/main/java/zmq/io/SessionBase.java
+++ b/src/main/java/zmq/io/SessionBase.java
@@ -309,7 +309,8 @@ public class SessionBase extends Own implements Pipe.IPipeEvents, IPollEvents
             errno.set(ZError.ECONNREFUSED);
             return ZError.ECONNREFUSED;
         }
-        if (peer.options.type != ZMQ.ZMQ_REP && peer.options.type != ZMQ.ZMQ_ROUTER) {
+        if (peer.options.type != ZMQ.ZMQ_REP && peer.options.type != ZMQ.ZMQ_ROUTER &&
+                peer.options.type != ZMQ.ZMQ_SERVER) {
             errno.set(ZError.ECONNREFUSED);
             return ZError.ECONNREFUSED;
         }

--- a/src/main/java/zmq/pipe/Pipe.java
+++ b/src/main/java/zmq/pipe/Pipe.java
@@ -80,6 +80,9 @@ public class Pipe extends ZObject
     //  Identity of the writer. Used uniquely by the reader side.
     private Blob identity;
 
+    //  Routing id of the writer. Used uniquely by the reader side.
+    private int routingId;
+
     //  Pipe's credential.
     private Blob credential;
 
@@ -164,6 +167,16 @@ public class Pipe extends ZObject
     public Blob getIdentity()
     {
         return identity;
+    }
+
+    public void setRoutingId(int routingId)
+    {
+        this.routingId = routingId;
+    }
+
+    public int getRoutingId()
+    {
+        return routingId;
     }
 
     public Blob getCredential()

--- a/src/main/java/zmq/pipe/YPipe.java
+++ b/src/main/java/zmq/pipe/YPipe.java
@@ -100,7 +100,7 @@ public class YPipe<T> implements YPipeBase<T>
     {
         //  Was the value prefetched already? If so, return.
         int h = queue.frontPos();
-        if (h != r) {
+        if (h != r && r != -1) {
             return true;
         }
 

--- a/src/main/java/zmq/socket/Sockets.java
+++ b/src/main/java/zmq/socket/Sockets.java
@@ -20,6 +20,8 @@ import zmq.socket.reqrep.Dealer;
 import zmq.socket.reqrep.Rep;
 import zmq.socket.reqrep.Req;
 import zmq.socket.reqrep.Router;
+import zmq.socket.clientserver.Server;
+import zmq.socket.clientserver.Client;
 
 public enum Sockets
 {
@@ -111,6 +113,20 @@ public enum Sockets
         SocketBase create(Ctx parent, int tid, int sid)
         {
             return new Stream(parent, tid, sid);
+        }
+    },
+    SERVER("CLIENT") {
+        @Override
+        SocketBase create(Ctx parent, int tid, int sid)
+        {
+            return new Server(parent, tid, sid);
+        }
+    },
+    CLIENT("SERVER") {
+        @Override
+        SocketBase create(Ctx parent, int tid, int sid)
+        {
+            return new Client(parent, tid, sid);
         }
     };
 

--- a/src/main/java/zmq/socket/clientserver/Client.java
+++ b/src/main/java/zmq/socket/clientserver/Client.java
@@ -1,0 +1,111 @@
+package zmq.socket.clientserver;
+
+import zmq.Ctx;
+import zmq.Msg;
+import zmq.SocketBase;
+import zmq.ZError;
+import zmq.ZMQ;
+import zmq.pipe.Pipe;
+import zmq.socket.FQ;
+import zmq.socket.LB;
+import zmq.util.Blob;
+
+public class Client extends SocketBase
+{
+    //  Messages are fair-queued from inbound pipes. And load-balanced to
+    //  the outbound pipes.
+    private final FQ fq;
+    private final LB lb;
+
+    //  Holds the prefetched message.
+    public Client(Ctx parent, int tid, int sid)
+    {
+        super(parent, tid, sid, true);
+
+        options.type = ZMQ.ZMQ_CLIENT;
+        options.canSendHelloMsg = true;
+
+        fq = new FQ();
+        lb = new LB();
+    }
+
+    @Override
+    protected void xattachPipe(Pipe pipe, boolean subscribe2all, boolean isLocallyInitiated)
+    {
+        assert (pipe != null);
+
+        fq.attach(pipe);
+        lb.attach(pipe);
+    }
+
+    @Override
+    protected boolean xsend(Msg msg)
+    {
+        //  CLIENT sockets do not allow multipart data (ZMQ_SNDMORE)
+        if (msg.hasMore()) {
+            errno.set(ZError.EINVAL);
+            return false;
+        }
+        return lb.sendpipe(msg, errno, null);
+    }
+
+    @Override
+    protected Msg xrecv()
+    {
+        Msg msg = fq.recvPipe(errno, null);
+
+        // Drop any messages with more flag
+        while (msg != null && msg.hasMore()) {
+            // drop all frames of the current multi-frame message
+            msg = fq.recvPipe(errno, null);
+
+            while (msg != null && msg.hasMore()) {
+                fq.recvPipe(errno, null);
+            }
+
+            // get the new message
+            if (msg != null) {
+                fq.recvPipe(errno, null);
+            }
+        }
+
+        return msg;
+    }
+
+    @Override
+    protected boolean xhasIn()
+    {
+        return fq.hasIn();
+    }
+
+    @Override
+    protected boolean xhasOut()
+    {
+        return lb.hasOut();
+    }
+
+    @Override
+    protected Blob getCredential()
+    {
+        return fq.getCredential();
+    }
+
+    @Override
+    protected void xreadActivated(Pipe pipe)
+    {
+        fq.activated(pipe);
+    }
+
+    @Override
+    protected void xwriteActivated(Pipe pipe)
+    {
+        lb.activated(pipe);
+    }
+
+    @Override
+    protected void xpipeTerminated(Pipe pipe)
+    {
+        fq.terminated(pipe);
+        lb.terminated(pipe);
+    }
+}

--- a/src/main/java/zmq/socket/clientserver/Server.java
+++ b/src/main/java/zmq/socket/clientserver/Server.java
@@ -1,0 +1,195 @@
+package zmq.socket.clientserver;
+
+import zmq.SocketBase;
+import zmq.Msg;
+import zmq.Ctx;
+import zmq.ZMQ;
+import zmq.ZError;
+import zmq.pipe.Pipe;
+import zmq.socket.FQ;
+import zmq.util.Blob;
+import zmq.util.Utils;
+import zmq.util.ValueReference;
+
+import java.util.HashMap;
+import java.util.Map;
+
+//TODO: This class uses O(n) scheduling. Rewrite it to use O(1) algorithm.
+public class Server extends SocketBase
+{
+    //  Fair queuing object for inbound pipes.
+    private final FQ fq;
+
+    class Outpipe
+    {
+        private Pipe pipe;
+        private boolean active;
+
+        public Outpipe(Pipe pipe, boolean active)
+        {
+            this.pipe = pipe;
+            this.active = active;
+        }
+    }
+
+    //  Outbound pipes indexed by the peer IDs.
+    private final Map<Integer, Outpipe> outpipes;
+
+    //  Routing IDs are generated. It's a simple increment and wrap-over
+    //  algorithm. This value is the next ID to use (if not used already).
+    private int nextRid;
+
+    public Server(Ctx parent, int tid, int sid)
+    {
+        super(parent, tid, sid, true);
+        nextRid = Utils.randomInt();
+
+        options.type = ZMQ.ZMQ_SERVER;
+        options.canSendHelloMsg = true;
+
+        fq = new FQ();
+        outpipes = new HashMap<>();
+    }
+
+    @Override
+    protected void destroy()
+    {
+        assert (outpipes.isEmpty());
+
+        super.destroy();
+    }
+
+    @Override
+    public void xattachPipe(Pipe pipe, boolean subscribe2all, boolean isLocallyInitiated)
+    {
+        assert (pipe != null);
+
+        int routingId = nextRid++;
+        if (routingId == 0) {
+            routingId = nextRid++; //  Never use Routing ID zero
+        }
+
+        pipe.setRoutingId(routingId);
+        //  Add the record into output pipes lookup table
+        Outpipe outpipe = new Outpipe(pipe, true);
+        Outpipe prev = outpipes.put(routingId, outpipe);
+        assert (prev == null);
+
+        fq.attach(pipe);
+    }
+
+    @Override
+    public void xpipeTerminated(Pipe pipe)
+    {
+        Outpipe old = outpipes.remove(pipe.getRoutingId());
+        assert (old != null);
+
+        fq.terminated(pipe);
+    }
+
+    @Override
+    public void xreadActivated(Pipe pipe)
+    {
+        fq.activated(pipe);
+    }
+
+    @Override
+    public void xwriteActivated(Pipe pipe)
+    {
+        Outpipe out = outpipes.get(pipe.getRoutingId());
+        assert (out != null);
+        assert (!out.active);
+        out.active = true;
+    }
+
+    @Override
+    protected boolean xsend(Msg msg)
+    {
+        //  SERVER sockets do not allow multipart data (ZMQ_SNDMORE)
+        if (msg.hasMore()) {
+            errno.set(ZError.EINVAL);
+            return false;
+        }
+
+        //  Find the pipe associated with the routing stored in the message.
+        int routingId = msg.getRoutingId();
+        Outpipe out = outpipes.get(routingId);
+
+        if (out != null) {
+            if (!out.pipe.checkWrite()) {
+                out.active = false;
+                errno.set(ZError.EAGAIN);
+                return false;
+            }
+        }
+        else {
+            errno.set(ZError.EHOSTUNREACH);
+            return false;
+        }
+
+        //  Message might be delivered over inproc, so we reset routing id
+        msg.resetRoutingId();
+
+        boolean ok = out.pipe.write(msg);
+        if (ok) {
+            out.pipe.flush();
+        }
+
+        return true;
+    }
+
+    @Override
+    protected Msg xrecv()
+    {
+        Msg msg;
+        ValueReference<Pipe> pipe = new ValueReference<>();
+        msg = fq.recvPipe(errno, pipe);
+
+        // Drop any messages with more flag
+        while (msg != null && msg.hasMore()) {
+            // drop all frames of the current multi-frame message
+            msg = fq.recvPipe(errno, null);
+
+            while (msg != null && msg.hasMore()) {
+                msg = fq.recvPipe(errno, null);
+            }
+
+            // get the new message
+            if (msg != null) {
+                msg = fq.recvPipe(errno, pipe);
+            }
+        }
+
+        if (msg == null) {
+            return msg;
+        }
+
+        assert (pipe.get() != null);
+
+        int routingId = pipe.get().getRoutingId();
+        msg.setRoutingId(routingId);
+
+        return msg;
+    }
+
+    @Override
+    protected boolean xhasIn()
+    {
+        return fq.hasIn();
+    }
+
+    @Override
+    protected boolean xhasOut()
+    {
+        //  In theory, ROUTER socket is always ready for writing. Whether actual
+        //  attempt to write succeeds depends on whitch pipe the message is going
+        //  to be routed to.
+        return true;
+    }
+
+    @Override
+    protected Blob getCredential()
+    {
+        return fq.getCredential();
+    }
+}

--- a/src/test/java/zmq/TestClientServer.java
+++ b/src/test/java/zmq/TestClientServer.java
@@ -1,0 +1,182 @@
+package zmq;
+
+import org.junit.Test;
+import zmq.util.Utils;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+public class TestClientServer
+{
+    @Test
+    public void testInproc() throws Exception
+    {
+        System.out.println("Scenario 1");
+
+        String address = "inproc://client-server";
+
+        Ctx context = ZMQ.createContext();
+        assertThat(context, notNullValue());
+
+        // Create a server
+        SocketBase server = ZMQ.socket(context, ZMQ.ZMQ_SERVER);
+        assertThat(server, notNullValue());
+
+        // bind server
+        boolean rc = ZMQ.bind(server, address);
+        assertThat(rc, is(true));
+
+        // create a client
+        SocketBase client = ZMQ.socket(context, ZMQ.ZMQ_CLIENT);
+        assertThat(client, notNullValue());
+        rc = ZMQ.connect(client, address);
+        assertThat(rc, is(true));
+
+        // Send a message from client
+        Msg msg = new Msg("X".getBytes());
+        int size = ZMQ.send(client, msg, 0);
+        assertThat(size, is(1));
+
+        // Recv message on the server side
+        msg = ZMQ.recv(server, 0);
+        assertThat(msg, notNullValue());
+        assertThat(new String(msg.data()), is("X"));
+        int routingId = msg.getRoutingId();
+        assertThat(routingId, not(0));
+
+        // Send message back to client using routing id
+        msg = new Msg("HELLO".getBytes());
+        msg.setRoutingId(routingId);
+        size = ZMQ.send(server, msg, 0);
+        assertThat(size, is(5));
+
+        // Client recv message from server
+        msg = ZMQ.recv(client, 0);
+        assertThat(msg, notNullValue());
+        assertThat(new String(msg.data()), is("HELLO"));
+
+        ZMQ.close(client);
+        ZMQ.close(server);
+        ZMQ.term(context);
+    }
+
+    @Test
+    public void testTcp() throws Exception
+    {
+        System.out.println("Scenario 2");
+
+        int port = Utils.findOpenPort();
+
+        Ctx context = ZMQ.createContext();
+        assertThat(context, notNullValue());
+
+        // Create a server
+        SocketBase server = ZMQ.socket(context, ZMQ.ZMQ_SERVER);
+        assertThat(server, notNullValue());
+
+        // bind server
+        boolean rc = ZMQ.bind(server, "tcp://*:" + port);
+        assertThat(rc, is(true));
+
+        // create a client
+        SocketBase client = ZMQ.socket(context, ZMQ.ZMQ_CLIENT);
+        assertThat(client, notNullValue());
+        rc = ZMQ.connect(client, "tcp://localhost:" + port);
+        assertThat(rc, is(true));
+
+        // Send a message from client
+        Msg msg = new Msg("X".getBytes());
+        int size = ZMQ.send(client, msg, 0);
+        assertThat(size, is(1));
+
+        // Recv message on the server side
+        msg = ZMQ.recv(server, 0);
+        assertThat(msg, notNullValue());
+        assertThat(new String(msg.data()), is("X"));
+        int routingId = msg.getRoutingId();
+        assertThat(routingId, not(0));
+
+        // Send message back to client using routing id
+        msg = new Msg("HELLO".getBytes());
+        msg.setRoutingId(routingId);
+        size = ZMQ.send(server, msg, 0);
+        assertThat(size, is(5));
+
+        // Client recv message from server
+        msg = ZMQ.recv(client, 0);
+        assertThat(msg, notNullValue());
+        assertThat(new String(msg.data()), is("HELLO"));
+
+        ZMQ.close(client);
+        ZMQ.close(server);
+        ZMQ.term(context);
+    }
+
+    //  Client threads loop on send/recv until told to exit
+    class ClientThread extends Thread
+    {
+        SocketBase client;
+
+        ClientThread(SocketBase client)
+        {
+            this.client = client;
+        }
+
+        public void run()
+        {
+            for (int count = 0; count < 15000; count++) {
+                Msg msg = new Msg("0".getBytes());
+                int rc = ZMQ.send(client, msg, 0);
+                assertThat(rc, is(1));
+            }
+            Msg msg = new Msg("1".getBytes());
+            int rc = ZMQ.send(client, msg, 0);
+            assertThat(rc, is(1));
+        }
+    }
+
+    @Test
+    public void testThreadSafe() throws Exception
+    {
+        System.out.println("Scenario 3");
+
+        int port = Utils.findOpenPort();
+
+        Ctx context = ZMQ.createContext();
+        assertThat(context, notNullValue());
+
+        SocketBase server = ZMQ.socket(context, ZMQ.ZMQ_SERVER);
+        assertThat(server, notNullValue());
+        boolean rc = ZMQ.bind(server, "tcp://*:" + port);
+        assertThat(rc, is(true));
+
+        SocketBase client = ZMQ.socket(context, ZMQ.ZMQ_CLIENT);
+        assertThat(client, notNullValue());
+        rc = ZMQ.connect(client, "tcp://localhost:" + port);
+        assertThat(rc, is(true));
+
+        ClientThread t1 = new ClientThread(client);
+        ClientThread t2 = new ClientThread(client);
+        t1.start();
+        t2.start();
+
+        int threadsCompleted = 0;
+        while (threadsCompleted < 2) {
+            Msg msg = ZMQ.recv(server, 0);
+            assertThat(msg, notNullValue());
+
+            if (msg.data()[0] == '1') {
+                threadsCompleted++; //  Thread ended
+            }
+        }
+
+        t1.join();
+        t2.join();
+
+        ZMQ.close(client);
+        ZMQ.close(server);
+        ZMQ.term(context);
+    }
+}


### PR DESCRIPTION
Solution: port CLIENT and SERVER sockets from libzmq, which are thread-safe sockets.

The thread-safe sockets family includes other sockets, which are not part of this commit.

Also, CLIENT and SERVER cannot be used with a poller at the moment. For poller support, zmq_poller from libzmq has to be ported as well. 