### PR TITLE
Fixing some exceptions

### DIFF
--- a/src/main/java/org/zeromq/ZStar.java
+++ b/src/main/java/org/zeromq/ZStar.java
@@ -502,13 +502,7 @@ public class ZStar implements ZAgent
 
                     if (tell && gossip != null) {
                         // inform the Corbeille side of the future closing of the plateau and the vanishing of the star
-                        try {
-                            mic.send(gossip);
-                        }
-                        catch (Exception e) {
-                            // really ?
-                            e.printStackTrace();
-                        }
+                        mic.send(gossip);
                     }
 
                     // we are not in a hurry at this point when cleaning up the remains of a good show ...

--- a/src/main/java/zmq/Ctx.java
+++ b/src/main/java/zmq/Ctx.java
@@ -269,7 +269,7 @@ public class Ctx
             //  Wait till reaper thread closes all the sockets.
             Command cmd = termMailbox.recv(WAIT_FOREVER);
             if (cmd == null) {
-                throw new IllegalStateException(ZError.toString(errno.get()));
+                throw new ZMQException(errno.get());
             }
             assert (cmd.type == Command.Type.DONE) : cmd;
 
@@ -287,7 +287,7 @@ public class Ctx
             destroy();
         }
         catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new ZError.IOException(e);
         }
     }
 


### PR DESCRIPTION
- an exception caugh in ZStar that should not be.
- Some RuntimeException and IllegalStateException replaced that the usual
  exceptions from ØMQ (ZMQException or ZError.IOException