### PR TITLE
problem: cannot cancel ongoing recv/send operation

### DIFF
--- a/src/main/java/zmq/Command.java
+++ b/src/main/java/zmq/Command.java
@@ -55,7 +55,9 @@ public class Command
         INPROC_CONNECTED,
         //  Sent by reaper thread to the term thread when all the sockets
         //  are successfully deallocated.
-        DONE
+        DONE,
+        //  Cancel a single pending I/O call
+        CANCEL
     }
 
     Command(ZObject destination, Type type)

--- a/src/main/java/zmq/ZError.java
+++ b/src/main/java/zmq/ZError.java
@@ -69,6 +69,7 @@ public class ZError
     public static final int ENOTCONN        = 57;
     public static final int ECONNREFUSED    = 61;
     public static final int EHOSTUNREACH    = 65;
+    public static final int ECANCELED       = 125;
 
     private static final int ZMQ_HAUSNUMERO = 156384712;
 

--- a/src/main/java/zmq/ZObject.java
+++ b/src/main/java/zmq/ZObject.java
@@ -115,6 +115,10 @@ public abstract class ZObject
             processSeqnum();
             break;
 
+        case CANCEL:
+            processCancel();
+            break;
+
         case DONE:
         default:
             throw new IllegalArgumentException();
@@ -294,6 +298,12 @@ public abstract class ZObject
         ctx.sendCommand(Ctx.TERM_TID, cmd);
     }
 
+    protected final void sendCancel()
+    {
+        Command cmd = new Command(this, Command.Type.CANCEL);
+        sendCommand(cmd);
+    }
+
     protected void processStop()
     {
         throw new UnsupportedOperationException();
@@ -375,6 +385,10 @@ public abstract class ZObject
     protected void processSeqnum()
     {
         throw new UnsupportedOperationException();
+    }
+
+    protected void processCancel()
+    {
     }
 
     private void sendCommand(Command cmd)

--- a/src/test/java/org/zeromq/TestZCancellationToken.java
+++ b/src/test/java/org/zeromq/TestZCancellationToken.java
@@ -1,0 +1,124 @@
+package org.zeromq;
+
+import org.junit.Assert;
+import org.junit.Test;
+import zmq.ZError;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+public class TestZCancellationToken
+{
+    @Test
+    public void cancelReceiveThreadSafe()
+    {
+        try (ZContext context = new ZContext();
+             ZMQ.Socket socket = context.createSocket(SocketType.CLIENT);) {
+            ZMQ.CancellationToken cancellationToken = socket.createCancellationToken();
+
+            Thread t = new Thread(() -> {
+                try {
+                    Thread.sleep(100);
+                }
+                catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                cancellationToken.cancel();
+            });
+            t.start();
+
+            try {
+                socket.recv(0, cancellationToken);
+                Assert.fail();
+            }
+            catch (ZMQException ex) {
+                assertThat(ex.getErrorCode(), is(ZError.ECANCELED));
+            }
+        }
+    }
+
+    @Test
+    public void cancelSendThreadSafe()
+    {
+        try (ZContext context = new ZContext();
+             ZMQ.Socket socket = context.createSocket(SocketType.CLIENT);) {
+            ZMQ.CancellationToken cancellationToken = socket.createCancellationToken();
+
+            Thread t = new Thread(() -> {
+                try {
+                    Thread.sleep(100);
+                }
+                catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                cancellationToken.cancel();
+            });
+            t.start();
+
+            try {
+                socket.send(new byte[1],0, cancellationToken);
+                Assert.fail();
+            }
+            catch (ZMQException ex) {
+                assertThat(ex.getErrorCode(), is(ZError.ECANCELED));
+            }
+        }
+    }
+
+    @Test
+    public void cancelReceive()
+    {
+        try (ZContext context = new ZContext();
+             ZMQ.Socket socket = context.createSocket(SocketType.DEALER);) {
+            ZMQ.CancellationToken cancellationToken = socket.createCancellationToken();
+
+            Thread t = new Thread(() -> {
+                try {
+                    Thread.sleep(100);
+                }
+                catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                cancellationToken.cancel();
+            });
+            t.start();
+
+            try {
+                socket.recv(0, cancellationToken);
+                Assert.fail();
+            }
+            catch (ZMQException ex) {
+                assertThat(ex.getErrorCode(), is(ZError.ECANCELED));
+            }
+        }
+    }
+
+    @Test
+    public void cancelSend()
+    {
+        try (ZContext context = new ZContext();
+             ZMQ.Socket socket = context.createSocket(SocketType.DEALER);) {
+            ZMQ.CancellationToken cancellationToken = socket.createCancellationToken();
+
+            Thread t = new Thread(() -> {
+                try {
+                    Thread.sleep(100);
+                }
+                catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                cancellationToken.cancel();
+            });
+            t.start();
+
+            try {
+                socket.send(new byte[1],0, cancellationToken);
+                Assert.fail();
+            }
+            catch (ZMQException ex) {
+                assertThat(ex.getErrorCode(), is(ZError.ECANCELED));
+            }
+        }
+    }
+}


### PR DESCRIPTION
For thread-safe sockets this is an issue because at the moment there is no way to poll over thread-safe sockets.
This PR adds a CancellationToken to allow cancel pending send/recv operation, both for thread-safe and regular sockets