### PR TITLE
problem: disconnected endpoint laying around forever

### DIFF
--- a/src/main/java/zmq/SocketBase.java
+++ b/src/main/java/zmq/SocketBase.java
@@ -765,7 +765,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
                 //  If we have an associated pipe, terminate it.
                 for (EndpointPipe ep : eps) {
                     if (ep.pipe != null) {
-                        ep.pipe.terminate(true);
+                        ep.pipe.terminate(false);
                     }
                     termChild(ep.endpoint);
                 }


### PR DESCRIPTION
This is not the same behavior as with libzmq:

https://github.com/zeromq/libzmq/blob/master/src/socket_base.cpp\#L1215