### PR TITLE
Ipc v6

### DIFF
--- a/src/main/java/zmq/Options.java
+++ b/src/main/java/zmq/Options.java
@@ -192,8 +192,7 @@ public class Options
         maxMsgSize = -1;
         recvTimeout = -1;
         sendTimeout = -1;
-        ipv6 = "false".equals(System.getProperty("java.net.preferIPv4Stack", null)) ||
-               "true".equals(System.getProperty("java.net.preferIPv6Addresses", null));
+        ipv6 = ZMQ.PREFER_IPV6;
         immediate = true;
         filter = false;
         recvIdentity = false;

--- a/src/main/java/zmq/ZMQ.java
+++ b/src/main/java/zmq/ZMQ.java
@@ -204,6 +204,18 @@ public class ZMQ
     public static final byte[] PROXY_RESUME    = "RESUME".getBytes(ZMQ.CHARSET);
     public static final byte[] PROXY_TERMINATE = "TERMINATE".getBytes(ZMQ.CHARSET);
 
+    public static final boolean PREFER_IPV6;
+    static {
+        String preferIPv4Stack = System.getProperty("java.net.preferIPv4Stack");
+        String preferIPv6Addresses = System.getProperty("java.net.preferIPv6Addresses");
+        if ("false".equalsIgnoreCase(preferIPv4Stack) || "true".equalsIgnoreCase(preferIPv6Addresses)) {
+            PREFER_IPV6 = true;
+        }
+        else {
+            PREFER_IPV6 = false;
+        }
+    }
+
     public static class Event
     {
         private static final int VALUE_INTEGER = 1;

--- a/src/main/java/zmq/io/net/ipc/IpcAddress.java
+++ b/src/main/java/zmq/io/net/ipc/IpcAddress.java
@@ -30,6 +30,18 @@ public class IpcAddress implements Address.IZAddress
         }
     }
 
+    private static final boolean DEFAULTIPV6;
+    static {
+        String preferIPv4Stack = System.getProperty("java.net.preferIPv4Stack", "");
+        String preferIPv6Addresses = System.getProperty("java.net.preferIPv6Addresses", "");
+        if (!"true".equalsIgnoreCase(preferIPv4Stack) && "true".equalsIgnoreCase(preferIPv6Addresses)) {
+            DEFAULTIPV6 = true;
+        }
+        else {
+            DEFAULTIPV6 = false;
+        }
+    }
+
     private String                  name;
     private final InetSocketAddress address;
     private final SocketAddress     sourceAddress;
@@ -38,9 +50,9 @@ public class IpcAddress implements Address.IZAddress
     {
         String[] strings = addr.split(";");
 
-        address = resolve(strings[0], false, false);
+        address = resolve(strings[0], DEFAULTIPV6, true);
         if (strings.length == 2 && !"".equals(strings[1])) {
-            sourceAddress = resolve(strings[1], false, false);
+            sourceAddress = resolve(strings[1], DEFAULTIPV6, true);
         }
         else {
             sourceAddress = null;
@@ -68,7 +80,7 @@ public class IpcAddress implements Address.IZAddress
     }
 
     @Override
-    public InetSocketAddress resolve(String name, boolean ipv6, boolean local)
+    public InetSocketAddress resolve(String name, boolean ipv6, boolean loopback)
     {
         this.name = name;
 
@@ -84,7 +96,7 @@ public class IpcAddress implements Address.IZAddress
             hash += 10000;
         }
 
-        return new InetSocketAddress(findAddress(ipv6, local), hash);
+        return new InetSocketAddress(findAddress(ipv6, loopback), hash);
     }
 
     @Override
@@ -105,16 +117,16 @@ public class IpcAddress implements Address.IZAddress
         return sourceAddress;
     }
 
-    private InetAddress findAddress(boolean ipv6, boolean local)
+    private InetAddress findAddress(boolean ipv6, boolean loopback)
     {
-        Class addressClass = ipv6 ? Inet6Address.class : Inet4Address.class;
+        Class<? extends InetAddress> addressClass = ipv6 ? Inet6Address.class : Inet4Address.class;
         try {
             for (Enumeration<NetworkInterface> interfaces = NetworkInterface
                     .getNetworkInterfaces(); interfaces.hasMoreElements(); ) {
                 NetworkInterface net = interfaces.nextElement();
                 for (Enumeration<InetAddress> addresses = net.getInetAddresses(); addresses.hasMoreElements(); ) {
                     InetAddress inetAddress = addresses.nextElement();
-                    if (inetAddress.isLoopbackAddress() == local && addressClass.isInstance(inetAddress)) {
+                    if (inetAddress.isLoopbackAddress() == loopback && addressClass.isInstance(inetAddress)) {
                         return inetAddress;
                     }
                 }
@@ -123,6 +135,6 @@ public class IpcAddress implements Address.IZAddress
         catch (SocketException e) {
             throw new IllegalArgumentException(e);
         }
-        throw new IllegalArgumentException("no address found " + (ipv6 ? "IPV6" : "IPV4") + (local ? "local" : ""));
+        throw new IllegalArgumentException("no address found " + (ipv6 ? "IPV6" : "IPV4") + (loopback ? "local" : ""));
     }
 }

--- a/src/main/java/zmq/io/net/ipc/IpcAddress.java
+++ b/src/main/java/zmq/io/net/ipc/IpcAddress.java
@@ -9,6 +9,7 @@ import java.net.SocketAddress;
 import java.net.SocketException;
 import java.util.Enumeration;
 
+import zmq.ZMQ;
 import zmq.io.net.Address;
 import zmq.io.net.ProtocolFamily;
 import zmq.io.net.StandardProtocolFamily;
@@ -30,18 +31,6 @@ public class IpcAddress implements Address.IZAddress
         }
     }
 
-    private static final boolean DEFAULTIPV6;
-    static {
-        String preferIPv4Stack = System.getProperty("java.net.preferIPv4Stack", "");
-        String preferIPv6Addresses = System.getProperty("java.net.preferIPv6Addresses", "");
-        if (!"true".equalsIgnoreCase(preferIPv4Stack) && "true".equalsIgnoreCase(preferIPv6Addresses)) {
-            DEFAULTIPV6 = true;
-        }
-        else {
-            DEFAULTIPV6 = false;
-        }
-    }
-
     private String                  name;
     private final InetSocketAddress address;
     private final SocketAddress     sourceAddress;
@@ -50,9 +39,9 @@ public class IpcAddress implements Address.IZAddress
     {
         String[] strings = addr.split(";");
 
-        address = resolve(strings[0], DEFAULTIPV6, true);
+        address = resolve(strings[0], ZMQ.PREFER_IPV6, true);
         if (strings.length == 2 && !"".equals(strings[1])) {
-            sourceAddress = resolve(strings[1], DEFAULTIPV6, true);
+            sourceAddress = resolve(strings[1], ZMQ.PREFER_IPV6, true);
         }
         else {
             sourceAddress = null;

--- a/src/main/java/zmq/io/net/ipc/IpcListener.java
+++ b/src/main/java/zmq/io/net/ipc/IpcListener.java
@@ -35,7 +35,6 @@ public class IpcListener extends TcpListener
         address = new IpcAddress(addr);
 
         InetSocketAddress sock = (InetSocketAddress) address.address();
-        String fake = sock.getAddress().getHostAddress() + ":" + sock.getPort();
-        return super.setAddress(fake);
+        return super.setAddress(sock);
     }
 }

--- a/src/main/java/zmq/io/net/tcp/TcpAddress.java
+++ b/src/main/java/zmq/io/net/tcp/TcpAddress.java
@@ -45,6 +45,12 @@ public class TcpAddress implements Address.IZAddress
         }
     }
 
+    protected TcpAddress(InetSocketAddress address)
+    {
+        this.address = address;
+        sourceAddress = null;
+    }
+
     @Override
     public ProtocolFamily family()
     {

--- a/src/main/java/zmq/io/net/tcp/TcpListener.java
+++ b/src/main/java/zmq/io/net/tcp/TcpListener.java
@@ -1,6 +1,7 @@
 package zmq.io.net.tcp;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.util.Locale;
@@ -164,6 +165,19 @@ public class TcpListener extends Own implements IPollEvents
     {
         //  Convert the textual address into address structure.
         address = new TcpAddress(addr, options.ipv6);
+        return setAddress();
+    }
+
+    //  Set address to listen on, used by IpcListener that already resolved the address.
+    protected boolean setAddress(InetSocketAddress addr)
+    {
+        //  Convert the textual address into address structure.
+        address = new TcpAddress(addr);
+        return setAddress();
+    }
+
+    private boolean setAddress()
+    {
         endpoint = address.toString();
 
         //  Create a listening socket.


### PR DESCRIPTION
Detect prefered use if IPv6 in ipc implemtation, and should use a local address.

It make tests fails in some custom network setup.