### PR TITLE
problem: New thread-safe sockets cannot communicate with non-thread-safe sockets

### DIFF
--- a/src/main/java/zmq/Options.java
+++ b/src/main/java/zmq/Options.java
@@ -170,6 +170,9 @@ public class Options
     public Msg helloMsg;
     public boolean canSendHelloMsg;
 
+    //  As Socket type on the network.
+    public int asType;
+
     public final Errno errno = new Errno();
 
     public Options()
@@ -226,6 +229,8 @@ public class Options
 
         canSendHelloMsg = false;
         helloMsg = null;
+
+        asType = -1;
     }
 
     @SuppressWarnings("deprecation")
@@ -564,6 +569,10 @@ public class Options
             }
             return true;
 
+        case ZMQ.ZMQ_AS_TYPE:
+            this.asType = (Integer) optval;
+            return true;
+
         default:
             throw new IllegalArgumentException("Unknown Option " + option);
         }
@@ -811,6 +820,9 @@ public class Options
 
         case ZMQ.ZMQ_SELECTOR_PROVIDERCHOOSER:
             return selectorChooser;
+
+        case ZMQ.ZMQ_AS_TYPE:
+            return asType;
 
         default:
             throw new IllegalArgumentException("option=" + option);

--- a/src/main/java/zmq/ZMQ.java
+++ b/src/main/java/zmq/ZMQ.java
@@ -131,6 +131,7 @@ public class ZMQ
     @Deprecated
     public static final int ZMQ_XPUB_VERBOSE_UNSUBSCRIBE = 78;
     public static final int ZMQ_HELLO_MSG                = 79;
+    public static final int ZMQ_AS_TYPE                  = 80;
 
     /* Custom options */
     @Deprecated

--- a/src/main/java/zmq/io/mechanism/Mechanism.java
+++ b/src/main/java/zmq/io/mechanism/Mechanism.java
@@ -146,11 +146,13 @@ public abstract class Mechanism
             @Override
             public int parsed(String name, byte[] value, String valueAsString)
             {
+                int type = options.asType != -1 ? options.asType : options.type;
+
                 if (IDENTITY.equals(name) && options.recvIdentity) {
                     setPeerIdentity(value);
                 }
                 else if (SOCKET_TYPE.equals(name)) {
-                    if (!Sockets.compatible(options.type, valueAsString)) {
+                    if (!Sockets.compatible(type, valueAsString)) {
                         return ZError.EINVAL;
                     }
                 }
@@ -173,9 +175,13 @@ public abstract class Mechanism
         return 0;
     }
 
-    protected final String socketType(int socketType)
+    protected final String socketType()
     {
-        return Sockets.name(options.type);
+        if (options.asType != -1) {
+            return Sockets.name(options.asType);
+        } else {
+            return Sockets.name(options.type);
+        }
     }
 
     protected boolean compare(Msg msg, String data, boolean includeLength)

--- a/src/main/java/zmq/io/mechanism/NullMechanism.java
+++ b/src/main/java/zmq/io/mechanism/NullMechanism.java
@@ -71,7 +71,7 @@ class NullMechanism extends Mechanism
         msg.putShortString(READY);
 
         //  Add socket type property
-        String socketType = socketType(options.type);
+        String socketType = socketType();
         addProperty(msg, SOCKET_TYPE, socketType);
 
         //  Add identity property

--- a/src/main/java/zmq/io/mechanism/curve/CurveClientMechanism.java
+++ b/src/main/java/zmq/io/mechanism/curve/CurveClientMechanism.java
@@ -351,7 +351,7 @@ public class CurveClientMechanism extends Mechanism
         //  Metadata starts after vouch
 
         //  Add socket type property
-        String socketType = socketType(options.type);
+        String socketType = socketType();
         addProperty(initiatePlaintext, SOCKET_TYPE, socketType);
 
         //  Add identity property

--- a/src/main/java/zmq/io/mechanism/curve/CurveServerMechanism.java
+++ b/src/main/java/zmq/io/mechanism/curve/CurveServerMechanism.java
@@ -478,7 +478,7 @@ public class CurveServerMechanism extends Mechanism
         //  Create Box [metadata](S'->C')
         readyPlaintext.position(Curve.Size.ZERO.bytes());
         //  Add socket type property
-        String socketType = socketType(options.type);
+        String socketType = socketType();
         addProperty(readyPlaintext, SOCKET_TYPE, socketType);
 
         //  Add identity property

--- a/src/main/java/zmq/io/mechanism/plain/PlainClientMechanism.java
+++ b/src/main/java/zmq/io/mechanism/plain/PlainClientMechanism.java
@@ -131,7 +131,7 @@ public class PlainClientMechanism extends Mechanism
         msg.putShortString("INITIATE");
 
         //  Add socket type property
-        String socketType = socketType(options.type);
+        String socketType = socketType();
         addProperty(msg, SOCKET_TYPE, socketType);
 
         //  Add identity property

--- a/src/main/java/zmq/io/mechanism/plain/PlainServerMechanism.java
+++ b/src/main/java/zmq/io/mechanism/plain/PlainServerMechanism.java
@@ -200,7 +200,7 @@ public class PlainServerMechanism extends Mechanism
         msg.putShortString("READY");
 
         //  Add socket type property
-        String socketType = socketType(options.type);
+        String socketType = socketType();
         addProperty(msg, SOCKET_TYPE, socketType);
 
         //  Add identity property


### PR DESCRIPTION


This is a problem, because if you want to benefit from thread safe socket in existing system you have to change the entire stack.
For system that already using a single message frame, can benefit from thread-safe socket by using the ZMQ_AS_TYPE option to make the socket use another socket type on the wire