### PR TITLE
Improving some tests

### DIFF
--- a/src/test/java/org/zeromq/TestPoller.java
+++ b/src/test/java/org/zeromq/TestPoller.java
@@ -44,6 +44,7 @@ public class TestPoller
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testPollerPollout() throws Exception
     {
@@ -86,6 +87,7 @@ public class TestPoller
         context.term();
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testExitPollerIssue580() throws InterruptedException, ExecutionException
     {

--- a/src/test/java/org/zeromq/TestPoller.java
+++ b/src/test/java/org/zeromq/TestPoller.java
@@ -44,7 +44,7 @@ public class TestPoller
         }
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testPollerPollout() throws Exception
     {
         int port = Utils.findOpenPort();
@@ -86,7 +86,7 @@ public class TestPoller
         context.term();
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testExitPollerIssue580() throws InterruptedException, ExecutionException
     {
         Future<Integer> future = null;

--- a/src/test/java/org/zeromq/TestPoller.java
+++ b/src/test/java/org/zeromq/TestPoller.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -18,8 +19,9 @@ public class TestPoller
 {
     static class Client implements Runnable
     {
-        private final AtomicBoolean received = new AtomicBoolean();
-        private final String        address;
+        private final AtomicBoolean  received = new AtomicBoolean();
+        private final String         address;
+        private final CountDownLatch ready = new CountDownLatch(0);
 
         public Client(String addr)
         {
@@ -37,6 +39,11 @@ public class TestPoller
             System.out.println("Receiver Started");
             pullConnect.recv(0);
             received.set(true);
+            try {
+                ready.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
 
             pullConnect.close();
             context.close();
@@ -63,23 +70,26 @@ public class TestPoller
         ZMQ.Poller outItems = context.poller();
         outItems.register(sender, ZMQ.Poller.POLLOUT);
 
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-        while (!Thread.currentThread().isInterrupted()) {
-            outItems.poll(1000);
-            if (outItems.pollout(0)) {
-                boolean rc = sender.send("OK", 0);
-                assertThat(rc, is(true));
-                System.out.println("Sender: wrote message");
-                break;
-            }
-            else {
-                System.out.println("Sender: not writable");
-                executor.submit(client);
-            }
+        ExecutorService executor;
+        try {
+            executor = Executors.newSingleThreadExecutor();
+            while (!Thread.currentThread().isInterrupted()) {
+                outItems.poll(1000);
+                if (outItems.pollout(0)) {
+                    boolean rc = sender.send("OK", 0);
+                    assertThat(rc, is(true));
+                    System.out.println("Sender: wrote message");
+                    break;
+                } else {
+                    System.out.println("Sender: not writable");
+                    executor.submit(client);
+                }
+            } 
+        } finally {
+            client.ready.countDown();
         }
-
         executor.shutdown();
-        executor.awaitTermination(30, TimeUnit.SECONDS);
+        executor.awaitTermination(4, TimeUnit.SECONDS);
         outItems.close();
         sender.close();
         System.out.println("Poller test done");
@@ -95,8 +105,8 @@ public class TestPoller
 
         ExecutorService service = Executors.newSingleThreadExecutor();
         try (
-             ZContext context = new ZContext(1);
-             ZMQ.Poller poller = context.createPoller(1)) {
+            ZContext context = new ZContext(1);
+            ZMQ.Poller poller = context.createPoller(1)) {
             ZMQ.Socket socket = context.createSocket(SocketType.PAIR);
             assertThat(socket, notNullValue());
 

--- a/src/test/java/org/zeromq/TestProxy.java
+++ b/src/test/java/org/zeromq/TestProxy.java
@@ -30,6 +30,7 @@ public class TestProxy
             this.frontend = frontend;
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public void run()
         {

--- a/src/test/java/org/zeromq/TestZContext.java
+++ b/src/test/java/org/zeromq/TestZContext.java
@@ -46,6 +46,7 @@ public class TestZContext
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testConstruction()
     {
@@ -77,6 +78,7 @@ public class TestZContext
         assertThat(ctx1.getContext(), notNullValue());
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testAddingSockets() throws ZMQException
     {

--- a/src/test/java/org/zeromq/TestZContext.java
+++ b/src/test/java/org/zeromq/TestZContext.java
@@ -33,18 +33,16 @@ public class TestZContext
         ctx.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testZContextLinger()
     {
-        ZContext ctx = new ZContext();
-        int linger = ctx.getLinger();
-        assertThat(linger, is(0));
-
-        final int newLinger = 1000;
-        ctx.setLinger(newLinger);
-        linger = ctx.getLinger();
-        assertThat(linger, is(newLinger));
-        ctx.close();
+        try (ZContext ctx = new ZContext()) {
+            ctx.setLinger(125);
+            Socket s = ctx.createSocket(SocketType.PUSH);
+            assertThat(ctx.getLinger(), is(125));
+            assertThat(s.getLinger(), is(125));
+        }
     }
 
     @Test(timeout = 5000)

--- a/src/test/java/org/zeromq/TestZContext.java
+++ b/src/test/java/org/zeromq/TestZContext.java
@@ -9,6 +9,7 @@ import org.zeromq.ZMQ.Socket;
 
 public class TestZContext
 {
+    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testZContext()
     {
@@ -94,6 +95,7 @@ public class TestZContext
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testRemovingSockets() throws ZMQException
     {
@@ -129,6 +131,7 @@ public class TestZContext
         ctx.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testSeveralPendingInprocSocketsAreClosedIssue595()
     {

--- a/src/test/java/org/zeromq/TestZPoller.java
+++ b/src/test/java/org/zeromq/TestZPoller.java
@@ -38,6 +38,7 @@ public class TestZPoller
             this.count = count;
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public Boolean apply(SelectableChannel channel, Integer events)
         {
@@ -130,6 +131,7 @@ public class TestZPoller
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testPollerPollout() throws IOException, InterruptedException
     {
@@ -171,6 +173,7 @@ public class TestZPoller
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testUseNull() throws IOException
     {
@@ -236,6 +239,7 @@ public class TestZPoller
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testGlobalHandler() throws IOException
     {
@@ -253,6 +257,7 @@ public class TestZPoller
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testItemEqualsBasic() throws IOException
     {
@@ -276,6 +281,7 @@ public class TestZPoller
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testItemEquals() throws IOException
     {
@@ -310,6 +316,7 @@ public class TestZPoller
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testReadable() throws IOException
     {
@@ -334,6 +341,7 @@ public class TestZPoller
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testWritable() throws IOException
     {
@@ -358,6 +366,7 @@ public class TestZPoller
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testError() throws IOException
     {
@@ -382,6 +391,7 @@ public class TestZPoller
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testRegister() throws IOException
     {
@@ -399,6 +409,7 @@ public class TestZPoller
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testItems() throws IOException
     {
@@ -420,6 +431,7 @@ public class TestZPoller
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testMultipleRegistrations() throws IOException
     {
@@ -455,6 +467,7 @@ public class TestZPoller
         }
     }
 
+    @SafeVarargs
     private final Pipe pipe(ZPoller poller, BiFunction<SelectableChannel, Integer, Boolean> errors,
                             BiFunction<SelectableChannel, Integer, Boolean>... ins)
                                     throws IOException
@@ -472,6 +485,7 @@ public class TestZPoller
         return pipe;
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testIssue729() throws InterruptedException, IOException
     {

--- a/src/test/java/org/zeromq/ZBeaconTest.java
+++ b/src/test/java/org/zeromq/ZBeaconTest.java
@@ -2,6 +2,7 @@ package org.zeromq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -59,7 +60,8 @@ public class ZBeaconTest
         }
 
         //Ensure that the real interval is almost the required interval
-        assertThat(((beacon2.get() - beacon1.get()) / 10), is(interval / 10));
+        long delta = beacon2.get() - beacon1.get();
+        assertTrue(String.format("expected %d, got %d",  interval, delta), (delta > interval - 10) && (delta < interval + 10));
         assertThat(receivedBeacon.get(), is(beacondata));
 
     }

--- a/src/test/java/org/zeromq/guide/EspressoTest.java
+++ b/src/test/java/org/zeromq/guide/EspressoTest.java
@@ -193,7 +193,7 @@ public class EspressoTest
         final int frontend = Utils.findOpenPort();
         final int backend = Utils.findOpenPort();
         try (
-             final ZContext ctx = new ZContext()) {
+            final ZContext ctx = new ZContext()) {
             ZActor publisher = new ZActor(ctx, new Publisher(frontend), "motdelafin");
             ZActor subscriber = new ZActor(ctx, new Subscriber(backend), "motdelafin");
             ZActor listener = new ZActor(ctx, new Listener(), "motdelafin");

--- a/src/test/java/zmq/Helper.java
+++ b/src/test/java/zmq/Helper.java
@@ -143,6 +143,7 @@ public class Helper
 
     }
 
+    @SuppressWarnings("deprecation")
     public static void bounce(SocketBase sb, SocketBase sc)
     {
         byte[] content = "12345678ABCDEFGH12345678abcdefgh".getBytes(ZMQ.CHARSET);

--- a/src/test/java/zmq/PollTest.java
+++ b/src/test/java/zmq/PollTest.java
@@ -30,7 +30,7 @@ public class PollTest
         R apply(ByteBuffer bb) throws IOException;
     }
 
-    @Test
+    @Test(timeout = 1000)
     public void testPollTcp() throws IOException
     {
         ServerSocketChannel server = ServerSocketChannel.open();
@@ -61,7 +61,7 @@ public class PollTest
         }
     }
 
-    @Test
+    @Test(timeout = 1000)
     public void testPollPipe() throws IOException
     {
         Pipe pipe = Pipe.open();
@@ -85,7 +85,7 @@ public class PollTest
 
     }
 
-    @Test
+    @Test(timeout = 1000)
     public void testPollUdp() throws IOException
     {
         DatagramChannel in = DatagramChannel.open();
@@ -154,7 +154,7 @@ public class PollTest
     }
 
     @Ignore
-    @Test
+    @Test(timeout = 1000)
     public void testRepeated() throws IOException
     {
         for (int idx = 0; idx < 10_000_000; ++idx) {

--- a/src/test/java/zmq/socket/pair/TestPairIpc.java
+++ b/src/test/java/zmq/socket/pair/TestPairIpc.java
@@ -18,6 +18,7 @@ public class TestPairIpc
     //  Create REQ/ROUTER wiring.
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testPairIpc()
     {
         Ctx ctx = ZMQ.init(1);

--- a/src/test/java/zmq/socket/pair/TestPairIpc.java
+++ b/src/test/java/zmq/socket/pair/TestPairIpc.java
@@ -17,8 +17,8 @@ public class TestPairIpc
 {
     //  Create REQ/ROUTER wiring.
 
-    @Test
     @SuppressWarnings("deprecation")
+    @Test(timeout = 5000)
     public void testPairIpc()
     {
         Ctx ctx = ZMQ.init(1);


### PR DESCRIPTION
Many tests are flaky, some test failures are ignored, some are too slow. Old Junit assertions are used, trying to reduce code warning.

Not all problems are solved. But it should reduce the number of false negative during CI tests, and perhaps catch some false positive.

A test in ZContext was wrong, it's corrected.