### PR TITLE
problem: Thread Safe sockets causing high CPU

### DIFF
--- a/src/main/java/zmq/MailboxSafe.java
+++ b/src/main/java/zmq/MailboxSafe.java
@@ -99,7 +99,12 @@ public class MailboxSafe implements IMailbox
         else {
             try {
                 //  Wait for signal from the command sender.
-                condition.await(timeout, TimeUnit.MILLISECONDS);
+                if (timeout == -1) {
+                    condition.await();
+                }
+                else {
+                    condition.await(timeout, TimeUnit.MILLISECONDS);
+                }
             }
             catch (InterruptedException e) {
                 errno.set(ZError.EINTR);


### PR DESCRIPTION
calling condition.await is -1 returns immediately.
Solution: when timeout is -1 calling the blocking version of await