### PR TITLE
Finishing improved monitor, with more thorought tests.

### DIFF
--- a/src/main/java/zmq/io/mechanism/Mechanism.java
+++ b/src/main/java/zmq/io/mechanism/Mechanism.java
@@ -249,21 +249,15 @@ public abstract class Mechanism
                         && reason.charAt(0) <= '5') {
             try {
                 int statusCode = Integer.parseInt(reason);
-                if (session != null) {
-                    session.getSocket().eventHandshakeFailedAuth(session.getEndpoint(), statusCode);
-                }
+                session.getSocket().eventHandshakeFailedAuth(session.getEndpoint(), statusCode);
                 rc = 0;
             }
             catch (NumberFormatException e) {
-                if (session != null) {
-                    session.getSocket().eventHandshakeFailedProtocol(session.getEndpoint(), ZMQ.ZMQ_PROTOCOL_ERROR_ZAP_MALFORMED_REPLY);
-                }
+                session.getSocket().eventHandshakeFailedProtocol(session.getEndpoint(), ZMQ.ZMQ_PROTOCOL_ERROR_ZAP_MALFORMED_REPLY);
             }
         }
         else {
-            if (session != null) {
-                session.getSocket().eventHandshakeFailedProtocol(session.getEndpoint(), ZMQ.ZMQ_PROTOCOL_ERROR_ZAP_MALFORMED_REPLY);
-            }
+            session.getSocket().eventHandshakeFailedProtocol(session.getEndpoint(), ZMQ.ZMQ_PROTOCOL_ERROR_ZAP_MALFORMED_REPLY);
         }
         return rc;
     }

--- a/src/main/java/zmq/io/mechanism/Mechanisms.java
+++ b/src/main/java/zmq/io/mechanism/Mechanisms.java
@@ -56,7 +56,7 @@ public enum Mechanisms
                 return new PlainServerMechanism(session, peerAddress, options);
             }
             else {
-                return new PlainClientMechanism(options);
+                return new PlainClientMechanism(session, options);
             }
         }
     },
@@ -85,7 +85,7 @@ public enum Mechanisms
                 return new CurveServerMechanism(session, peerAddress, options);
             }
             else {
-                return new CurveClientMechanism(options);
+                return new CurveClientMechanism(session, options);
             }
         }
     },
@@ -102,7 +102,7 @@ public enum Mechanisms
                 return new GssapiServerMechanism(session, peerAddress, options);
             }
             else {
-                return new GssapiClientMechanism(options);
+                return new GssapiClientMechanism(session, options);
             }
         }
     };

--- a/src/main/java/zmq/io/mechanism/curve/CurveClientMechanism.java
+++ b/src/main/java/zmq/io/mechanism/curve/CurveClientMechanism.java
@@ -9,6 +9,7 @@ import zmq.Msg;
 import zmq.Options;
 import zmq.ZError;
 import zmq.ZMQ;
+import zmq.io.SessionBase;
 import zmq.io.mechanism.Mechanism;
 import zmq.util.Errno;
 import zmq.util.Wire;
@@ -51,9 +52,9 @@ public class CurveClientMechanism extends Mechanism
 
     private final Errno errno;
 
-    public CurveClientMechanism(Options options)
+    public CurveClientMechanism(SessionBase session, Options options)
     {
-        super(null, null, options);
+        super(session, null, options);
         this.state = State.SEND_HELLO;
         cnNonce = 1;
         cnPeerNonce = 1;

--- a/src/main/java/zmq/io/mechanism/curve/CurveServerMechanism.java
+++ b/src/main/java/zmq/io/mechanism/curve/CurveServerMechanism.java
@@ -289,7 +289,7 @@ public class CurveServerMechanism extends Mechanism
         if (rc != 0) {
             session.getSocket().eventHandshakeFailedProtocol(session.getEndpoint(), ZMQ.ZMQ_PROTOCOL_ERROR_ZMTP_CRYPTOGRAPHIC);
             state = State.SEND_ERROR;
-            statusCode = "999";
+            statusCode = null;
             return 0;
         }
 
@@ -507,10 +507,10 @@ public class CurveServerMechanism extends Mechanism
 
     private int produceError(Msg msg)
     {
-        assert (statusCode != null && statusCode.length() == 3);
+        assert (statusCode == null || statusCode.length() == 3);
 
         msg.putShortString("ERROR");
-        if (! "999".equals(statusCode)) {
+        if (statusCode != null) {
             msg.putShortString(statusCode);
         }
 

--- a/src/main/java/zmq/io/mechanism/gssapi/GssapiClientMechanism.java
+++ b/src/main/java/zmq/io/mechanism/gssapi/GssapiClientMechanism.java
@@ -2,14 +2,15 @@ package zmq.io.mechanism.gssapi;
 
 import zmq.Msg;
 import zmq.Options;
+import zmq.io.SessionBase;
 import zmq.io.mechanism.Mechanism;
 
 // TODO V4 implement GSSAPI
 public class GssapiClientMechanism extends Mechanism
 {
-    public GssapiClientMechanism(Options options)
+    public GssapiClientMechanism(SessionBase session, Options options)
     {
-        super(null, null, options);
+        super(session, null, options);
         throw new UnsupportedOperationException("GSSAPI mechanism is not yet implemented");
     }
 

--- a/src/main/java/zmq/io/mechanism/plain/PlainClientMechanism.java
+++ b/src/main/java/zmq/io/mechanism/plain/PlainClientMechanism.java
@@ -7,6 +7,7 @@ import zmq.Msg;
 import zmq.Options;
 import zmq.ZError;
 import zmq.ZMQ;
+import zmq.io.SessionBase;
 import zmq.io.mechanism.Mechanism;
 
 public class PlainClientMechanism extends Mechanism
@@ -23,9 +24,9 @@ public class PlainClientMechanism extends Mechanism
 
     private State state;
 
-    public PlainClientMechanism(Options options)
+    public PlainClientMechanism(SessionBase session, Options options)
     {
-        super(null, null, options);
+        super(session, null, options);
         this.state = State.SENDING_HELLO;
     }
 

--- a/src/test/java/org/zeromq/ZMonitorTest.java
+++ b/src/test/java/org/zeromq/ZMonitorTest.java
@@ -1,15 +1,21 @@
 package org.zeromq;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Test;
+import org.zeromq.ZAuth.ZapRequest;
 import org.zeromq.ZMQ.Socket;
 import org.zeromq.ZMonitor.Event;
 import org.zeromq.ZMonitor.ZEvent;
+
+import zmq.io.mechanism.curve.Curve;
 
 public class ZMonitorTest
 {
@@ -23,9 +29,9 @@ public class ZMonitorTest
 
         // impossible to monitor events before being started
         ZEvent event = monitor.nextEvent();
-        assertThat(event, nullValue());
+        Assert.assertNull(event);
         event = monitor.nextEvent(-1);
-        assertThat(event, nullValue());
+        Assert.assertNull(event);
 
         monitor.start();
 
@@ -37,6 +43,7 @@ public class ZMonitorTest
         ctx.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testZMonitor() throws IOException
     {
@@ -59,29 +66,27 @@ public class ZMonitorTest
         //  Check server is now listening
         int port = server.bindToRandomPort("tcp://127.0.0.1");
         ZEvent received = serverMonitor.nextEvent();
-        assertThat(received.type, is(Event.LISTENING));
+        Assert.assertEquals(Event.LISTENING, received.type);
 
         //  Check server connected to client
         boolean rc = client.connect("tcp://127.0.0.1:" + port);
-        assertThat(rc, is(true));
+        Assert.assertTrue(rc);
         received = clientMonitor.nextEvent();
         assertThat(received.type, is(Event.CONNECTED));
 
         //  Check server accepted connection
         received = serverMonitor.nextEvent(true);
-        assertThat(received.type, is(Event.ACCEPTED));
-
-        System.out.println("server @ tcp://127.0.0.1:" + port + " received " + received.toString());
+        Assert.assertEquals(Event.ACCEPTED, received.type);
 
         //  Check server accepted connection
         received = serverMonitor.nextEvent(-1); // timeout -1 aka blocking
-        assertThat(received.type, is(Event.HANDSHAKE_PROTOCOL));
+        Assert.assertEquals(Event.HANDSHAKE_PROTOCOL, received.type);
 
         received = serverMonitor.nextEvent(false); // with no blocking
-        assertThat(received, nullValue());
+        Assert.assertNull(received);
 
         received = serverMonitor.nextEvent(10); // timeout
-        assertThat(received, nullValue());
+        Assert.assertNull(received);
 
         client.close();
         clientMonitor.close();
@@ -92,12 +97,251 @@ public class ZMonitorTest
         ctx.close();
     }
 
-    //    @Test
-    public void testRepeated() throws IOException
+    @Test(timeout = 5000)
+    public void testZMonitorCurveOK() throws IOException
     {
-        for (int idx = 0; idx < 10000; ++idx) {
-            System.out.println("+++++ " + idx);
-            testZMonitor();
+        final List<ZEvent> receivedEventsClient = new ArrayList<>();
+        final List<ZEvent> receivedEventsServer = new ArrayList<>();
+        final byte[][] serverKeyPair = new Curve().keypair();
+        final byte[] serverPublicKey = serverKeyPair[0];
+        final byte[] serverSecretKey = serverKeyPair[1];
+
+        final byte[][] clientKeyPair = new Curve().keypair();
+        final byte[] clientPublicKey = clientKeyPair[0];
+        final byte[] clientSecretKey = clientKeyPair[1];
+
+        final ZContext ctx = new ZContext();
+        final Socket client = ctx.createSocket(SocketType.PUSH);
+        client.setCurveServerKey(serverPublicKey);
+        client.setCurvePublicKey(clientPublicKey);
+        client.setCurveSecretKey(clientSecretKey);
+        final Socket server = ctx.createSocket(SocketType.PULL);
+        server.setCurveServer(true);
+        server.setCurveSecretKey(serverSecretKey);
+
+        final ZMonitor clientMonitor = new ZMonitor(ctx, client);
+        clientMonitor.verbose(true);
+        clientMonitor.add(Event.ALL);
+        clientMonitor.start();
+
+        final ZMonitor serverMonitor = new ZMonitor(ctx, server);
+        serverMonitor.verbose(true);
+        serverMonitor.add(Event.ALL);
+        serverMonitor.start();
+
+        //  Check server is now listening
+        int port = server.bindToRandomPort("tcp://127.0.0.1");
+
+        //  Check server connected to client
+        boolean rc = client.connect("tcp://127.0.0.1:" + port);
+        client.send("hello");
+        server.recvStr();
+        Assert.assertTrue(rc);
+        client.close();
+
+        ZEvent received;
+        while ((received = clientMonitor.nextEvent(100)) != null) {
+            receivedEventsClient.add(received);
+        }
+        clientMonitor.close();
+
+        server.close();
+        while ((received = serverMonitor.nextEvent(100)) != null) {
+            receivedEventsServer.add(received);
+        }
+        serverMonitor.close();
+
+        ctx.close();
+        // [ZEvent [_PROTOCOL, code=32768, address=tcp://127.0.0.1:53682, value=3], ZEvent [type=DISCONNECTED, code=512, address=tcp://127.0.0.1:53682, value=null]]
+
+        final Event[] expectedEventsClient = new Event[] {
+            Event.CONNECT_DELAYED,
+            Event.CONNECTED,
+            Event.HANDSHAKE_PROTOCOL,
+            Event.MONITOR_STOPPED,
+        };
+        check(receivedEventsClient, expectedEventsClient);
+        final Event[] expectedEventsServer = new Event[] {
+            Event.LISTENING,
+            Event.ACCEPTED,
+            Event.HANDSHAKE_PROTOCOL,
+            Event.DISCONNECTED,
+            Event.CLOSED,
+            Event.MONITOR_STOPPED,
+        };
+        check(receivedEventsServer, expectedEventsServer);
+    }
+
+    @Test(timeout = 5000)
+    public void testZMonitorCurveKo() throws IOException, InterruptedException
+    {
+        final List<ZEvent> receivedEventsClient = new ArrayList<>();
+        final List<ZEvent> receivedEventsServer = new ArrayList<>();
+
+        final byte[][] serverKeyPair = new Curve().keypair();
+        final byte[] serverPublicKey = serverKeyPair[0];
+        final byte[] serverSecretKey = serverKeyPair[1];
+
+        final byte[][] clientKeyPair = new Curve().keypair();
+        final byte[] clientPublicKey = clientKeyPair[0];
+        final byte[] clientSecretKey = clientKeyPair[1];
+
+        final ZContext ctx = new ZContext();
+        final Socket client = ctx.createSocket(SocketType.PUSH);
+        client.setCurveServerKey(serverPublicKey);
+        client.setCurvePublicKey(clientPublicKey);
+        client.setCurveSecretKey(serverSecretKey);
+        final Socket server = ctx.createSocket(SocketType.PULL);
+        server.setCurveServer(true);
+        server.setCurveSecretKey(clientSecretKey);
+
+        final ZMonitor clientMonitor = new ZMonitor(ctx, client);
+        clientMonitor.verbose(true);
+        clientMonitor.add(Event.ALL);
+        clientMonitor.start();
+
+        final ZMonitor serverMonitor = new ZMonitor(ctx, server);
+        serverMonitor.verbose(true);
+        serverMonitor.add(Event.ALL);
+        serverMonitor.start();
+
+        //  Check server is now listening
+        server.bind("tcp://127.0.0.1:34782");
+
+        //  Check server connected to client
+        boolean rc = client.connect("tcp://127.0.0.1:" + 34782);
+        Assert.assertTrue(rc);
+        Thread.sleep(100);
+        client.send("hello");
+        Thread.sleep(100);
+        client.close();
+
+        ZEvent received;
+        while ((received = clientMonitor.nextEvent(100)) != null) {
+            receivedEventsClient.add(received);
+        }
+        clientMonitor.close();
+
+        server.close();
+        while ((received = serverMonitor.nextEvent(100)) != null) {
+            receivedEventsServer.add(received);
+        }
+        serverMonitor.close();
+
+        ctx.close();
+
+        final Event[] expectedEventsClient = new Event[] {
+            Event.CONNECT_DELAYED,
+            Event.CONNECTED,
+            Event.HANDSHAKE_PROTOCOL,
+            Event.DISCONNECTED,
+            Event.MONITOR_STOPPED,
+        };
+        check(receivedEventsClient, expectedEventsClient);
+        final Event[] expectedEventsServer = new Event[] {
+            Event.LISTENING,
+            Event.ACCEPTED,
+            Event.HANDSHAKE_PROTOCOL,
+            Event.HANDSHAKE_FAILED_PROTOCOL,
+            Event.DISCONNECTED,
+            Event.CLOSED,
+            Event.MONITOR_STOPPED,
+        };
+        check(receivedEventsServer, expectedEventsServer);
+    }
+
+    @Test(timeout = 5000)
+    public void testPlainKo() throws IOException, InterruptedException
+    {
+        final List<ZEvent> receivedEventsClient = new ArrayList<>();
+        final List<ZEvent> receivedEventsServer = new ArrayList<>();
+
+        ZAuth.Auth plain = new ZAuth.Auth() {
+            @Override
+            public boolean authorize(ZapRequest request, boolean verbose)
+            {
+                return false;
+            }
+            @Override
+            public boolean configure(ZMsg msg, boolean verbose)
+            {
+                return true;
+            }
+        };
+
+        try (ZContext ctx = new ZContext();
+             ZAuth auth = new ZAuth(ctx, "authenticator", Collections.singletonMap("PLAIN", plain));
+             Socket server = ctx.createSocket(SocketType.PUSH);
+             ZMonitor serverMonitor = new ZMonitor(ctx, server);
+             Socket client = ctx.createSocket(SocketType.PULL);
+             ZMonitor clientMonitor = new ZMonitor(ctx, client);) {
+            clientMonitor.verbose(true);
+            clientMonitor.add(Event.ALL);
+            clientMonitor.start();
+
+            serverMonitor.verbose(true);
+            serverMonitor.add(Event.ALL);
+            serverMonitor.start();
+
+            server.setPlainServer(true);
+            //  Start an authentication engine for this context. This engine
+            //  allows or denies incoming connections (talking to the libzmq
+            //  core over a protocol called ZAP).
+            //  Get some indication of what the authenticator is deciding
+            auth.setVerbose(true);
+            // auth send the replies
+            auth.replies(true);
+
+            //  Create and bind server socket
+            server.setPlainServer(true);
+            server.setZapDomain("global".getBytes());
+            final int port = server.bindToRandomPort("tcp://*");
+
+            //  Create and connect client socket
+            client.setPlainUsername("admin".getBytes());
+            client.setPlainPassword("wrong".getBytes());
+            boolean rc = client.connect("tcp://127.0.0.1:" + port);
+            Assert.assertTrue(rc);
+
+            //  Send a single message from server to client
+            rc = server.send("Hello");
+            Assert.assertTrue(rc);
+
+            ZAuth.ZapReply reply = auth.nextReply();
+            Assert.assertEquals(400, reply.statusCode);
+
+            ZEvent received;
+            while ((received = clientMonitor.nextEvent(100)) != null) {
+                receivedEventsClient.add(received);
+            }
+
+            while ((received = serverMonitor.nextEvent(100)) != null) {
+                receivedEventsServer.add(received);
+            }
+
+            final Event[] expectedEventsClient = new Event[] {
+                Event.CONNECT_DELAYED,
+                Event.CONNECTED,
+                Event.HANDSHAKE_PROTOCOL,
+                Event.HANDSHAKE_FAILED_AUTH,
+                Event.DISCONNECTED,
+           };
+            check(receivedEventsClient, expectedEventsClient);
+            final Event[] expectedEventsServer = new Event[] {
+                Event.LISTENING,
+                Event.ACCEPTED,
+                Event.HANDSHAKE_PROTOCOL,
+                Event.DISCONNECTED,
+            };
+            check(receivedEventsServer, expectedEventsServer);
+        }
+    }
+
+    private void check(final List<ZEvent> receivedEvents, final Event[] expectedEvents)
+    {
+        Assert.assertEquals(expectedEvents.length, receivedEvents.size());
+        for (int i = 0; i < expectedEvents.length; i++) {
+            Assert.assertEquals(expectedEvents[i], receivedEvents.get(i).type);
         }
     }
 }


### PR DESCRIPTION
 Some events were missed on client side.

In this branch, if CureServerMechanism refuses a connection because the curve
key is invalid, an hard error (with sending the message ERROR) is send, so
connection is no retried. It's done only on first decryption, because only at this
step it's critical. Latter failures means network error, but that's not sure.