### PR TITLE
An undefine Actor.premiere should not return "?"

### DIFF
--- a/src/main/java/org/zeromq/ZActor.java
+++ b/src/main/java/org/zeromq/ZActor.java
@@ -240,8 +240,7 @@ public class ZActor extends ZStar
         @Override
         public String premiere(final Socket pipe)
         {
-            // do nothing
-            return "?";
+            return null;
         }
 
         @Override


### PR DESCRIPTION
An undefined Actor.premiere should not return "?" as it will be the thread name.

Returning null will use an automatic name.