### PR TITLE
problem: router doesn't know when peer disconnected

### DIFF
--- a/src/main/java/zmq/Ctx.java
+++ b/src/main/java/zmq/Ctx.java
@@ -732,6 +732,10 @@ public class Ctx
         pendingConnection.connectPipe.setHwms(hwms[1], hwms[0]);
         pendingConnection.bindPipe.setHwms(hwms[0], hwms[1]);
 
+        if (bindOptions.canReceiveDisconnectMsg && bindOptions.disconnectMsg != null) {
+            pendingConnection.connectPipe.setDisconnectMsg(bindOptions.disconnectMsg);
+        }
+
         if (side == Side.BIND) {
             Command cmd = new Command(null, Command.Type.BIND, pendingConnection.bindPipe);
             bindSocket.processCommand(cmd);

--- a/src/main/java/zmq/Options.java
+++ b/src/main/java/zmq/Options.java
@@ -171,6 +171,10 @@ public class Options
     public Msg helloMsg;
     public boolean canSendHelloMsg;
 
+    // Disconnect message to receive when peer disconnect
+    public Msg disconnectMsg;
+    public boolean canReceiveDisconnectMsg;
+
     //  As Socket type on the network.
     public int asType;
 
@@ -233,6 +237,9 @@ public class Options
 
         canSendHelloMsg = false;
         helloMsg = null;
+
+        canReceiveDisconnectMsg = false;
+        disconnectMsg = null;
 
         asType = -1;
 
@@ -592,6 +599,21 @@ public class Options
                 }
                 else {
                     helloMsg = new Msg(Arrays.copyOf(bytes, bytes.length));
+                }
+            }
+            return true;
+
+        case ZMQ.ZMQ_DISCONNECT_MSG:
+            if (optval == null) {
+                disconnectMsg = null;
+            }
+            else {
+                byte[] bytes = parseBytes(option, optval);
+                if (bytes.length == 0) {
+                    disconnectMsg = null;
+                }
+                else {
+                    disconnectMsg = new Msg(Arrays.copyOf(bytes, bytes.length));
                 }
             }
             return true;

--- a/src/main/java/zmq/SocketBase.java
+++ b/src/main/java/zmq/SocketBase.java
@@ -599,6 +599,10 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
                     pipes[1].flush();
                 }
 
+                if (peer.options.canReceiveDisconnectMsg && peer.options.disconnectMsg != null) {
+                    pipes[0].setDisconnectMsg(peer.options.disconnectMsg);
+                }
+
                 //  Attach remote end of the pipe to the peer socket. Note that peer's
                 //  seqnum was incremented in findEndpoint function. We don't need it
                 //  increased here.
@@ -721,6 +725,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
                 }
                 else {
                     for (Pipe old : olds) {
+                        old.sendDisconnectMsg();
                         old.terminate(true);
                     }
                 }
@@ -1168,6 +1173,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
 
         //  Ask all attached pipes to terminate.
         for (Pipe pipe : pipes) {
+            pipe.sendDisconnectMsg();
             pipe.terminate(false);
         }
         registerTermAcks(pipes.size());

--- a/src/main/java/zmq/ZMQ.java
+++ b/src/main/java/zmq/ZMQ.java
@@ -139,6 +139,7 @@ public class ZMQ
     public static final int ZMQ_XPUB_VERBOSE_UNSUBSCRIBE = 78;
     public static final int ZMQ_HELLO_MSG                = 79;
     public static final int ZMQ_AS_TYPE                  = 80;
+    public static final int ZMQ_DISCONNECT_MSG           = 81;
 
     /* Custom options */
     @Deprecated

--- a/src/main/java/zmq/io/SessionBase.java
+++ b/src/main/java/zmq/io/SessionBase.java
@@ -376,7 +376,7 @@ public class SessionBase extends Own implements Pipe.IPipeEvents, IPollEvents
         this.engine.plug(ioThread, this);
     }
 
-    public void engineError(ErrorReason reason)
+    public void engineError(boolean handshaked, ErrorReason reason)
     {
         //  Engine is dead. Let's forget about it.
         engine = null;
@@ -384,6 +384,12 @@ public class SessionBase extends Own implements Pipe.IPipeEvents, IPollEvents
         //  Remove any half-done messages from the pipes.
         if (pipe != null) {
             cleanPipes();
+
+            //  Only send disconnect message if socket was accepted and handshake was completed
+            if (!active && handshaked && options.canReceiveDisconnectMsg && options.disconnectMsg != null) {
+                pipe.setDisconnectMsg(options.disconnectMsg);
+                pipe.sendDisconnectMsg();
+            }
         }
 
         assert (reason == ErrorReason.CONNECTION || reason == ErrorReason.TIMEOUT || reason == ErrorReason.PROTOCOL);

--- a/src/main/java/zmq/io/StreamEngine.java
+++ b/src/main/java/zmq/io/StreamEngine.java
@@ -91,12 +91,12 @@ public class StreamEngine implements IEngine, IPollEvents
     private Poller.Handle handle;
 
     private ByteBuffer inpos;
-    private int        insize;
-    private IDecoder   decoder;
+    private int insize;
+    private IDecoder decoder;
 
     private final ValueReference<ByteBuffer> outpos;
-    private int                              outsize;
-    private IEncoder                         encoder;
+    private int outsize;
+    private IEncoder encoder;
 
     private Metadata metadata;
 
@@ -131,7 +131,7 @@ public class StreamEngine implements IEngine, IPollEvents
 
     private boolean plugged;
 
-    private Supplier<Msg>          nextMsg;
+    private Supplier<Msg> nextMsg;
     private Function<Msg, Boolean> processMsg;
 
     private boolean ioError;
@@ -150,18 +150,18 @@ public class StreamEngine implements IEngine, IPollEvents
     private boolean outputStopped;
 
     //  ID of the handshake timer
-    private static final int HANDSHAKE_TIMER_ID         = 0x40;
-    private static final int HEARTBEAT_TTL_TIMER_ID     = 0x80;
-    private static final int HEARTBEAT_IVL_TIMER_ID     = 0x81;
+    private static final int HANDSHAKE_TIMER_ID = 0x40;
+    private static final int HEARTBEAT_TTL_TIMER_ID = 0x80;
+    private static final int HEARTBEAT_IVL_TIMER_ID = 0x81;
     private static final int HEARTBEAT_TIMEOUT_TIMER_ID = 0x82;
 
     //  True is linger timer is running.
     private boolean hasHandshakeTimer;
 
-    private boolean      hasTtlTimer;
-    private boolean      hasTimeoutTimer;
-    private boolean      hasHeartbeatTimer;
-    private final int    heartbeatTimeout;
+    private boolean hasTtlTimer;
+    private boolean hasTimeoutTimer;
+    private boolean hasHeartbeatTimer;
+    private final int heartbeatTimeout;
     private final byte[] heartbeatContext;
 
     // Socket
@@ -876,7 +876,7 @@ public class StreamEngine implements IEngine, IPollEvents
     }
 
     private final Function<Msg, Boolean> processIdentity = this::processIdentityMsg;
-    private final Supplier<Msg>          nextIdentity    = this::identityMsg;
+    private final Supplier<Msg> nextIdentity = this::identityMsg;
 
     private Msg nextHandshakeCommand()
     {
@@ -930,7 +930,7 @@ public class StreamEngine implements IEngine, IPollEvents
     }
 
     private final Function<Msg, Boolean> processHandshakeCommand = this::processHandshakeCommand;
-    private final Supplier<Msg>          nextHandshakeCommand    = this::nextHandshakeCommand;
+    private final Supplier<Msg> nextHandshakeCommand = this::nextHandshakeCommand;
 
     @Override
     public void zapMsgAvailable()
@@ -1004,8 +1004,8 @@ public class StreamEngine implements IEngine, IPollEvents
         return session.pushMsg(msg);
     }
 
-    private final Function<Msg, Boolean> pushMsgToSession   = this::pushMsgToSession;
-    private final Supplier<Msg>          pullMsgFromSession = this::pullMsgFromSession;
+    private final Function<Msg, Boolean> pushMsgToSession = this::pushMsgToSession;
+    private final Supplier<Msg> pullMsgFromSession = this::pullMsgFromSession;
 
     private boolean pushRawMsgToSession(Msg msg)
     {
@@ -1114,7 +1114,8 @@ public class StreamEngine implements IEngine, IPollEvents
         assert (session != null);
         socket.eventDisconnected(endpoint, fd);
         session.flush();
-        session.engineError(error);
+        session.engineError(!handshaking && (mechanism == null ||
+                mechanism.status() != Mechanism.Status.HANDSHAKING), error);
         unplug();
         destroy();
     }

--- a/src/main/java/zmq/socket/Peer.java
+++ b/src/main/java/zmq/socket/Peer.java
@@ -13,6 +13,7 @@ public class Peer extends Server
 
         options.type = ZMQ.ZMQ_PEER;
         options.canSendHelloMsg = true;
+        options.canReceiveDisconnectMsg = true;
     }
 
     @Override

--- a/src/main/java/zmq/socket/clientserver/Server.java
+++ b/src/main/java/zmq/socket/clientserver/Server.java
@@ -46,6 +46,7 @@ public class Server extends SocketBase
 
         options.type = ZMQ.ZMQ_SERVER;
         options.canSendHelloMsg = true;
+        options.canReceiveDisconnectMsg = true;
 
         fq = new FQ();
         outpipes = new HashMap<>();

--- a/src/main/java/zmq/socket/reqrep/Router.java
+++ b/src/main/java/zmq/socket/reqrep/Router.java
@@ -101,6 +101,7 @@ public class Router extends SocketBase
         options.recvIdentity = true;
         options.rawSocket = false;
         options.canSendHelloMsg = true;
+        options.canReceiveDisconnectMsg = true;
 
         fq = new FQ();
         prefetchedId = new Msg();

--- a/src/test/java/zmq/TestDisconnectMsg.java
+++ b/src/test/java/zmq/TestDisconnectMsg.java
@@ -1,0 +1,119 @@
+package zmq;
+
+import org.junit.Test;
+import zmq.util.Utils;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TestDisconnectMsg
+{
+    void test(String address) throws Exception
+    {
+        Ctx context = ZMQ.createContext();
+        assertThat(context, notNullValue());
+
+        // Create a server
+        SocketBase server = ZMQ.socket(context, ZMQ.ZMQ_SERVER);
+        assertThat(server, notNullValue());
+
+        // set router socket options
+        boolean rc = ZMQ.setSocketOption(server, ZMQ.ZMQ_DISCONNECT_MSG, "D");
+        assertThat(rc, is(true));
+
+        // bind server
+        rc = ZMQ.bind(server, address);
+        assertThat(rc, is(true));
+
+        // Create a client
+        SocketBase client = ZMQ.socket(context, ZMQ.ZMQ_CLIENT);
+        assertThat(client, notNullValue());
+        rc = ZMQ.setSocketOption(client, ZMQ.ZMQ_HELLO_MSG, "H");
+        assertThat(rc, is(true));
+        rc = ZMQ.connect(client, address);
+        assertThat(rc, is(true));
+
+        // Receive the hello message from client
+        Msg msg = ZMQ.recv(server, 0);
+        assertThat(new String(msg.data()), is("H"));
+
+        // Kill the client
+        ZMQ.close(client);
+
+        // Receive the disconnect message
+        msg = ZMQ.recv(server, 0);
+        assertThat(new String(msg.data()), is("D"));
+
+        //  Clean up.
+        ZMQ.close(server);
+        ZMQ.term(context);
+    }
+
+    @Test
+    public void testTcp() throws Exception
+    {
+        System.out.println("Scenario 1");
+
+        int port = Utils.findOpenPort();
+        String address = "tcp://localhost:" + port;
+
+        test(address);
+    }
+
+    @Test
+    public void testInproc() throws Exception
+    {
+        System.out.println("Scenario 2");
+
+        test ("inproc://disconnect-msg");
+    }
+
+    @Test
+    public void testInprocDisconnect()
+    {
+        System.out.println("Scenario 3");
+
+        String address = "inproc://disconnect-msg";
+
+        Ctx context = ZMQ.createContext();
+        assertThat(context, notNullValue());
+
+        // Create a server
+        SocketBase server = ZMQ.socket(context, ZMQ.ZMQ_SERVER);
+        assertThat(server, notNullValue());
+
+        // set server socket options
+        boolean rc = ZMQ.setSocketOption(server, ZMQ.ZMQ_DISCONNECT_MSG, "D");
+        assertThat(rc, is(true));
+
+        // bind server
+        rc = ZMQ.bind(server, address);
+        assertThat(rc, is(true));
+
+        // Create a client
+        SocketBase client = ZMQ.socket(context, ZMQ.ZMQ_CLIENT);
+        assertThat(client, notNullValue());
+        rc = ZMQ.setSocketOption(client, ZMQ.ZMQ_HELLO_MSG, "H");
+        assertThat(rc, is(true));
+        rc = ZMQ.connect(client, address);
+        assertThat(rc, is(true));
+
+        // Receive the hello message from client
+        Msg msg = ZMQ.recv(server, 0);
+        assertThat(new String(msg.data()), is("H"));
+
+        // disconnect the client
+        rc = client.termEndpoint(address);
+        assertThat(rc, is(true));
+
+        // Receive the disconnect message
+        msg = ZMQ.recv(server, 0);
+        assertThat(new String(msg.data()), is("D"));
+
+        //  Clean up.
+        ZMQ.close(client);
+        ZMQ.close(server);
+        ZMQ.term(context);
+    }
+}


### PR DESCRIPTION
ZMQ_ROUTER_NOTIFY doesn't have a context and doesn't play nice with protocols. with ZMQ_DISCONNECT_MSG we can set it to a protocol message, like DISCONNECT in majordomo. Router will send it when a peer disconnects. Another advantage of ZMQ_DISCONNECT_MSG is that it also works on inproc.

Together with ZMQ_HEARTBEAT it allows to build very reliable protocols, and much simpler as well.

Port of https://github.com/zeromq/libzmq/pull/3871