### PR TITLE
Less warnings in tests

### DIFF
--- a/src/test/java/org/zeromq/DealerDealerTest.java
+++ b/src/test/java/org/zeromq/DealerDealerTest.java
@@ -1,7 +1,7 @@
 package org.zeromq;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.Deque;

--- a/src/test/java/org/zeromq/HighWatermarkTest.java
+++ b/src/test/java/org/zeromq/HighWatermarkTest.java
@@ -1,7 +1,7 @@
 package org.zeromq;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.security.SecureRandom;
@@ -12,6 +12,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.LockSupport;
 
 import org.junit.Test;
+
 import zmq.util.AndroidProblematic;
 
 public class HighWatermarkTest

--- a/src/test/java/org/zeromq/ParanoidPiratServerWithLazyPiratClientTest.java
+++ b/src/test/java/org/zeromq/ParanoidPiratServerWithLazyPiratClientTest.java
@@ -2,7 +2,7 @@ package org.zeromq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;

--- a/src/test/java/org/zeromq/PubSubTest.java
+++ b/src/test/java/org/zeromq/PubSubTest.java
@@ -2,7 +2,7 @@ package org.zeromq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.lang.Thread.UncaughtExceptionHandler;
@@ -90,7 +90,6 @@ public class PubSubTest
         context.close();
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     @Ignore
     public void testPubConnectSubBindIssue289and342() throws IOException
@@ -123,7 +122,6 @@ public class PubSubTest
         context.term();
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testUnsubscribeIssue554() throws Exception
     {

--- a/src/test/java/org/zeromq/PushPullTest.java
+++ b/src/test/java/org/zeromq/PushPullTest.java
@@ -2,7 +2,7 @@ package org.zeromq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;

--- a/src/test/java/org/zeromq/TestPoller.java
+++ b/src/test/java/org/zeromq/TestPoller.java
@@ -2,7 +2,7 @@ package org.zeromq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -52,7 +52,6 @@ public class TestPoller
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testPollerPollout() throws Exception
     {
@@ -100,7 +99,6 @@ public class TestPoller
         context.term();
     }
 
-    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testExitPollerIssue580() throws InterruptedException, ExecutionException
     {

--- a/src/test/java/org/zeromq/TestProxy.java
+++ b/src/test/java/org/zeromq/TestProxy.java
@@ -2,7 +2,7 @@ package org.zeromq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.Random;
@@ -30,7 +30,6 @@ public class TestProxy
             this.frontend = frontend;
         }
 
-        @SuppressWarnings("deprecation")
         @Override
         public void run()
         {

--- a/src/test/java/org/zeromq/TestPushPullThreadedTcp.java
+++ b/src/test/java/org/zeromq/TestPushPullThreadedTcp.java
@@ -2,7 +2,7 @@ package org.zeromq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;

--- a/src/test/java/org/zeromq/TestRapidOpenCloseSocket.java
+++ b/src/test/java/org/zeromq/TestRapidOpenCloseSocket.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.junit.Ignore;
 import org.junit.Test;
-
 import org.zeromq.ZMQ.Socket;
 
 // For issue: https://github.com/zeromq/jeromq/issues/198

--- a/src/test/java/org/zeromq/TestReqRouterThreadedTcp.java
+++ b/src/test/java/org/zeromq/TestReqRouterThreadedTcp.java
@@ -2,7 +2,7 @@ package org.zeromq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;

--- a/src/test/java/org/zeromq/TestZLoop.java
+++ b/src/test/java/org/zeromq/TestZLoop.java
@@ -2,7 +2,7 @@ package org.zeromq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;

--- a/src/test/java/org/zeromq/TestZMQ.java
+++ b/src/test/java/org/zeromq/TestZMQ.java
@@ -7,7 +7,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;

--- a/src/test/java/org/zeromq/TestZPoller.java
+++ b/src/test/java/org/zeromq/TestZPoller.java
@@ -6,7 +6,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -38,7 +38,6 @@ public class TestZPoller
             this.count = count;
         }
 
-        @SuppressWarnings("deprecation")
         @Override
         public Boolean apply(SelectableChannel channel, Integer events)
         {
@@ -131,7 +130,6 @@ public class TestZPoller
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testPollerPollout() throws IOException, InterruptedException
     {
@@ -173,7 +171,6 @@ public class TestZPoller
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testUseNull() throws IOException
     {
@@ -239,7 +236,6 @@ public class TestZPoller
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testGlobalHandler() throws IOException
     {
@@ -257,7 +253,6 @@ public class TestZPoller
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testItemEqualsBasic() throws IOException
     {
@@ -281,7 +276,6 @@ public class TestZPoller
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testItemEquals() throws IOException
     {
@@ -316,7 +310,6 @@ public class TestZPoller
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testReadable() throws IOException
     {
@@ -341,7 +334,6 @@ public class TestZPoller
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testWritable() throws IOException
     {
@@ -366,7 +358,6 @@ public class TestZPoller
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testError() throws IOException
     {
@@ -391,7 +382,6 @@ public class TestZPoller
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testRegister() throws IOException
     {
@@ -409,7 +399,6 @@ public class TestZPoller
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testItems() throws IOException
     {
@@ -431,7 +420,6 @@ public class TestZPoller
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testMultipleRegistrations() throws IOException
     {
@@ -485,7 +473,6 @@ public class TestZPoller
         return pipe;
     }
 
-    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testIssue729() throws InterruptedException, IOException
     {

--- a/src/test/java/org/zeromq/TestZThread.java
+++ b/src/test/java/org/zeromq/TestZThread.java
@@ -9,7 +9,7 @@ import java.util.concurrent.CountDownLatch;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TestZThread
 {

--- a/src/test/java/org/zeromq/TooManyOpenFilesTester.java
+++ b/src/test/java/org/zeromq/TooManyOpenFilesTester.java
@@ -2,7 +2,7 @@ package org.zeromq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/org/zeromq/ZBeaconTest.java
+++ b/src/test/java/org/zeromq/ZBeaconTest.java
@@ -1,7 +1,7 @@
 package org.zeromq;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -17,7 +17,6 @@ import org.zeromq.ZBeacon.Listener;
 
 public class ZBeaconTest
 {
-    @SuppressWarnings("deprecation")
     @Test(timeout = 2000)
     public void testUseBuilder() throws InterruptedException, IOException
     {

--- a/src/test/java/org/zeromq/ZCertStoreTest.java
+++ b/src/test/java/org/zeromq/ZCertStoreTest.java
@@ -9,7 +9,7 @@ import java.io.File;
 import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ZCertStoreTest
 {

--- a/src/test/java/org/zeromq/ZCertTest.java
+++ b/src/test/java/org/zeromq/ZCertTest.java
@@ -14,7 +14,7 @@ import java.util.regex.Pattern;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @AndroidProblematic
 public class ZCertTest

--- a/src/test/java/org/zeromq/ZFrameTest.java
+++ b/src/test/java/org/zeromq/ZFrameTest.java
@@ -4,7 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/src/test/java/org/zeromq/ZLoopTest.java
+++ b/src/test/java/org/zeromq/ZLoopTest.java
@@ -2,7 +2,7 @@ package org.zeromq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.After;
 //import org.junit.Assert;

--- a/src/test/java/org/zeromq/ZMonitorTest.java
+++ b/src/test/java/org/zeromq/ZMonitorTest.java
@@ -1,7 +1,7 @@
 package org.zeromq;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -43,7 +43,6 @@ public class ZMonitorTest
         ctx.close();
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testZMonitor() throws IOException
     {

--- a/src/test/java/org/zeromq/ZMsgTest.java
+++ b/src/test/java/org/zeromq/ZMsgTest.java
@@ -7,7 +7,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
@@ -418,7 +418,6 @@ public class ZMsgTest
         assertThat(msg3.isEmpty(), is(true));
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testClosedContext()
     {

--- a/src/test/java/org/zeromq/auth/ZConfigTest.java
+++ b/src/test/java/org/zeromq/auth/ZConfigTest.java
@@ -1,7 +1,7 @@
 package org.zeromq.auth;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 import java.io.FileWriter;

--- a/src/test/java/org/zeromq/guide/AsyncServerTest.java
+++ b/src/test/java/org/zeromq/guide/AsyncServerTest.java
@@ -3,7 +3,7 @@ package org.zeromq.guide;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/org/zeromq/guide/EspressoTest.java
+++ b/src/test/java/org/zeromq/guide/EspressoTest.java
@@ -2,7 +2,7 @@ package org.zeromq.guide;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -41,7 +41,6 @@ public class EspressoTest
             this.wait = wait;
         }
 
-        @SuppressWarnings("deprecation")
         @Override
         public List<Socket> createSockets(ZContext ctx, Object... args)
         {
@@ -50,7 +49,6 @@ public class EspressoTest
             return Collections.singletonList(sub);
         }
 
-        @SuppressWarnings("deprecation")
         @Override
         public void start(Socket pipe, List<Socket> sockets, ZPoller poller)
         {
@@ -94,7 +92,6 @@ public class EspressoTest
             this.wait = wait;
         }
 
-        @SuppressWarnings("deprecation")
         @Override
         public List<Socket> createSockets(ZContext ctx, Object... args)
         {
@@ -103,7 +100,6 @@ public class EspressoTest
             return Collections.singletonList(pub);
         }
 
-        @SuppressWarnings("deprecation")
         @Override
         public void start(Socket pipe, List<Socket> sockets, ZPoller poller)
         {
@@ -141,7 +137,6 @@ public class EspressoTest
             this.wait = wait;
         }
 
-        @SuppressWarnings("deprecation")
         @Override
         public List<Socket> createSockets(ZContext ctx, Object... args)
         {
@@ -150,7 +145,6 @@ public class EspressoTest
             return Collections.singletonList(pull);
         }
 
-        @SuppressWarnings("deprecation")
         @Override
         public void start(Socket pipe, List<Socket> sockets, ZPoller poller)
         {
@@ -168,7 +162,6 @@ public class EspressoTest
             return "Listener";
         }
 
-        @SuppressWarnings("deprecation")
         @Override
         public boolean stage(Socket socket, Socket pipe, ZPoller poller, int events)
         {
@@ -225,7 +218,6 @@ public class EspressoTest
     //  .split main thread
     //  The main task starts the subscriber and publisher, and then sets
     //  itself up as a listening proxy. The listener runs as a child thread:
-    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testEspresso() throws IOException, InterruptedException
     {

--- a/src/test/java/org/zeromq/proto/ZNeedleTest.java
+++ b/src/test/java/org/zeromq/proto/ZNeedleTest.java
@@ -1,7 +1,7 @@
 package org.zeromq.proto;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/org/zeromq/proto/ZPictureTest.java
+++ b/src/test/java/org/zeromq/proto/ZPictureTest.java
@@ -2,7 +2,7 @@ package org.zeromq.proto;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 import org.zeromq.SocketType;

--- a/src/test/java/org/zeromq/timer/ZTickerTest.java
+++ b/src/test/java/org/zeromq/timer/ZTickerTest.java
@@ -2,7 +2,7 @@ package org.zeromq.timer;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.zeromq.timer.ZTicket.Ticket;
 import org.zeromq.timer.ZTimer.Timer;
+
 import zmq.ZMQ;
 
 public class ZTickerTest

--- a/src/test/java/org/zeromq/timer/ZTicketTest.java
+++ b/src/test/java/org/zeromq/timer/ZTicketTest.java
@@ -3,7 +3,7 @@ package org.zeromq.timer;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/org/zeromq/timer/ZTimerTest.java
+++ b/src/test/java/org/zeromq/timer/ZTimerTest.java
@@ -3,7 +3,7 @@ package org.zeromq.timer;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/org/zeromq/util/ZDataTest.java
+++ b/src/test/java/org/zeromq/util/ZDataTest.java
@@ -1,7 +1,7 @@
 package org.zeromq.util;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 

--- a/src/test/java/org/zeromq/util/ZDigestTest.java
+++ b/src/test/java/org/zeromq/util/ZDigestTest.java
@@ -1,7 +1,7 @@
 package org.zeromq.util;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 

--- a/src/test/java/zmq/ConnectRidTest.java
+++ b/src/test/java/zmq/ConnectRidTest.java
@@ -3,7 +3,7 @@ package zmq;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 

--- a/src/test/java/zmq/CtxTest.java
+++ b/src/test/java/zmq/CtxTest.java
@@ -2,7 +2,7 @@ package zmq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/zmq/HeartbeatsTest.java
+++ b/src/test/java/zmq/HeartbeatsTest.java
@@ -3,7 +3,7 @@ package zmq;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/src/test/java/zmq/Helper.java
+++ b/src/test/java/zmq/Helper.java
@@ -1,7 +1,7 @@
 package zmq;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -144,7 +144,6 @@ public class Helper
 
     }
 
-    @SuppressWarnings("deprecation")
     public static void bounce(SocketBase sb, SocketBase sc)
     {
         byte[] content = "12345678ABCDEFGH12345678abcdefgh".getBytes(ZMQ.CHARSET);

--- a/src/test/java/zmq/ImmediateTest.java
+++ b/src/test/java/zmq/ImmediateTest.java
@@ -2,7 +2,7 @@ package zmq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/zmq/InprocUnbindTest.java
+++ b/src/test/java/zmq/InprocUnbindTest.java
@@ -2,7 +2,7 @@ package zmq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 

--- a/src/test/java/zmq/OptionsTest.java
+++ b/src/test/java/zmq/OptionsTest.java
@@ -4,16 +4,16 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.zeromq.SelectorProviderTest.DefaultSelectorProviderChooser;
 import org.zeromq.SocketType;
 import org.zeromq.ZContext;
-import org.zeromq.SelectorProviderTest.DefaultSelectorProviderChooser;
 import org.zeromq.ZMQ.Socket;
 
 import zmq.io.mechanism.Mechanisms;

--- a/src/test/java/zmq/PollTest.java
+++ b/src/test/java/zmq/PollTest.java
@@ -2,7 +2,7 @@ package zmq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;

--- a/src/test/java/zmq/TestClientServer.java
+++ b/src/test/java/zmq/TestClientServer.java
@@ -1,12 +1,13 @@
 package zmq;
 
 import org.junit.Test;
+
 import zmq.util.Utils;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TestClientServer
 {

--- a/src/test/java/zmq/TestConnectDelay.java
+++ b/src/test/java/zmq/TestConnectDelay.java
@@ -2,7 +2,7 @@ package zmq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/zmq/TestConnectResolve.java
+++ b/src/test/java/zmq/TestConnectResolve.java
@@ -2,7 +2,7 @@ package zmq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 

--- a/src/test/java/zmq/TestHelloMsg.java
+++ b/src/test/java/zmq/TestHelloMsg.java
@@ -1,11 +1,12 @@
 package zmq;
 
 import org.junit.Test;
+
 import zmq.util.Utils;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TestHelloMsg
 {

--- a/src/test/java/zmq/TestHwm.java
+++ b/src/test/java/zmq/TestHwm.java
@@ -2,7 +2,7 @@ package zmq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/zmq/TestLastEndpoint.java
+++ b/src/test/java/zmq/TestLastEndpoint.java
@@ -3,7 +3,7 @@ package zmq;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.regex.Matcher;

--- a/src/test/java/zmq/TestMonitor.java
+++ b/src/test/java/zmq/TestMonitor.java
@@ -2,7 +2,7 @@ package zmq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;

--- a/src/test/java/zmq/TestMsg.java
+++ b/src/test/java/zmq/TestMsg.java
@@ -2,7 +2,7 @@ package zmq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;

--- a/src/test/java/zmq/TestMsgFlags.java
+++ b/src/test/java/zmq/TestMsgFlags.java
@@ -2,7 +2,7 @@ package zmq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/zmq/TestRadioDish.java
+++ b/src/test/java/zmq/TestRadioDish.java
@@ -6,7 +6,7 @@ import zmq.util.Utils;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TestRadioDish
 {

--- a/src/test/java/zmq/TestShutdownStress.java
+++ b/src/test/java/zmq/TestShutdownStress.java
@@ -2,7 +2,7 @@ package zmq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 

--- a/src/test/java/zmq/TestTermEndpoint.java
+++ b/src/test/java/zmq/TestTermEndpoint.java
@@ -2,7 +2,7 @@ package zmq;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 

--- a/src/test/java/zmq/TestTimeo.java
+++ b/src/test/java/zmq/TestTimeo.java
@@ -3,7 +3,7 @@ package zmq;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/zmq/io/AbstractProtocolVersion.java
+++ b/src/test/java/zmq/io/AbstractProtocolVersion.java
@@ -2,7 +2,7 @@ package zmq.io;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/test/java/zmq/io/MetadataTest.java
+++ b/src/test/java/zmq/io/MetadataTest.java
@@ -3,7 +3,7 @@ package zmq.io;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/src/test/java/zmq/io/MsgsTest.java
+++ b/src/test/java/zmq/io/MsgsTest.java
@@ -1,7 +1,7 @@
 package zmq.io;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 

--- a/src/test/java/zmq/io/StreamEngineTest.java
+++ b/src/test/java/zmq/io/StreamEngineTest.java
@@ -2,7 +2,7 @@ package zmq.io;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 

--- a/src/test/java/zmq/io/TimerEventTest.java
+++ b/src/test/java/zmq/io/TimerEventTest.java
@@ -2,7 +2,7 @@ package zmq.io;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/src/test/java/zmq/io/coder/AbstractDecoderTest.java
+++ b/src/test/java/zmq/io/coder/AbstractDecoderTest.java
@@ -2,7 +2,7 @@ package zmq.io.coder;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.nio.ByteBuffer;
 

--- a/src/test/java/zmq/io/coder/CustomDecoderTest.java
+++ b/src/test/java/zmq/io/coder/CustomDecoderTest.java
@@ -1,7 +1,7 @@
 package zmq.io.coder;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.nio.ByteBuffer;
 

--- a/src/test/java/zmq/io/coder/CustomEncoderTest.java
+++ b/src/test/java/zmq/io/coder/CustomEncoderTest.java
@@ -1,7 +1,7 @@
 package zmq.io.coder;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/src/test/java/zmq/io/coder/V1EncoderTest.java
+++ b/src/test/java/zmq/io/coder/V1EncoderTest.java
@@ -3,7 +3,7 @@ package zmq.io.coder;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.nio.ByteBuffer;
 

--- a/src/test/java/zmq/io/coder/V2EncoderTest.java
+++ b/src/test/java/zmq/io/coder/V2EncoderTest.java
@@ -3,7 +3,7 @@ package zmq.io.coder;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.nio.ByteBuffer;
 

--- a/src/test/java/zmq/io/mechanism/SecurityCurveTest.java
+++ b/src/test/java/zmq/io/mechanism/SecurityCurveTest.java
@@ -4,7 +4,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/src/test/java/zmq/io/mechanism/SecurityNullTest.java
+++ b/src/test/java/zmq/io/mechanism/SecurityNullTest.java
@@ -3,7 +3,7 @@ package zmq.io.mechanism;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/src/test/java/zmq/io/mechanism/SecurityPlainTest.java
+++ b/src/test/java/zmq/io/mechanism/SecurityPlainTest.java
@@ -3,7 +3,7 @@ package zmq.io.mechanism;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/src/test/java/zmq/io/net/TestAddress.java
+++ b/src/test/java/zmq/io/net/TestAddress.java
@@ -1,7 +1,7 @@
 package zmq.io.net;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;

--- a/src/test/java/zmq/pipe/YQueueTest.java
+++ b/src/test/java/zmq/pipe/YQueueTest.java
@@ -1,7 +1,7 @@
 package zmq.pipe;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/zmq/poll/PollerBaseTest.java
+++ b/src/test/java/zmq/poll/PollerBaseTest.java
@@ -1,7 +1,7 @@
 package zmq.poll;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/src/test/java/zmq/proxy/ProxySingleSocketTest.java
+++ b/src/test/java/zmq/proxy/ProxySingleSocketTest.java
@@ -2,7 +2,7 @@ package zmq.proxy;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;

--- a/src/test/java/zmq/proxy/ProxyTcpTest.java
+++ b/src/test/java/zmq/proxy/ProxyTcpTest.java
@@ -2,7 +2,7 @@ package zmq.proxy;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.net.Socket;

--- a/src/test/java/zmq/proxy/ProxyTerminateTest.java
+++ b/src/test/java/zmq/proxy/ProxyTerminateTest.java
@@ -2,7 +2,7 @@ package zmq.proxy;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.lang.Thread.UncaughtExceptionHandler;
@@ -33,7 +33,6 @@ public class ProxyTerminateTest
             this.resultHander = resultHander;
         }
 
-        @SuppressWarnings("deprecation")
         @Override
         public void run()
         {
@@ -75,7 +74,6 @@ public class ProxyTerminateTest
 
     }
 
-    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testProxyTerminate() throws IOException, InterruptedException, ExecutionException
     {

--- a/src/test/java/zmq/proxy/ProxyTest.java
+++ b/src/test/java/zmq/proxy/ProxyTest.java
@@ -2,7 +2,7 @@ package zmq.proxy;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.nio.channels.Selector;
@@ -59,7 +59,6 @@ public class ProxyTest
             this.started = new CountDownLatch(1);
         }
 
-        @SuppressWarnings("deprecation")
         @Override
         public Boolean call()
         {
@@ -157,7 +156,6 @@ public class ProxyTest
             this.started = new CountDownLatch(1);
         }
 
-        @SuppressWarnings("deprecation")
         @Override
         public Boolean call() throws InterruptedException, ExecutionException, TimeoutException
         {
@@ -239,7 +237,6 @@ public class ProxyTest
             this.started = new CountDownLatch(1);
        }
 
-        @SuppressWarnings("deprecation")
         @Override
         public Boolean call()
         {
@@ -307,7 +304,6 @@ public class ProxyTest
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Test(timeout = 10000)
     public void testProxy() throws Throwable
     {

--- a/src/test/java/zmq/socket/AbstractSpecTest.java
+++ b/src/test/java/zmq/socket/AbstractSpecTest.java
@@ -2,7 +2,7 @@ package zmq.socket;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import zmq.Msg;
 import zmq.SocketBase;

--- a/src/test/java/zmq/socket/pair/TestPairInproc.java
+++ b/src/test/java/zmq/socket/pair/TestPairInproc.java
@@ -2,7 +2,7 @@ package zmq.socket.pair;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/zmq/socket/pair/TestPairIpc.java
+++ b/src/test/java/zmq/socket/pair/TestPairIpc.java
@@ -2,7 +2,7 @@ package zmq.socket.pair;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.UUID;
 
@@ -17,7 +17,6 @@ public class TestPairIpc
 {
     //  Create REQ/ROUTER wiring.
 
-    @SuppressWarnings("deprecation")
     @Test(timeout = 5000)
     public void testPairIpc()
     {

--- a/src/test/java/zmq/socket/pair/TestPairTcp.java
+++ b/src/test/java/zmq/socket/pair/TestPairTcp.java
@@ -3,7 +3,7 @@ package zmq.socket.pair;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 

--- a/src/test/java/zmq/socket/pipeline/PushPullSpecTest.java
+++ b/src/test/java/zmq/socket/pipeline/PushPullSpecTest.java
@@ -2,7 +2,7 @@ package zmq.socket.pipeline;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/zmq/socket/pipeline/TestPushPullTcp.java
+++ b/src/test/java/zmq/socket/pipeline/TestPushPullTcp.java
@@ -2,7 +2,7 @@ package zmq.socket.pipeline;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 

--- a/src/test/java/zmq/socket/pubsub/DistTest.java
+++ b/src/test/java/zmq/socket/pubsub/DistTest.java
@@ -2,12 +2,13 @@ package zmq.socket.pubsub;
 
 import org.junit.Before;
 import org.junit.Test;
+
 import zmq.Msg;
 import zmq.ZObject;
 import zmq.pipe.Pipe;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DistTest
 {

--- a/src/test/java/zmq/socket/pubsub/MTrieTest.java
+++ b/src/test/java/zmq/socket/pubsub/MTrieTest.java
@@ -1,7 +1,7 @@
 package zmq.socket.pubsub;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/src/test/java/zmq/socket/pubsub/PubSubHwmTest.java
+++ b/src/test/java/zmq/socket/pubsub/PubSubHwmTest.java
@@ -1,9 +1,9 @@
 package zmq.socket.pubsub;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/zmq/socket/pubsub/PubTest.java
+++ b/src/test/java/zmq/socket/pubsub/PubTest.java
@@ -1,7 +1,7 @@
 package zmq.socket.pubsub;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/src/test/java/zmq/socket/pubsub/SubTest.java
+++ b/src/test/java/zmq/socket/pubsub/SubTest.java
@@ -1,7 +1,7 @@
 package zmq.socket.pubsub;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/src/test/java/zmq/socket/pubsub/TestPubsubTcp.java
+++ b/src/test/java/zmq/socket/pubsub/TestPubsubTcp.java
@@ -2,7 +2,7 @@ package zmq.socket.pubsub;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/zmq/socket/pubsub/TestSubForward.java
+++ b/src/test/java/zmq/socket/pubsub/TestSubForward.java
@@ -3,7 +3,7 @@ package zmq.socket.pubsub;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 

--- a/src/test/java/zmq/socket/pubsub/TrieTest.java
+++ b/src/test/java/zmq/socket/pubsub/TrieTest.java
@@ -1,7 +1,7 @@
 package zmq.socket.pubsub;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 

--- a/src/test/java/zmq/socket/pubsub/XPubManualTest.java
+++ b/src/test/java/zmq/socket/pubsub/XPubManualTest.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class XPubManualTest
 {

--- a/src/test/java/zmq/socket/pubsub/XPubNodropTest.java
+++ b/src/test/java/zmq/socket/pubsub/XPubNodropTest.java
@@ -2,7 +2,7 @@ package zmq.socket.pubsub;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 

--- a/src/test/java/zmq/socket/pubsub/XPubTest.java
+++ b/src/test/java/zmq/socket/pubsub/XPubTest.java
@@ -1,7 +1,7 @@
 package zmq.socket.pubsub;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/zmq/socket/reqrep/DealerDealerTest.java
+++ b/src/test/java/zmq/socket/reqrep/DealerDealerTest.java
@@ -2,7 +2,7 @@ package zmq.socket.reqrep;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 

--- a/src/test/java/zmq/socket/reqrep/DealerSpecTest.java
+++ b/src/test/java/zmq/socket/reqrep/DealerSpecTest.java
@@ -2,7 +2,7 @@ package zmq.socket.reqrep;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/zmq/socket/reqrep/RepSpecTest.java
+++ b/src/test/java/zmq/socket/reqrep/RepSpecTest.java
@@ -2,7 +2,7 @@ package zmq.socket.reqrep;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/zmq/socket/reqrep/ReqSpecTest.java
+++ b/src/test/java/zmq/socket/reqrep/ReqSpecTest.java
@@ -2,7 +2,7 @@ package zmq.socket.reqrep;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/zmq/socket/reqrep/RouterHandoverTest.java
+++ b/src/test/java/zmq/socket/reqrep/RouterHandoverTest.java
@@ -3,7 +3,7 @@ package zmq.socket.reqrep;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/zmq/socket/reqrep/RouterMandatoryTest.java
+++ b/src/test/java/zmq/socket/reqrep/RouterMandatoryTest.java
@@ -2,7 +2,7 @@ package zmq.socket.reqrep;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/zmq/socket/reqrep/RouterProbeTest.java
+++ b/src/test/java/zmq/socket/reqrep/RouterProbeTest.java
@@ -2,7 +2,7 @@ package zmq.socket.reqrep;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 

--- a/src/test/java/zmq/socket/reqrep/RouterSpecTest.java
+++ b/src/test/java/zmq/socket/reqrep/RouterSpecTest.java
@@ -2,7 +2,7 @@ package zmq.socket.reqrep;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/zmq/socket/reqrep/TestInvalidRep.java
+++ b/src/test/java/zmq/socket/reqrep/TestInvalidRep.java
@@ -2,7 +2,7 @@ package zmq.socket.reqrep;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/zmq/socket/reqrep/TestReqCorrelateRelaxed.java
+++ b/src/test/java/zmq/socket/reqrep/TestReqCorrelateRelaxed.java
@@ -3,7 +3,7 @@ package zmq.socket.reqrep;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 

--- a/src/test/java/zmq/socket/reqrep/TestReqRelaxed.java
+++ b/src/test/java/zmq/socket/reqrep/TestReqRelaxed.java
@@ -2,7 +2,7 @@ package zmq.socket.reqrep;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/zmq/socket/reqrep/TestReqrepDevice.java
+++ b/src/test/java/zmq/socket/reqrep/TestReqrepDevice.java
@@ -2,7 +2,7 @@ package zmq.socket.reqrep;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 

--- a/src/test/java/zmq/socket/reqrep/TestReqrepInproc.java
+++ b/src/test/java/zmq/socket/reqrep/TestReqrepInproc.java
@@ -2,7 +2,7 @@ package zmq.socket.reqrep;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/zmq/socket/reqrep/TestReqrepIpc.java
+++ b/src/test/java/zmq/socket/reqrep/TestReqrepIpc.java
@@ -2,7 +2,7 @@ package zmq.socket.reqrep;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/zmq/socket/reqrep/TestReqrepTcp.java
+++ b/src/test/java/zmq/socket/reqrep/TestReqrepTcp.java
@@ -2,7 +2,7 @@ package zmq.socket.reqrep;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/zmq/socket/reqrep/TestRouterMandatory.java
+++ b/src/test/java/zmq/socket/reqrep/TestRouterMandatory.java
@@ -2,7 +2,7 @@ package zmq.socket.reqrep;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/zmq/socket/stream/StreamEmptyTest.java
+++ b/src/test/java/zmq/socket/stream/StreamEmptyTest.java
@@ -2,7 +2,7 @@ package zmq.socket.stream;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 

--- a/src/test/java/zmq/socket/stream/StreamTest.java
+++ b/src/test/java/zmq/socket/stream/StreamTest.java
@@ -2,7 +2,7 @@ package zmq.socket.stream;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/src/test/java/zmq/util/MultimapTest.java
+++ b/src/test/java/zmq/util/MultimapTest.java
@@ -1,7 +1,7 @@
 package zmq.util;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/src/test/java/zmq/util/TestBlob.java
+++ b/src/test/java/zmq/util/TestBlob.java
@@ -2,7 +2,7 @@ package zmq.util;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.HashMap;
 

--- a/src/test/java/zmq/util/TestUtils.java
+++ b/src/test/java/zmq/util/TestUtils.java
@@ -3,7 +3,7 @@ package zmq.util;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.File;

--- a/src/test/java/zmq/util/TimersTest.java
+++ b/src/test/java/zmq/util/TimersTest.java
@@ -3,7 +3,7 @@ package zmq.util;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Iterator;
 import java.util.Map.Entry;

--- a/src/test/java/zmq/util/WireTest.java
+++ b/src/test/java/zmq/util/WireTest.java
@@ -1,7 +1,7 @@
 package zmq.util;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;


### PR DESCRIPTION
Removing many of the warning in tests because of the use of org.junit.Assert.assertThat.

So many @SuppressWarnings("deprecation") removed