### PR TITLE
Improving build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <version>3.0.0-M3</version>
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
+          <rerunFailingTestsCount>5</rerunFailingTestsCount>
         </configuration>
       </plugin>
       <plugin>
@@ -236,6 +237,7 @@
   </reporting>
   <profiles>
     <profile>
+      <!--Activate jacoco coverage -->
       <id>coverage</id>
         <activation>
           <activeByDefault>false</activeByDefault>
@@ -293,6 +295,7 @@
       </build>
     </profile>
     <profile>
+      <!-- Used with the phase 'site' to check plugins and dependency versions -->
       <id>versions</id>
       <reporting>
         <plugins>
@@ -314,6 +317,7 @@
       </reporting>
     </profile>
     <profile>
+      <!-- Activate the checkstyle plugin, to ensure conformance with code style -->
       <id>checkstyle</id>
       <build>
         <plugins>
@@ -348,6 +352,9 @@
       </build>
     </profile>
     <profile>
+      <!-- With this profile, it's possible to used the latest jvm but still get jar compatible with pre-9 JVM.
+           It must be used with -Djdk.8.home=$JAVA8_HOME. Example:
+           JAVA_HOME=$JAVA14_HOME mvn compile -Pcrosscompile -Djdk.8.home=$JAVA8_HOME !-->
       <id>crosscompile</id>
       <build>
         <plugins>
@@ -367,6 +374,7 @@
       </build>
     </profile>
     <profile>
+      <!-- Used to sign a release -->
       <id>release</id>
       <activation>
         <property>

--- a/src/test/java/org/zeromq/guide/AsyncServerTest.java
+++ b/src/test/java/org/zeromq/guide/AsyncServerTest.java
@@ -226,7 +226,7 @@ public class AsyncServerTest
 
     //The main thread simply starts several clients, and a server, and then
     //waits for the server to finish.
-    @Test
+    @Test(timeout = 5000)
     public void testAsyncServer() throws Exception
     {
         try (

--- a/src/test/java/zmq/socket/pubsub/XpubXsubTest.java
+++ b/src/test/java/zmq/socket/pubsub/XpubXsubTest.java
@@ -21,7 +21,7 @@ import zmq.util.Utils;
 
 public class XpubXsubTest
 {
-    @Test
+    @Test(timeout = 5000)
     public void testXpubSub() throws InterruptedException, IOException, ExecutionException
     {
         final Ctx ctx = zmq.ZMQ.createContext();
@@ -93,7 +93,7 @@ public class XpubXsubTest
         System.out.println("Done.");
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testXpubXSub() throws InterruptedException, IOException, ExecutionException
     {
         final Ctx ctx = zmq.ZMQ.createContext();
@@ -153,7 +153,7 @@ public class XpubXsubTest
         zmq.ZMQ.term(ctx);
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testIssue476() throws InterruptedException, IOException, ExecutionException
     {
         final int front = Utils.findOpenPort();


### PR DESCRIPTION
- Adding comment about the purpose of profiles.
- Some tests are flaky, allows build to succeed any way, until this issue
  is really resolved.
- Some tests are probably missing timeout, giving a default 5s timeout to them.