### PR TITLE
Simplifications of TcpUtils, using lambda.

### DIFF
--- a/src/main/java/zmq/io/net/tcp/TcpUtils.java
+++ b/src/main/java/zmq/io/net/tcp/TcpUtils.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
-import java.net.SocketException;
 import java.net.SocketOption;
 import java.nio.channels.Channel;
 import java.nio.channels.SelectableChannel;
@@ -20,183 +19,119 @@ public class TcpUtils
     public static final boolean WITH_EXTENDED_KEEPALIVE = SocketOptionsProvider.WITH_EXTENDED_KEEPALIVE;
 
     @SuppressWarnings("unchecked")
-    private static final class SocketOptionsProvider {
+    private static final class SocketOptionsProvider
+    {
         // Wrapped in a inner class, to avoid the @SuppressWarnings for the whole class
         private static final SocketOption<Integer> TCP_KEEPCOUNT;
         private static final SocketOption<Integer> TCP_KEEPIDLE;
         private static final SocketOption<Integer> TCP_KEEPINTERVAL;
         private static final boolean WITH_EXTENDED_KEEPALIVE;
         static {
-            SocketOption<Integer> try_TCP_KEEPCOUNT = null;
-            SocketOption<Integer> try_TCP_KEEPIDLE = null;
-            SocketOption<Integer> try_TCP_KEEPINTERVAL = null;
+            SocketOption<Integer> tryCount = null;
+            SocketOption<Integer> tryIdle = null;
+            SocketOption<Integer> tryInterval = null;
 
             boolean extendedKeepAlive = false;
             try {
                 Class<?> eso = Options.class.getClassLoader().loadClass("jdk.net.ExtendedSocketOptions");
-                try_TCP_KEEPCOUNT = (SocketOption<Integer>) eso.getField("TCP_KEEPCOUNT").get(null);
-                try_TCP_KEEPIDLE = (SocketOption<Integer>) eso.getField("TCP_KEEPIDLE").get(null);
-                try_TCP_KEEPINTERVAL = (SocketOption<Integer>) eso.getField("TCP_KEEPINTERVAL").get(null);
+                tryCount = (SocketOption<Integer>) eso.getField("TCP_KEEPCOUNT").get(null);
+                tryIdle = (SocketOption<Integer>) eso.getField("TCP_KEEPIDLE").get(null);
+                tryInterval = (SocketOption<Integer>) eso.getField("TCP_KEEPINTERVAL").get(null);
                 extendedKeepAlive = true;
-            } catch (Throwable e) {
             }
-            TCP_KEEPCOUNT = try_TCP_KEEPCOUNT;
-            TCP_KEEPIDLE = try_TCP_KEEPIDLE;
-            TCP_KEEPINTERVAL = try_TCP_KEEPINTERVAL;
+            catch (Throwable e) {
+            }
+            TCP_KEEPCOUNT = tryCount;
+            TCP_KEEPIDLE = tryIdle;
+            TCP_KEEPINTERVAL = tryInterval;
             WITH_EXTENDED_KEEPALIVE = extendedKeepAlive;
         }
         @SuppressWarnings("restriction")
-        private static void conditionnalSet(Socket socket, SocketOption<Integer> option, int value) throws IOException {
+        private static void conditionnalSet(Socket socket, SocketOption<Integer> option, int value) throws IOException
+        {
             if (value >= 0) {
                 jdk.net.Sockets.setOption(socket, option, value);
             }
         }
     }
 
-    private static interface OptionSetter
+    private static interface OptionSetter<S>
     {
-        boolean setOption(Socket socket) throws SocketException;
-
-        boolean setOption(ServerSocket socket) throws SocketException;
-    }
-
-    private abstract static class SocketOptionSetter implements OptionSetter
-    {
-        @Override
-        public boolean setOption(ServerSocket socket) throws SocketException
-        {
-            return false;
-        }
+        void setOption(S socket) throws IOException;
     }
 
     private TcpUtils()
     {
     }
 
+    // The explicit IOException is useless, but kept for API compatibility
     public static void tuneTcpSocket(SocketChannel channel) throws IOException
     {
         // Disable Nagle's algorithm. We are doing data batching on 0MQ level,
         // so using Nagle wouldn't improve throughput in anyway, but it would
         // hurt latency.
-        setOption(channel, new SocketOptionSetter()
-        {
-            @Override
-            public boolean setOption(Socket socket) throws SocketException
-            {
-                socket.setTcpNoDelay(true);
-                return true;
-            }
-        });
+        setOption(channel, socket -> socket.setTcpNoDelay(true));
     }
 
     public static void tuneTcpKeepalives(SocketChannel channel, int tcpKeepAlive, int tcpKeepAliveCnt,
-                                         int tcpKeepAliveIdle, int tcpKeepAliveIntvl)
-            throws IOException
+            int tcpKeepAliveIdle, int tcpKeepAliveIntvl)
     {
-        final boolean keepAlive = tcpKeepAlive == 1;
-        final int KeepAliveCnt = tcpKeepAliveCnt;
-        final int KeepAliveIdle = tcpKeepAliveIdle;
-        final int KeepAliveIntvl = tcpKeepAliveIntvl;
-        setOption(channel, new SocketOptionSetter()
-        {
-            @Override
-            public boolean setOption(Socket socket) throws SocketException
-            {
-                socket.setKeepAlive(keepAlive);
-                if (WITH_EXTENDED_KEEPALIVE) {
-                    try {
-                        SocketOptionsProvider.conditionnalSet(socket, SocketOptionsProvider.TCP_KEEPCOUNT, KeepAliveCnt);
-                        SocketOptionsProvider.conditionnalSet(socket, SocketOptionsProvider.TCP_KEEPIDLE, KeepAliveIdle);
-                        SocketOptionsProvider.conditionnalSet(socket, SocketOptionsProvider.TCP_KEEPINTERVAL, KeepAliveIntvl);
-                    } catch (IOException e) {
-                        throw new SocketException(e.getMessage());
-                    }
-                }
-                return true;
+        setOption(channel, socket -> {
+            socket.setKeepAlive(tcpKeepAlive == 1);
+            if (WITH_EXTENDED_KEEPALIVE) {
+                SocketOptionsProvider.conditionnalSet(socket, SocketOptionsProvider.TCP_KEEPCOUNT, tcpKeepAliveCnt);
+                SocketOptionsProvider.conditionnalSet(socket, SocketOptionsProvider.TCP_KEEPIDLE, tcpKeepAliveIdle);
+                SocketOptionsProvider.conditionnalSet(socket, SocketOptionsProvider.TCP_KEEPINTERVAL, tcpKeepAliveIntvl);
             }
         });
     }
 
     public static boolean setTcpReceiveBuffer(Channel channel, final int rcvbuf)
     {
-        return setOption(channel, new OptionSetter()
-        {
-            @Override
-            public boolean setOption(Socket socket) throws SocketException
-            {
-                socket.setReceiveBufferSize(rcvbuf);
-                return true;
-            }
-
-            @Override
-            public boolean setOption(ServerSocket socket) throws SocketException
-            {
-                socket.setReceiveBufferSize(rcvbuf);
-                return true;
-            }
-        });
+        setOption(channel,
+                socket -> socket.setReceiveBufferSize(rcvbuf),
+                socket -> socket.setReceiveBufferSize(rcvbuf));
+        return true;
     }
 
     public static boolean setTcpSendBuffer(Channel channel, final int sndbuf)
     {
-        return setOption(channel, new SocketOptionSetter()
-        {
-            @Override
-            public boolean setOption(Socket socket) throws SocketException
-            {
-                socket.setSendBufferSize(sndbuf);
-                return true;
-            }
-        });
+        setOption(channel, socket -> socket.setSendBufferSize(sndbuf));
+        return true;
     }
 
     public static boolean setIpTypeOfService(Channel channel, final int tos)
     {
-        return setOption(channel, new SocketOptionSetter()
-        {
-            @Override
-            public boolean setOption(Socket socket) throws SocketException
-            {
-                socket.setTrafficClass(tos);
-                return true;
-            }
-        });
+        setOption(channel, socket -> socket.setTrafficClass(tos));
+        return true;
     }
 
     public static boolean setReuseAddress(Channel channel, final boolean reuse)
     {
-        return setOption(channel, new OptionSetter()
-        {
-            @Override
-            public boolean setOption(Socket socket) throws SocketException
-            {
-                socket.setReuseAddress(reuse);
-                return true;
-            }
-
-            @Override
-            public boolean setOption(ServerSocket socket) throws SocketException
-            {
-                socket.setReuseAddress(reuse);
-                return true;
-            }
-        });
+        setOption(channel,
+                socket -> socket.setReuseAddress(reuse),
+                socket -> socket.setReuseAddress(reuse));
+        return true;
     }
 
-    private static boolean setOption(Channel channel, OptionSetter setter)
+    private static void setOption(Channel channel, OptionSetter<Socket> setter)
+    {
+        setOption(channel, setter, s -> { });
+    }
+
+    private static void setOption(Channel channel, OptionSetter<Socket> setter, OptionSetter<ServerSocket> serverSetter)
     {
         try {
             if (channel instanceof ServerSocketChannel) {
-                return setter.setOption(((ServerSocketChannel) channel).socket());
+                serverSetter.setOption(((ServerSocketChannel) channel).socket());
             }
             else if (channel instanceof SocketChannel) {
-                return setter.setOption(((SocketChannel) channel).socket());
+                setter.setOption(((SocketChannel) channel).socket());
             }
         }
-        catch (SocketException e) {
+        catch (IOException e) {
             throw new ZError.IOException(e);
         }
-        return false;
     }
 
     public static void unblockSocket(SelectableChannel... channels) throws IOException


### PR DESCRIPTION
It avoid creating an useless object on each call, and more readable.

Exception handling was not consistent. A useless throws IOException is kept
for tuneTcpSocket, even if it's now useless.