### PR TITLE
Third try to improve TestZPoller.

### DIFF
--- a/src/main/java/org/zeromq/ZContext.java
+++ b/src/main/java/org/zeromq/ZContext.java
@@ -162,26 +162,6 @@ public class ZContext implements Closeable
         if (s == null) {
             return;
         }
-        s.setLinger(linger);
-        try {
-            s.internalClose();
-        }
-        finally {
-            sockets.remove(s);
-        }
-    }
-
-    /**
-     * Close managed socket within this context and remove from sockets list.
-     * There is no need to call this method as any {@link Socket} created by
-     * this context will call it on termination.
-     * @param s {@link org.zeromq.ZMQ.Socket} object to destroy
-     */
-    void closeSocket(Socket s)
-    {
-        if (s == null) {
-            return;
-        }
         try {
             s.internalClose();
         }
@@ -299,6 +279,9 @@ public class ZContext implements Closeable
     public void setLinger(int linger)
     {
         this.linger = linger;
+        for (Socket s : sockets) {
+            s.setLinger(linger, true);
+        }
     }
 
     /**


### PR DESCRIPTION
Issue #800  was indeed a problem in the linger of the test. But I also raising problems
with linking of linger in ZMQ.Socket and ZContext. When a socket is obtained
from a ZContext, the linger value of this socket is meaningless. So let
ZContext handle it for all it's owned socket, and explained it in the documentation.

That don't change the old inner working, but make it more explicit in code
and documentation.

Another solution would be to use the context linger only as an hint and let
each socket manage it's own linger, so removing the Socket.setLinger in
ZContext.destroySocket, just using it at socket creation.

Any way, in the test, the linger needs to be set to a non null value.