### PR TITLE
minor: initialize `strhex`'s StringBuilder with the correct capacity

### DIFF
--- a/src/main/java/org/zeromq/util/ZData.java
+++ b/src/main/java/org/zeromq/util/ZData.java
@@ -116,7 +116,7 @@ public class ZData
         if (data == null) {
             return "";
         }
-        StringBuilder b = new StringBuilder();
+        StringBuilder b = new StringBuilder(data.length * 2);
         for (byte aData : data) {
             int b1 = aData >>> 4 & 0xf;
             int b2 = aData & 0xf;


### PR DESCRIPTION
This change prevents further reallocations when the `data` content is bigger than 8 bytes