### PR TITLE
A new ZBeacon implementation.

### DIFF
--- a/src/main/java/org/zeromq/ZBeacon.java
+++ b/src/main/java/org/zeromq/ZBeacon.java
@@ -15,20 +15,38 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import zmq.util.Objects;
 
+/**
+ * This class implements a peer-to-peer discovery service for local networks.
+ * A beacon can broadcast and/or capture service announcements using UDP messages
+ * on the local area network. This implementation uses IPv4 UDP broadcasts. You can
+ * define the format of your outgoing beacons, and set a filter that validates incoming
+ * beacons. Beacons are sent and received asynchronously in the background.
+ *
+ */
 public class ZBeacon
 {
     public static final long    DEFAULT_BROADCAST_INTERVAL = 1000L;
     public static final String  DEFAULT_BROADCAST_HOST     = "255.255.255.255"; // is this the source/interface address? or the broadcast address
-    private static final byte[] DEFAULT_BROADCAST_ADDRESS = { 0, 0, 0, 0 };
+    private static final InetAddress DEFAULT_BROADCAST_HOST_ADDRESS;
+    private static final InetAddress DEFAULT_BROADCAST_ADDRESS;
+    static {
+        try {
+            DEFAULT_BROADCAST_HOST_ADDRESS = InetAddress.getByName(DEFAULT_BROADCAST_HOST);
+            DEFAULT_BROADCAST_ADDRESS = InetAddress.getByName("0.0.0.0");
+        }
+        catch (UnknownHostException e) {
+            throw new IllegalArgumentException("Invalid default broadcast address", e);
+        }
+    }
 
     private final BroadcastClient           broadcastClient;
     private final BroadcastServer           broadcastServer;
-    private final AtomicReference<byte[]>   prefix            = new AtomicReference<>(new byte[0]);
-    private final AtomicReference<byte[]>   beacon            = new AtomicReference<>(new byte[0]);
+    private final AtomicReference<byte[]>   prefix = new AtomicReference<>();
+    private final AtomicReference<byte[]>   beacon = new AtomicReference<>();
     private final AtomicLong                broadcastInterval = new AtomicLong(DEFAULT_BROADCAST_INTERVAL);
     private final AtomicReference<Listener> listener          = new AtomicReference<>();
-    private AtomicReference<Thread.UncaughtExceptionHandler> clientHandler = new AtomicReference<>();
-    private AtomicReference<Thread.UncaughtExceptionHandler> serverHandler = new AtomicReference<>();
+    private final AtomicReference<Thread.UncaughtExceptionHandler> clientExHandler = new AtomicReference<>();
+    private final AtomicReference<Thread.UncaughtExceptionHandler> serverExHandler = new AtomicReference<>();
 
     public ZBeacon(int port, byte[] beacon)
     {
@@ -47,29 +65,51 @@ public class ZBeacon
 
     public ZBeacon(String host, int port, byte[] beacon, boolean ignoreLocalAddress, boolean blocking)
     {
-        this(host, DEFAULT_BROADCAST_ADDRESS, port, beacon, DEFAULT_BROADCAST_INTERVAL, ignoreLocalAddress, blocking);
+        this(host, DEFAULT_BROADCAST_ADDRESS.getAddress(), port, beacon, DEFAULT_BROADCAST_INTERVAL, ignoreLocalAddress, blocking);
     }
 
+    public ZBeacon(InetAddress broadcastAddress, InetAddress serverAddress, int port, byte[] beacon, long broadcastInterval, boolean ignoreLocalAddress, boolean blocking)
+    {
+        Objects.requireNonNull(broadcastAddress, "Host cannot be null");
+        Objects.requireNonNull(serverAddress, "Server address cannot be null");
+        Objects.requireNonNull(beacon, "Beacon cannot be null");
+        this.broadcastInterval.set(broadcastInterval);
+        this.beacon.set(Arrays.copyOf(beacon, beacon.length));
+        broadcastServer = new BroadcastServer(port, ignoreLocalAddress);
+        broadcastClient = new BroadcastClient(serverAddress, broadcastAddress, port, this.broadcastInterval);
+    }
+
+    @Deprecated
     public ZBeacon(String broadcastAddress, byte[] serverAddress, int port, byte[] beacon, long broadcastInterval, boolean ignoreLocalAddress, boolean blocking)
     {
         Objects.requireNonNull(broadcastAddress, "Host cannot be null");
         Objects.requireNonNull(serverAddress, "Server address cannot be null");
         Objects.requireNonNull(beacon, "Beacon cannot be null");
         this.broadcastInterval.set(broadcastInterval);
-        this.beacon.set(beacon);
-        broadcastServer = new BroadcastServer(serverAddress, port, ignoreLocalAddress, blocking);
-        broadcastClient = new BroadcastClient(serverAddress, broadcastAddress, port, this.broadcastInterval);
+        this.beacon.set(Arrays.copyOf(beacon, beacon.length));
+        broadcastServer = new BroadcastServer(port, ignoreLocalAddress);
+        try {
+            broadcastClient = new BroadcastClient(InetAddress.getByAddress(serverAddress), InetAddress.getByName(broadcastAddress), port, this.broadcastInterval);
+        }
+        catch (UnknownHostException e) {
+            throw new IllegalArgumentException("Invalid server address", e);
+        }
     }
 
     public static class Builder
     {
-        private String  clientHost         = DEFAULT_BROADCAST_HOST;
-        private byte[]  serverAddr         = DEFAULT_BROADCAST_ADDRESS;
+        private InetAddress  clientHost    = DEFAULT_BROADCAST_HOST_ADDRESS;
+        private InetAddress  serverAddr    = DEFAULT_BROADCAST_ADDRESS;
         private int     port;
         private long    broadcastInterval  = DEFAULT_BROADCAST_INTERVAL;
         private byte[]  beacon;
         private boolean ignoreLocalAddress = true;
         private boolean blocking           = false;
+        // Those arguments are not set using the constructor, so they are optional for backward compatibility
+        private Listener listener          = null;
+        private byte[]  prefix             = null;
+        private Thread.UncaughtExceptionHandler clientExHandler = null;
+        private Thread.UncaughtExceptionHandler serverExHandler = null;
 
         public Builder port(int port)
         {
@@ -83,15 +123,39 @@ public class ZBeacon
             return this;
         }
 
+        @Deprecated
         public Builder client(String host)
+        {
+            try {
+                this.clientHost = InetAddress.getByName(host);
+            }
+            catch (UnknownHostException e) {
+                throw new IllegalArgumentException("Invalid server address", e);
+            }
+            return this;
+        }
+
+        public Builder client(InetAddress host)
         {
             this.clientHost = host;
             return this;
         }
 
+        @Deprecated
         public Builder server(byte[] addr)
         {
             Utils.checkArgument(addr.length == 4 || addr.length == 16, "Server Address has to be 4 or 16 bytes long");
+            try {
+                this.serverAddr = InetAddress.getByAddress(addr);
+            }
+            catch (UnknownHostException e) {
+                throw new IllegalArgumentException("Invalid server address", e);
+            }
+            return this;
+        }
+
+        public Builder server(InetAddress addr)
+        {
             this.serverAddr = addr;
             return this;
         }
@@ -102,6 +166,12 @@ public class ZBeacon
             return this;
         }
 
+        /**
+         * @deprecated ignored
+         * @param blocking
+         * @return
+         */
+        @Deprecated
         public Builder blocking(boolean blocking)
         {
             this.blocking = blocking;
@@ -114,17 +184,60 @@ public class ZBeacon
             return this;
         }
 
+        public Builder listener(Listener listener)
+        {
+            this.listener = listener;
+            return this;
+        }
+
+        public Builder prefix(byte[] prefix)
+        {
+            this.prefix = Arrays.copyOf(prefix, prefix.length);
+            return this;
+        }
+
+        public Builder setClientUncaughtExceptionHandlers(Thread.UncaughtExceptionHandler clientExHandler)
+        {
+            this.clientExHandler = clientExHandler;
+            return this;
+        }
+
+        public Builder setServerUncaughtExceptionHandlers(Thread.UncaughtExceptionHandler serverExHandler)
+        {
+            this.serverExHandler = serverExHandler;
+            return this;
+        }
+
         public ZBeacon build()
         {
-            return new ZBeacon(clientHost, serverAddr, port, beacon, broadcastInterval, ignoreLocalAddress, blocking);
+            ZBeacon zbeacon = new ZBeacon(clientHost, serverAddr, port, beacon, broadcastInterval, ignoreLocalAddress, blocking);
+            if (listener != null) {
+                zbeacon.setListener(listener);
+            }
+            if (prefix != null) {
+                zbeacon.setPrefix(prefix);
+            }
+            if (this.serverExHandler != null) {
+                zbeacon.serverExHandler.set(this.serverExHandler);
+            }
+            if (this.clientExHandler != null) {
+                zbeacon.clientExHandler.set(this.clientExHandler);
+            }
+            return zbeacon;
         }
     }
 
-    public void setUncaughtExceptionHandlers(Thread.UncaughtExceptionHandler clientHandler,
-                                             Thread.UncaughtExceptionHandler serverHandler)
+    /**
+     * @deprecated use the builder
+     * @param clientExHandler
+     * @param serverExHandler
+     */
+    @Deprecated
+    public void setUncaughtExceptionHandlers(Thread.UncaughtExceptionHandler clientExHandler,
+                                             Thread.UncaughtExceptionHandler serverExHandler)
     {
-        this.clientHandler.set(clientHandler);
-        this.serverHandler.set(serverHandler);
+        this.clientExHandler.set(clientExHandler);
+        this.serverExHandler.set(serverExHandler);
     }
 
     public void startClient()
@@ -134,7 +247,7 @@ public class ZBeacon
                 broadcastClient.thread = new Thread(broadcastClient);
                 broadcastClient.thread.setName("ZBeacon Client Thread");
                 broadcastClient.thread.setDaemon(true);
-                broadcastClient.thread.setUncaughtExceptionHandler(clientHandler.get());
+                broadcastClient.thread.setUncaughtExceptionHandler(clientExHandler.get());
             }
             broadcastClient.thread.start();
         }
@@ -148,7 +261,7 @@ public class ZBeacon
                     broadcastServer.thread = new Thread(broadcastServer);
                     broadcastServer.thread.setName("ZBeacon Server Thread");
                     broadcastServer.thread.setDaemon(true);
-                    broadcastServer.thread.setUncaughtExceptionHandler(serverHandler.get());
+                    broadcastServer.thread.setUncaughtExceptionHandler(serverExHandler.get());
                 }
                 broadcastServer.thread.start();
             }
@@ -173,26 +286,43 @@ public class ZBeacon
         }
     }
 
+    /**
+     * @deprecated use the builder
+     * @param beacon
+     */
+    @Deprecated
     public void setBeacon(byte[] beacon)
     {
-        this.beacon.set(beacon);
+        this.beacon.set(Arrays.copyOf(beacon, beacon.length));
     }
 
-    public byte[] getBeacon()
+    public synchronized byte[] getBeacon()
     {
-        return beacon.get();
+        byte[] beaconBuffer = beacon.get();
+        return Arrays.copyOf(beaconBuffer, beaconBuffer.length);
     }
 
-    public void setPrefix(byte[] prefix)
+    /**
+     * @deprecated use the builder
+     * @param prefix
+     */
+    @Deprecated
+    public synchronized void setPrefix(byte[] prefix)
     {
-        this.prefix.set(prefix);
+        this.prefix.set(Arrays.copyOf(prefix, prefix.length));
     }
 
-    public byte[] getPrefix()
+    public synchronized byte[] getPrefix()
     {
-        return prefix.get();
+        byte[] prefixBuffer = prefix.get();
+        return Arrays.copyOf(prefixBuffer, prefixBuffer.length);
     }
 
+    /**
+     * @deprecated use the builder
+     * @param listener
+     */
+    @Deprecated
     public void setListener(Listener listener)
     {
         this.listener.set(listener);
@@ -216,40 +346,30 @@ public class ZBeacon
      */
     private class BroadcastClient implements Runnable
     {
-        private DatagramChannel         broadcastChannel;
         private final InetSocketAddress broadcastAddress;
-        private final InetAddress interfaceAddress;
+        private final InetAddress       interfaceAddress;
         private final AtomicLong        broadcastInterval;
         private boolean                 isRunning;
         private Thread                  thread;
 
-        public BroadcastClient(byte[] interfaceAddress, String broadcastAddress, int port, AtomicLong broadcastInterval)
+        public BroadcastClient(InetAddress interfaceAddress, InetAddress broadcastAddress, int port, AtomicLong broadcastInterval)
         {
             this.broadcastInterval = broadcastInterval;
-            try {
-                this.broadcastAddress = new InetSocketAddress(InetAddress.getByName(broadcastAddress), port);
-                this.interfaceAddress = InetAddress.getByAddress(interfaceAddress);
-            }
-            catch (UnknownHostException unknownHostException) {
-                throw new RuntimeException(unknownHostException);
-            }
+            this.broadcastAddress = new InetSocketAddress(broadcastAddress, port);
+            this.interfaceAddress = interfaceAddress;
         }
 
         @Override
         public void run()
         {
-            try {
-                broadcastChannel = DatagramChannel.open();
-                //broadcastChannel.setOption(StandardSocketOptions.SO_BROADCAST, true);
-                //broadcastChannel.setOption(StandardSocketOptions.SO_REUSEADDR, true);
-                //broadcastChannel.setOption(StandardSocketOptions.SO_REUSEPORT, true);
+            try (DatagramChannel broadcastChannel = DatagramChannel.open()) {
                 broadcastChannel.socket().setBroadcast(true);
                 broadcastChannel.socket().setReuseAddress(true);
                 broadcastChannel.socket().bind(new InetSocketAddress(interfaceAddress, 0));
                 broadcastChannel.connect(broadcastAddress);
 
                 isRunning = true;
-                while (!thread.interrupted() && isRunning) {
+                while (!Thread.interrupted() && isRunning) {
                     try {
                         broadcastChannel.send(ByteBuffer.wrap(beacon.get()), broadcastAddress);
                         Thread.sleep(broadcastInterval.get());
@@ -270,12 +390,6 @@ public class ZBeacon
             finally {
                 isRunning = false;
                 thread = null;
-                try {
-                    broadcastChannel.close();
-                }
-                catch (IOException ioException) {
-                    throw new RuntimeException(ioException);
-                }
             }
         }
 
@@ -291,13 +405,13 @@ public class ZBeacon
         private Thread                thread;
         private boolean               isRunning;
 
-        public BroadcastServer(byte[] serverAddress, int port, boolean ignoreLocalAddress, boolean blocking)
+        public BroadcastServer(int port, boolean ignoreLocalAddress)
         {
             this.ignoreLocalAddress = ignoreLocalAddress;
             try {
                 // Create UDP socket
                 handle = DatagramChannel.open();
-                handle.configureBlocking(blocking);
+                handle.configureBlocking(true);
                 handle.socket().setReuseAddress(true);
                 handle.socket().bind(new InetSocketAddress(port));
             }
@@ -311,18 +425,12 @@ public class ZBeacon
         {
             ByteBuffer buffer = ByteBuffer.allocate(65535);
             SocketAddress sender;
-            int size;
             isRunning = true;
             try {
-                while (!thread.interrupted() && isRunning) {
+                while (!Thread.interrupted() && isRunning) {
                     buffer.clear();
                     try {
-                        int read = buffer.remaining();
                         sender = handle.receive(buffer);
-                        if (sender == null) {
-                            continue;
-                        }
-
                         InetAddress senderAddress = ((InetSocketAddress) sender).getAddress();
 
                         if (ignoreLocalAddress
@@ -331,8 +439,7 @@ public class ZBeacon
                             continue;
                         }
 
-                        size = read - buffer.remaining();
-                        handleMessage(buffer, size, senderAddress);
+                        handleMessage(buffer, senderAddress);
                     }
                     catch (ClosedChannelException ioException) {
                         break;
@@ -350,21 +457,22 @@ public class ZBeacon
             }
         }
 
-        private void handleMessage(ByteBuffer buffer, int size, InetAddress from)
+        private void handleMessage(ByteBuffer buffer, InetAddress from)
         {
             byte[] prefix = ZBeacon.this.prefix.get();
-            if (size < prefix.length) {
+            if (buffer.remaining() < prefix.length) {
                 return;
             }
-            ByteBuffer buf = buffer.duplicate();
-            buf.position(0);
-            for (int i = 0; i < prefix.length; i++) {
-                if (buf.get() != prefix[i]) {
-                    return;
-                }
-            }
-            // prefix matched
-            listener.get().onBeacon(from, Arrays.copyOf(buffer.array(), size));
+            buffer.flip();
+            buffer.mark();
+            byte[] prefixTry = new byte[prefix.length];
+            buffer.get(prefixTry);
+            if (Arrays.equals(prefix, prefixTry)) {
+                buffer.reset();
+                byte[] content = new byte[buffer.remaining()];
+                buffer.get(content);
+                listener.get().onBeacon(from, content);
+           }
         }
     }
 

--- a/src/test/java/org/zeromq/ZBeaconTest.java
+++ b/src/test/java/org/zeromq/ZBeaconTest.java
@@ -8,6 +8,7 @@ import java.net.InetAddress;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -15,39 +16,63 @@ import org.zeromq.ZBeacon.Listener;
 
 public class ZBeaconTest
 {
-    @Test
+    @SuppressWarnings("deprecation")
+    @Test(timeout = 2000)
     public void testUseBuilder() throws InterruptedException, IOException
     {
-        final CountDownLatch latch = new CountDownLatch(1);
+        long interval = ZBeacon.DEFAULT_BROADCAST_INTERVAL / 2;
+        AtomicLong beacon1 = new AtomicLong(0);
+        AtomicLong beacon2 = new AtomicLong(0);
+        CountDownLatch latch = new CountDownLatch(2);
         int port = Utils.findOpenPort();
-        ZBeacon.Builder builder = new ZBeacon.Builder().beacon(new byte[] { 'H', 'Y', 'D', 'R', 'A', 0x01, 0x12, 0x34 })
-                .ignoreLocalAddress(false).blocking(false).broadcastInterval(2000L).client("127.0.0.1").port(port)
-                .server(new byte[] { 127, 0, 0, 1 });
-        byte[] prefix = new byte[] { 'H', 'Y', 'D', 'R', 'A', 0x01 };
+        byte[] beacondata = new byte[] { 'H', 'Y', 'D', 'R', 'A', 0x01, 0x12, 0x34 };
+        AtomicReference<byte[]> receivedBeacon = new AtomicReference<>();
+        ZBeacon.Builder builder = new ZBeacon.Builder()
+                .beacon(beacondata)
+                .ignoreLocalAddress(false)
+                .broadcastInterval(interval)
+                .client(InetAddress.getLoopbackAddress()).port(port)
+                .server(InetAddress.getLoopbackAddress())
+                .prefix(new byte[] { 'H', 'Y', 'D', 'R', 'A', 0x01 })
+                .listener(new Listener()
+                {
+                    @Override
+                    public void onBeacon(InetAddress sender, byte[] received)
+                    {
+                        if (beacon1.get() == 0) {
+                            beacon1.set(System.currentTimeMillis());
+                        }
+                        else if (beacon2.get() == 0) {
+                            beacon2.set(System.currentTimeMillis());
+                            receivedBeacon.set(received);
+                        }
+                        latch.countDown();
+                    }
+                });
         ZBeacon beacon = builder.build();
-        beacon.setPrefix(prefix);
-        beacon.setListener(new Listener()
-        {
-            @Override
-            public void onBeacon(InetAddress sender, byte[] beacon)
-            {
-                latch.countDown();
-            }
-        });
+        try {
+            beacon.start();
+            assertThat(latch.await(interval * 3, TimeUnit.MILLISECONDS), is(Boolean.TRUE));
+        }
+        finally {
+            beacon.stop();
+        }
 
-        beacon.start();
-        latch.await(20, TimeUnit.SECONDS);
-        assertThat(latch.getCount(), is(0L));
-        beacon.stop();
+        //Ensure that the real interval is almost the required interval
+        assertThat(((beacon2.get() - beacon1.get()) / 10), is(interval / 10));
+        assertThat(receivedBeacon.get(), is(beacondata));
+
     }
 
-    @Test
+    @SuppressWarnings("deprecation")
+    @Test(timeout = 2000)
     public void testReceiveOwnBeacons() throws InterruptedException, IOException
     {
         final CountDownLatch latch = new CountDownLatch(1);
         byte[] beacon = new byte[] { 'H', 'Y', 'D', 'R', 'A', 0x01, 0x12, 0x34 };
         byte[] prefix = new byte[] { 'H', 'Y', 'D', 'R', 'A', 0x01 };
         int port = Utils.findOpenPort();
+        @SuppressWarnings("resource")
         ZBeacon zbeacon = new ZBeacon("127.0.0.1", port, beacon, false);
         zbeacon.setPrefix(prefix);
         zbeacon.setListener(new Listener()
@@ -59,13 +84,18 @@ public class ZBeaconTest
             }
         });
 
-        zbeacon.start();
-        latch.await(20, TimeUnit.SECONDS);
-        assertThat(latch.getCount(), is(0L));
-        zbeacon.stop();
+        try {
+            zbeacon.start();
+            latch.await(20, TimeUnit.SECONDS);
+            assertThat(latch.getCount(), is(0L));
+        }
+        finally {
+            zbeacon.stop();
+        }
     }
 
-    @Test
+    @SuppressWarnings("deprecation")
+    @Test(timeout = 2000)
     @Ignore
     public void testIgnoreOwnBeacon() throws IOException, InterruptedException
     {
@@ -73,6 +103,7 @@ public class ZBeaconTest
 
         final byte[] beacon = new byte[] { 'Z', 'R', 'E', 0x01, 0x2 };
         final byte[] prefix = new byte[] { 'Z', 'R', 'E', 0x01 };
+        @SuppressWarnings("resource")
         final ZBeacon zbeacon = new ZBeacon(ZBeacon.DEFAULT_BROADCAST_HOST, port, beacon, true);
         zbeacon.setPrefix(prefix);
 
@@ -100,13 +131,15 @@ public class ZBeaconTest
         assertThat(counter.get(), is(0L));
     }
 
-    @Test
+    @SuppressWarnings("deprecation")
+    @Test(timeout = 2000)
     public void testReceiveOwnBeaconsBlocking() throws InterruptedException, IOException
     {
         final CountDownLatch latch = new CountDownLatch(1);
         byte[] beacon = new byte[] { 'H', 'Y', 'D', 'R', 'A', 0x01, 0x12, 0x34 };
         byte[] prefix = new byte[] { 'H', 'Y', 'D', 'R', 'A', 0x01 };
         int port = Utils.findOpenPort();
+        @SuppressWarnings("resource")
         ZBeacon zbeacon = new ZBeacon("127.0.0.1", port, beacon, false, true);
         zbeacon.setPrefix(prefix);
         zbeacon.setListener(new Listener()
@@ -118,13 +151,18 @@ public class ZBeaconTest
             }
         });
 
-        zbeacon.start();
-        latch.await(20, TimeUnit.SECONDS);
-        assertThat(latch.getCount(), is(0L));
-        zbeacon.stop();
+        try {
+            zbeacon.start();
+            latch.await(20, TimeUnit.SECONDS);
+            assertThat(latch.getCount(), is(0L));
+        }
+        finally {
+            zbeacon.stop();
+        }
     }
 
-    @Test
+    @SuppressWarnings("deprecation")
+    @Test(timeout = 2000)
     @Ignore
     public void testIgnoreOwnBeaconBlocking() throws IOException, InterruptedException
     {
@@ -132,6 +170,7 @@ public class ZBeaconTest
 
         final byte[] beacon = new byte[] { 'Z', 'R', 'E', 0x01, 0x2 };
         final byte[] prefix = new byte[] { 'Z', 'R', 'E', 0x01 };
+        @SuppressWarnings("resource")
         final ZBeacon zbeacon = new ZBeacon(ZBeacon.DEFAULT_BROADCAST_HOST, port, beacon, true, true);
         zbeacon.setPrefix(prefix);
 


### PR DESCRIPTION
 The builder can be used exclusively, perhaps ZBeacon could be set immutable in a major revision ?
Client and server address was given using a String or a byte[]. Added direct
InetAddress support and deprecate old usage.
The message handler callback was given the full ByteBuffer (65535 bytes). It
now receives only the message payload, including the prefix.

The ZBeacon test was not complete. A few test were added when ZBeacon is
build using a builder.