### PR TITLE
Improved ZContext handling of shadows.

### DIFF
--- a/src/main/java/org/zeromq/ZThread.java
+++ b/src/main/java/org/zeromq/ZThread.java
@@ -98,7 +98,7 @@ public class ZThread
         }
 
         //  Connect child pipe to our pipe
-        ZContext ccontext = ZContext.shadow(ctx);
+        ZContext ccontext = ctx.shadow();
         Socket cpipe = ccontext.createSocket(SocketType.PAIR);
         if (cpipe == null) {
             return null;


### PR DESCRIPTION
Improved ZContext handling of shadows:
- when it vanishes, all shadows vanish too.
- replaced the static method org.zeromq.ZContext.shadow(ZContext)
  with a instance method org.zeromq.ZContext.shadow().
- added a org.zeromq.ZContext.isEmpty() method, that can be used to
  ensure good cleaning in tests or asserts.

This is not hierarchical: shadows don't cast shadow.