### PR TITLE
Adding support for ZMQ_TCP_KEEPALIVE_CNT, ZMQ_TCP_KEEPALIVE_IDLE and ZMQ_TCP_KEEPALIVE_INTVL.

### DIFF
--- a/src/main/java/zmq/Options.java
+++ b/src/main/java/zmq/Options.java
@@ -11,6 +11,7 @@ import zmq.io.net.SelectorProviderChooser;
 import zmq.io.net.ipc.IpcAddress;
 import zmq.io.net.tcp.TcpAddress;
 import zmq.io.net.tcp.TcpAddress.TcpAddressMask;
+import zmq.io.net.tcp.TcpUtils;
 import zmq.msg.MsgAllocator;
 import zmq.msg.MsgAllocatorThreshold;
 import zmq.util.Errno;
@@ -354,10 +355,28 @@ public class Options
             return true;
 
         case ZMQ.ZMQ_TCP_KEEPALIVE_CNT:
+            if (TcpUtils.WITH_EXTENDED_KEEPALIVE) {
+                tcpKeepAliveCnt = ((Number) optval).intValue();
+                return true;
+            } else {
+                return false;
+            }
+
         case ZMQ.ZMQ_TCP_KEEPALIVE_IDLE:
+            if (TcpUtils.WITH_EXTENDED_KEEPALIVE) {
+                tcpKeepAliveIdle = ((Number) optval).intValue();
+                return true;
+            } else {
+                return false;
+            }
+
         case ZMQ.ZMQ_TCP_KEEPALIVE_INTVL:
-            // not supported
-            return false;
+            if (TcpUtils.WITH_EXTENDED_KEEPALIVE) {
+                tcpKeepAliveIntvl = ((Number) optval).intValue();
+                return true;
+            } else {
+                return false;
+            }
 
         case ZMQ.ZMQ_IMMEDIATE:
             immediate = parseBoolean(option, optval);
@@ -747,10 +766,13 @@ public class Options
             return socksProxyAddress;
 
         case ZMQ.ZMQ_TCP_KEEPALIVE_CNT:
+            return tcpKeepAliveCnt;
+
         case ZMQ.ZMQ_TCP_KEEPALIVE_IDLE:
+            return tcpKeepAliveIdle;
+
         case ZMQ.ZMQ_TCP_KEEPALIVE_INTVL:
-            // not supported
-            return 0;
+            return tcpKeepAliveIntvl;
 
         case ZMQ.ZMQ_MECHANISM:
             return mechanism;

--- a/src/main/java/zmq/io/net/tcp/TcpUtils.java
+++ b/src/main/java/zmq/io/net/tcp/TcpUtils.java
@@ -5,16 +5,54 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
+import java.net.SocketOption;
 import java.nio.channels.Channel;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 
+import zmq.Options;
 import zmq.ZError;
 import zmq.io.net.Address;
 
 public class TcpUtils
 {
+    public static final boolean WITH_EXTENDED_KEEPALIVE = SocketOptionsProvider.WITH_EXTENDED_KEEPALIVE;
+
+    @SuppressWarnings("unchecked")
+    private static final class SocketOptionsProvider {
+        // Wrapped in a inner class, to avoid the @SuppressWarnings for the whole class
+        private static final SocketOption<Integer> TCP_KEEPCOUNT;
+        private static final SocketOption<Integer> TCP_KEEPIDLE;
+        private static final SocketOption<Integer> TCP_KEEPINTERVAL;
+        private static final boolean WITH_EXTENDED_KEEPALIVE;
+        static {
+            SocketOption<Integer> try_TCP_KEEPCOUNT = null;
+            SocketOption<Integer> try_TCP_KEEPIDLE = null;
+            SocketOption<Integer> try_TCP_KEEPINTERVAL = null;
+
+            boolean extendedKeepAlive = false;
+            try {
+                Class<?> eso = Options.class.getClassLoader().loadClass("jdk.net.ExtendedSocketOptions");
+                try_TCP_KEEPCOUNT = (SocketOption<Integer>) eso.getField("TCP_KEEPCOUNT").get(null);
+                try_TCP_KEEPIDLE = (SocketOption<Integer>) eso.getField("TCP_KEEPIDLE").get(null);
+                try_TCP_KEEPINTERVAL = (SocketOption<Integer>) eso.getField("TCP_KEEPINTERVAL").get(null);
+                extendedKeepAlive = true;
+            } catch (Throwable e) {
+            }
+            TCP_KEEPCOUNT = try_TCP_KEEPCOUNT;
+            TCP_KEEPIDLE = try_TCP_KEEPIDLE;
+            TCP_KEEPINTERVAL = try_TCP_KEEPINTERVAL;
+            WITH_EXTENDED_KEEPALIVE = extendedKeepAlive;
+        }
+        @SuppressWarnings("restriction")
+        private static void conditionnalSet(Socket socket, SocketOption<Integer> option, int value) throws IOException {
+            if (value >= 0) {
+                jdk.net.Sockets.setOption(socket, option, value);
+            }
+        }
+    }
+
     private static interface OptionSetter
     {
         boolean setOption(Socket socket) throws SocketException;
@@ -56,12 +94,24 @@ public class TcpUtils
             throws IOException
     {
         final boolean keepAlive = tcpKeepAlive == 1;
+        final int KeepAliveCnt = tcpKeepAliveCnt;
+        final int KeepAliveIdle = tcpKeepAliveIdle;
+        final int KeepAliveIntvl = tcpKeepAliveIntvl;
         setOption(channel, new SocketOptionSetter()
         {
             @Override
             public boolean setOption(Socket socket) throws SocketException
             {
                 socket.setKeepAlive(keepAlive);
+                if (WITH_EXTENDED_KEEPALIVE) {
+                    try {
+                        SocketOptionsProvider.conditionnalSet(socket, SocketOptionsProvider.TCP_KEEPCOUNT, KeepAliveCnt);
+                        SocketOptionsProvider.conditionnalSet(socket, SocketOptionsProvider.TCP_KEEPIDLE, KeepAliveIdle);
+                        SocketOptionsProvider.conditionnalSet(socket, SocketOptionsProvider.TCP_KEEPINTERVAL, KeepAliveIntvl);
+                    } catch (IOException e) {
+                        throw new SocketException(e.getMessage());
+                    }
+                }
                 return true;
             }
         });

--- a/src/test/java/org/zeromq/TestZMQ.java
+++ b/src/test/java/org/zeromq/TestZMQ.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -1226,10 +1227,10 @@ public class TestZMQ
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setTCPKeepAliveCount(42);
-        assertThat(rc, is(false));
+        assertThat(rc, anyOf(is(false), is(true)));
 
         long tcp = socket.getTCPKeepAliveCount();
-        assertThat(tcp, is(0L));
+        assertThat(tcp, anyOf(is(-1L), is(42L)));
 
         socket.close();
     }
@@ -1241,10 +1242,10 @@ public class TestZMQ
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setTCPKeepAliveInterval(42);
-        assertThat(rc, is(false));
+        assertThat(rc, anyOf(is(false), is(true)));
 
         long tcp = socket.getTCPKeepAliveInterval();
-        assertThat(tcp, is(0L));
+        assertThat(tcp, anyOf(is(-1L), is(42L)));
 
         socket.close();
     }
@@ -1256,10 +1257,10 @@ public class TestZMQ
         assertThat(socket, notNullValue());
 
         boolean rc = socket.setTCPKeepAliveIdle(42);
-        assertThat(rc, is(false));
+        assertThat(rc, anyOf(is(false), is(true)));
 
         long tcp = socket.getTCPKeepAliveIdle();
-        assertThat(tcp, is(0L));
+        assertThat(tcp, anyOf(is(-1L), is(42L)));
 
         socket.close();
     }


### PR DESCRIPTION
It's supported since Java 11, so it's protected by a check.