### PR TITLE
NetProtocol was not made Enum enough

### DIFF
--- a/src/main/java/zmq/io/SessionBase.java
+++ b/src/main/java/zmq/io/SessionBase.java
@@ -475,8 +475,7 @@ public class SessionBase extends Own implements Pipe.IPipeEvents, IPollEvents
 
         //  For delayed connect situations, terminate the pipe
         //  and reestablish later on
-        if (pipe != null && !options.immediate && !NetProtocol.pgm.equals(addr.protocol())
-                && !NetProtocol.epgm.equals(addr.protocol()) && !NetProtocol.norm.equals(addr.protocol())) {
+        if (pipe != null && !options.immediate && ! addr.protocol().isMulticast) {
             pipe.hiccup();
             pipe.terminate(false);
             terminatingPipes.add(pipe);
@@ -516,7 +515,7 @@ public class SessionBase extends Own implements Pipe.IPipeEvents, IPollEvents
         switch (protocol) {
         case tcp:
             if (options.socksProxyAddress != null) {
-                Address proxyAddress = new Address(NetProtocol.tcp.name(), options.socksProxyAddress);
+                Address proxyAddress = new Address(NetProtocol.tcp, options.socksProxyAddress);
                 SocksConnecter connecter = new SocksConnecter(ioThread, this, options, addr, proxyAddress, wait);
                 launchChild(connecter);
             }

--- a/src/main/java/zmq/io/net/Address.java
+++ b/src/main/java/zmq/io/net/Address.java
@@ -3,9 +3,6 @@ package zmq.io.net;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
-import zmq.io.net.ipc.IpcAddress;
-import zmq.io.net.tcp.TcpAddress;
-
 public class Address
 {
     public interface IZAddress
@@ -26,9 +23,26 @@ public class Address
 
     private IZAddress resolved;
 
+    /**
+     * @param protocol
+     * @param address
+     * @throws {@link IllegalArgumentException} if the protocol name can be matched to an actual supported protocol
+     */
+    @Deprecated
     public Address(final String protocol, final String address)
     {
         this.protocol = NetProtocol.getProtocol(protocol);
+        this.address = address;
+        resolved = null;
+    }
+
+    /**
+     * @param protocol
+     * @param address
+     */
+    public Address(final NetProtocol protocol, final String address)
+    {
+        this.protocol = protocol;
         this.address = address;
         resolved = null;
     }
@@ -44,10 +58,7 @@ public class Address
     @Override
     public String toString()
     {
-        if (NetProtocol.tcp == protocol && isResolved()) {
-            return resolved.toString();
-        }
-        else if (NetProtocol.ipc == protocol && isResolved()) {
+        if (isResolved()) {
             return resolved.toString();
         }
         else if (protocol != null && !address.isEmpty()) {
@@ -89,16 +100,7 @@ public class Address
 
     public IZAddress resolve(boolean ipv6)
     {
-        if (NetProtocol.tcp.equals(protocol)) {
-            resolved = new TcpAddress(address, ipv6);
-            return resolved;
-        }
-        else if (NetProtocol.ipc.equals(protocol)) {
-            resolved = new IpcAddress(address);
-            return resolved;
-        }
-        else {
-            return null;
-        }
+        resolved = protocol.zresolve(address, ipv6);
+        return resolved;
     }
 }

--- a/src/main/java/zmq/io/net/Listener.java
+++ b/src/main/java/zmq/io/net/Listener.java
@@ -1,0 +1,23 @@
+package zmq.io.net;
+
+import zmq.Options;
+import zmq.Own;
+import zmq.SocketBase;
+import zmq.io.IOThread;
+import zmq.poll.IPollEvents;
+
+public abstract class Listener extends Own implements IPollEvents
+{
+    //  Socket the listener belongs to.
+    protected final SocketBase socket;
+
+    protected Listener(IOThread ioThread, SocketBase socket, final Options options)
+    {
+        super(ioThread, options);
+        this.socket = socket;
+    }
+
+    public abstract boolean setAddress(String addr);
+
+    public abstract String getAddress();
+}

--- a/src/main/java/zmq/io/net/NetProtocol.java
+++ b/src/main/java/zmq/io/net/NetProtocol.java
@@ -1,41 +1,137 @@
 package zmq.io.net;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
 
+import zmq.Options;
+import zmq.SocketBase;
+import zmq.io.IOThread;
+import zmq.io.net.Address.IZAddress;
+import zmq.io.net.ipc.IpcAddress;
+import zmq.io.net.ipc.IpcListener;
+import zmq.io.net.tcp.TcpAddress;
+import zmq.io.net.tcp.TcpListener;
+import zmq.io.net.tipc.TipcListener;
 import zmq.socket.Sockets;
 
 public enum NetProtocol
 {
-    inproc(true),
-    ipc(true),
-    tcp(true),
-    pgm(false, Sockets.PUB, Sockets.SUB, Sockets.XPUB, Sockets.XPUB),
-    epgm(false, Sockets.PUB, Sockets.SUB, Sockets.XPUB, Sockets.XPUB),
-    tipc(false),
-    norm(false);
+    inproc(true, false, false),
+    ipc(true, false, false)
+    {
+        @Override
+        public Listener getListener(IOThread ioThread, SocketBase socket,
+                                    Options options)
+        {
+            return new IpcListener(ioThread, socket, options);
+        }
+
+        @Override
+        public void resolve(Address paddr, boolean ipv6)
+        {
+            paddr.resolve(ipv6);
+        }
+
+        @Override
+        public IZAddress zresolve(String addr, boolean ipv6)
+        {
+            return new IpcAddress(addr);
+        }
+
+    },
+    tcp(true, false, false)
+    {
+        @Override
+        public Listener getListener(IOThread ioThread, SocketBase socket,
+                                    Options options)
+        {
+            return new TcpListener(ioThread, socket, options);
+        }
+
+        @Override
+        public void resolve(Address paddr, boolean ipv6)
+        {
+            paddr.resolve(ipv6);
+        }
+
+        @Override
+        public IZAddress zresolve(String addr, boolean ipv6)
+        {
+            return  new TcpAddress(addr, ipv6);
+        }
+
+    },
+    //  PGM does not support subscription forwarding; ask for all data to be
+    //  sent to this pipe. (same for NORM, currently?)
+    pgm(false, true, true, Sockets.PUB, Sockets.SUB, Sockets.XPUB, Sockets.XPUB),
+    epgm(false, true, true, Sockets.PUB, Sockets.SUB, Sockets.XPUB, Sockets.XPUB),
+    tipc(false, false, false)
+    {
+        @Override
+        public Listener getListener(IOThread ioThread, SocketBase socket,
+                                    Options options)
+        {
+            return new TipcListener(ioThread, socket, options);
+        }
+
+        @Override
+        public void resolve(Address paddr, boolean ipv6)
+        {
+            paddr.resolve(ipv6);
+        }
+
+    },
+    norm(false, true, true);
 
     public final boolean  valid;
-    private List<Sockets> compatibles;
+    public final boolean  subscribe2all;
+    public final boolean  isMulticast;
+    private Set<Integer> compatibles;
 
-    NetProtocol(boolean implemented, Sockets... compatibles)
+    NetProtocol(boolean implemented, boolean subscribe2all, boolean isMulticast, Sockets... compatibles)
     {
         valid = implemented;
-        this.compatibles = Arrays.asList(compatibles);
+        this.compatibles = new HashSet<>(compatibles.length);
+        for (Sockets s : compatibles) {
+            this.compatibles.add(s.ordinal());
+        }
+        this.subscribe2all = subscribe2all;
+        this.isMulticast = isMulticast;
     }
 
+    /**
+     * @param protocol name
+     * @throws {@link IllegalArgumentException} if the protocol name can be matched to an actual supported protocol
+     * @return
+     */
     public static NetProtocol getProtocol(String protocol)
     {
-        for (NetProtocol candidate : values()) {
-            if (candidate.name().equals(protocol)) {
-                return candidate;
-            }
+        try {
+            return valueOf(protocol.toLowerCase(Locale.ENGLISH));
         }
-        return null;
+        catch (NullPointerException | IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unknown protocol: \"" + protocol + "\"");
+        }
     }
 
     public final boolean compatible(int type)
     {
-        return compatibles.isEmpty() || compatibles.contains(Sockets.fromType(type));
+        return compatibles.isEmpty() || compatibles.contains(type);
+    }
+
+    public Listener getListener(IOThread ioThread, SocketBase socket, Options options)
+    {
+        return null;
+    }
+
+    public void resolve(Address paddr, boolean ipv6)
+    {
+        // TODO V4 init address for pgm & epgm
+    }
+
+    public IZAddress zresolve(String addr, boolean ipv6)
+    {
+        return null;
     }
 }

--- a/src/main/java/zmq/io/net/tcp/TcpListener.java
+++ b/src/main/java/zmq/io/net/tcp/TcpListener.java
@@ -7,7 +7,6 @@ import java.nio.channels.SocketChannel;
 import java.util.Locale;
 
 import zmq.Options;
-import zmq.Own;
 import zmq.SocketBase;
 import zmq.ZError;
 import zmq.io.IOObject;
@@ -15,14 +14,14 @@ import zmq.io.IOThread;
 import zmq.io.SessionBase;
 import zmq.io.StreamEngine;
 import zmq.io.net.Address.IZAddress;
+import zmq.io.net.Listener;
 import zmq.io.net.StandardProtocolFamily;
-import zmq.poll.IPollEvents;
 import zmq.poll.Poller;
 import zmq.socket.Sockets;
 
-public class TcpListener extends Own implements IPollEvents
+public class TcpListener extends Listener
 {
-    private static boolean isWindows;
+    private static final boolean isWindows;
     static {
         String os = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
         isWindows = os.contains("win");
@@ -35,9 +34,6 @@ public class TcpListener extends Own implements IPollEvents
     private ServerSocketChannel fd;
     private Poller.Handle       handle;
 
-    //  Socket the listerner belongs to.
-    private SocketBase socket;
-
     // String representation of endpoint to bind to
     private String endpoint;
 
@@ -45,11 +41,10 @@ public class TcpListener extends Own implements IPollEvents
 
     public TcpListener(IOThread ioThread, SocketBase socket, final Options options)
     {
-        super(ioThread, options);
+        super(ioThread, socket, options);
 
         ioObject = new IOObject(ioThread, this);
         fd = null;
-        this.socket = socket;
     }
 
     @Override

--- a/src/test/java/zmq/Helper.java
+++ b/src/test/java/zmq/Helper.java
@@ -16,6 +16,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import zmq.io.IOThread;
 import zmq.io.SessionBase;
 import zmq.io.net.Address;
+import zmq.io.net.NetProtocol;
 import zmq.pipe.Pipe;
 import zmq.util.Errno;
 
@@ -113,7 +114,7 @@ public class Helper
 
         public DummySession()
         {
-            this(new DummyIOThread(), false, new DummySocket(), new Options(), new Address("tcp", "localhost:9090"));
+            this(new DummyIOThread(), false, new DummySocket(), new Options(), new Address(NetProtocol.tcp, "localhost:9090"));
         }
 
         public DummySession(IOThread ioThread, boolean connect, SocketBase socket, Options options, Address addr)

--- a/src/test/java/zmq/io/net/tcp/TcpAddressTest.java
+++ b/src/test/java/zmq/io/net/tcp/TcpAddressTest.java
@@ -24,7 +24,7 @@ public class TcpAddressTest
     {
         String addressString = "2000::a1";
         int port = Utils.findOpenPort();
-        Address addr = new Address(NetProtocol.tcp.name(), addressString + ":" + port);
+        Address addr = new Address(NetProtocol.tcp, addressString + ":" + port);
         addr.resolve(true);
         InetSocketAddress expected = new InetSocketAddress(addressString, port);
         Address.IZAddress resolved = addr.resolved();
@@ -39,7 +39,7 @@ public class TcpAddressTest
     {
         String addressString = "2000::a1";
         int port = Utils.findOpenPort();
-        Address addr = new Address(NetProtocol.tcp.name(), "[" + addressString + "]:" + port);
+        Address addr = new Address(NetProtocol.tcp, "[" + addressString + "]:" + port);
         addr.resolve(true);
         InetSocketAddress expected = new InetSocketAddress(addressString, port);
         Address.IZAddress resolved = addr.resolved();
@@ -55,7 +55,7 @@ public class TcpAddressTest
         try {
             String addressString = "2000::a1";
             int port = Utils.findOpenPort();
-            Address addr = new Address(NetProtocol.tcp.name(),
+            Address addr = new Address(NetProtocol.tcp,
                                        addressString + ":" + port);
             addr.resolve(false);
             InetSocketAddress expected = new InetSocketAddress(addressString,
@@ -77,7 +77,7 @@ public class TcpAddressTest
     @Test
     public void testGoodIPv6Google()
     {
-        Address addr = new Address(NetProtocol.tcp.name(), "www.google.com:80");
+        Address addr = new Address(NetProtocol.tcp, "www.google.com:80");
         addr.resolve(true);
         Address.IZAddress resolved = addr.resolved();
         InetSocketAddress sa = (InetSocketAddress) resolved.address();
@@ -88,7 +88,7 @@ public class TcpAddressTest
     @Test
     public void testGoodIP46Google()
     {
-        Address addr = new Address(NetProtocol.tcp.name(), "www.google.com:80");
+        Address addr = new Address(NetProtocol.tcp, "www.google.com:80");
         addr.resolve(false);
         Address.IZAddress resolved = addr.resolved();
         InetSocketAddress sa = (InetSocketAddress) resolved.address();
@@ -100,7 +100,7 @@ public class TcpAddressTest
     public void testBad()
     {
         try {
-            Address addr = new Address(NetProtocol.tcp.name(), "ggglocalhostxxx.google.com:80");
+            Address addr = new Address(NetProtocol.tcp, "ggglocalhostxxx.google.com:80");
             addr.resolve(true);
             addr.resolved();
             Assert.fail();
@@ -115,7 +115,7 @@ public class TcpAddressTest
     public void testUnspecifiedIPv6DoubleColon() throws IOException
     {
         int port = Utils.findOpenPort();
-        Address addr = new Address(NetProtocol.tcp.name(), ":::" + port);
+        Address addr = new Address(NetProtocol.tcp, ":::" + port);
         addr.resolve(true);
         Address.IZAddress resolved = addr.resolved();
         InetSocketAddress sa = (InetSocketAddress) resolved.address();
@@ -129,7 +129,7 @@ public class TcpAddressTest
     public void testUnspecifiedIPv6Star() throws IOException
     {
         int port = Utils.findOpenPort();
-        Address addr = new Address(NetProtocol.tcp.name(), "*:" + port);
+        Address addr = new Address(NetProtocol.tcp, "*:" + port);
         addr.resolve(true);
         Address.IZAddress resolved = addr.resolved();
         InetSocketAddress sa = (InetSocketAddress) resolved.address();
@@ -143,7 +143,7 @@ public class TcpAddressTest
     public void testUnspecifiedIPv4() throws IOException
     {
         int port = Utils.findOpenPort();
-        Address addr = new Address(NetProtocol.tcp.name(), "*:" + port);
+        Address addr = new Address(NetProtocol.tcp, "*:" + port);
         addr.resolve(false);
         Address.IZAddress resolved = addr.resolved();
         InetSocketAddress sa = (InetSocketAddress) resolved.address();


### PR DESCRIPTION
- Protocol name was used in place were NetProtocol would be better.
- Using .equals() were == works and is more readable.
- Remove some tests where a simple provider method in enum can do the same with more straigthfull code
- Adding a Listener abstract class, to hide the actual implementation of ipc protocol using tcp.
- NetProtocol.getProcol throws an IllegalArgumentException, more robust than a null that can sneak around. So SocketBase.checkProtocol needs to handle that.
- zmq.io.net.Address was missing a constructor using directly NetProtocol, deprecate the old constructor taking a String.
- Added explicit flag for multicasp transport kind. Is it redudant with subscribe2all ?
- Slightly better NetProtocol.isCompatible, using a Set instead of an List.