### PR TITLE
Exhandlers

### DIFF
--- a/src/main/java/org/zeromq/ZContext.java
+++ b/src/main/java/org/zeromq/ZContext.java
@@ -1,6 +1,7 @@
 package org.zeromq;
 
 import java.io.Closeable;
+import java.lang.Thread.UncaughtExceptionHandler;
 import java.nio.channels.Selector;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -364,6 +365,39 @@ public class ZContext implements Closeable
     public void setSndHWM(int sndhwm)
     {
         this.sndhwm = sndhwm;
+    }
+
+    /**
+     * Set the handler invoked when a {@link zmq.poll.Poller} abruptly terminates due to an uncaught exception.<p>
+     * It default to the value of {@link Thread#getDefaultUncaughtExceptionHandler()}
+     * @param the object to use as this thread's uncaught exception handler. If null then this thread has no explicit handler.
+     */
+    public void setUncaughtExceptionHandler(UncaughtExceptionHandler handler) {
+        context.setUncaughtExceptionHandler(handler);
+    }
+
+    /**
+     * @return The handler invoked when a {@link zmq.poll.Poller} abruptly terminates due to an uncaught exception.
+     */
+    public UncaughtExceptionHandler getUncaughtExceptionHandler() {
+        return context.getUncaughtExceptionHandler();
+    }
+
+    /**
+     * In {@link zmq.poll.Poller#run()}, some non-fatal exceptions can be thrown. This handler will be notified, so they can
+     * be logged.<p>
+     * Default to {@link Throwable#printStackTrace()}
+     * @param handler
+     */
+    public void setNotificationExceptionHandler(UncaughtExceptionHandler handler) {
+        context.setNotificationExceptionHandler(handler);
+    }
+
+    /**
+     * @return The handler invoked when a non-fatal exceptions is thrown in zmq.poll.Poller#run()
+     */
+    public UncaughtExceptionHandler getNotificationExceptionHandler() {
+        return context.getNotificationExceptionHandler();
     }
 
     /**

--- a/src/main/java/org/zeromq/ZContext.java
+++ b/src/main/java/org/zeromq/ZContext.java
@@ -372,14 +372,16 @@ public class ZContext implements Closeable
      * It default to the value of {@link Thread#getDefaultUncaughtExceptionHandler()}
      * @param the object to use as this thread's uncaught exception handler. If null then this thread has no explicit handler.
      */
-    public void setUncaughtExceptionHandler(UncaughtExceptionHandler handler) {
+    public void setUncaughtExceptionHandler(UncaughtExceptionHandler handler)
+    {
         context.setUncaughtExceptionHandler(handler);
     }
 
     /**
      * @return The handler invoked when a {@link zmq.poll.Poller} abruptly terminates due to an uncaught exception.
      */
-    public UncaughtExceptionHandler getUncaughtExceptionHandler() {
+    public UncaughtExceptionHandler getUncaughtExceptionHandler()
+    {
         return context.getUncaughtExceptionHandler();
     }
 
@@ -389,14 +391,16 @@ public class ZContext implements Closeable
      * Default to {@link Throwable#printStackTrace()}
      * @param handler
      */
-    public void setNotificationExceptionHandler(UncaughtExceptionHandler handler) {
+    public void setNotificationExceptionHandler(UncaughtExceptionHandler handler)
+    {
         context.setNotificationExceptionHandler(handler);
     }
 
     /**
      * @return The handler invoked when a non-fatal exceptions is thrown in zmq.poll.Poller#run()
      */
-    public UncaughtExceptionHandler getNotificationExceptionHandler() {
+    public UncaughtExceptionHandler getNotificationExceptionHandler()
+    {
         return context.getNotificationExceptionHandler();
     }
 

--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -1,6 +1,7 @@
 package org.zeromq;
 
 import java.io.Closeable;
+import java.lang.Thread.UncaughtExceptionHandler;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.Selector;
@@ -623,6 +624,39 @@ public class ZMQ
         public boolean setIPv6(boolean ipv6)
         {
             return ctx.set(zmq.ZMQ.ZMQ_IPV6, ipv6 ? 1 : 0);
+        }
+
+        /**
+         * Set the handler invoked when a {@link zmq.poll.Poller} abruptly terminates due to an uncaught exception.<p>
+         * It default to the value of {@link Thread#getDefaultUncaughtExceptionHandler()}
+         * @param the object to use as this thread's uncaught exception handler. If null then this thread has no explicit handler.
+         */
+        public void setUncaughtExceptionHandler(UncaughtExceptionHandler handler) {
+            ctx.setUncaughtExceptionHandler(handler);
+        }
+
+        /**
+         * @return The handler invoked when a {@link zmq.poll.Poller} abruptly terminates due to an uncaught exception.
+         */
+        public UncaughtExceptionHandler getUncaughtExceptionHandler() {
+            return ctx.getUncaughtExceptionHandler();
+        }
+
+        /**
+         * In {@link zmq.poll.Poller#run()}, some non-fatal exceptions can be thrown. This handler will be notified, so they can
+         * be logged.<p>
+         * Default to {@link Throwable#printStackTrace()}
+         * @param handler
+         */
+        public void setNotificationExceptionHandler(UncaughtExceptionHandler handler) {
+            ctx.setNotificationExceptionHandler(handler);
+        }
+
+        /**
+         * @return The handler invoked when a non-fatal exceptions is thrown in zmq.poll.Poller#run()
+         */
+        public UncaughtExceptionHandler getNotificationExceptionHandler() {
+            return ctx.getNotificationExceptionHandler();
         }
 
         /**

--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -631,14 +631,16 @@ public class ZMQ
          * It default to the value of {@link Thread#getDefaultUncaughtExceptionHandler()}
          * @param the object to use as this thread's uncaught exception handler. If null then this thread has no explicit handler.
          */
-        public void setUncaughtExceptionHandler(UncaughtExceptionHandler handler) {
+        public void setUncaughtExceptionHandler(UncaughtExceptionHandler handler)
+        {
             ctx.setUncaughtExceptionHandler(handler);
         }
 
         /**
          * @return The handler invoked when a {@link zmq.poll.Poller} abruptly terminates due to an uncaught exception.
          */
-        public UncaughtExceptionHandler getUncaughtExceptionHandler() {
+        public UncaughtExceptionHandler getUncaughtExceptionHandler()
+        {
             return ctx.getUncaughtExceptionHandler();
         }
 
@@ -648,14 +650,16 @@ public class ZMQ
          * Default to {@link Throwable#printStackTrace()}
          * @param handler
          */
-        public void setNotificationExceptionHandler(UncaughtExceptionHandler handler) {
+        public void setNotificationExceptionHandler(UncaughtExceptionHandler handler)
+        {
             ctx.setNotificationExceptionHandler(handler);
         }
 
         /**
          * @return The handler invoked when a non-fatal exceptions is thrown in zmq.poll.Poller#run()
          */
-        public UncaughtExceptionHandler getNotificationExceptionHandler() {
+        public UncaughtExceptionHandler getNotificationExceptionHandler()
+        {
             return ctx.getNotificationExceptionHandler();
         }
 

--- a/src/main/java/org/zeromq/ZThread.java
+++ b/src/main/java/org/zeromq/ZThread.java
@@ -39,6 +39,7 @@ public class ZThread
             this.attachedRunnable = runnable;
             this.args = args;
             this.pipe = pipe;
+            this.setUncaughtExceptionHandler(ctx.getUncaughtExceptionHandler());
         }
 
         public ShimThread(IDetachedRunnable runnable, Object[] args)

--- a/src/main/java/zmq/Ctx.java
+++ b/src/main/java/zmq/Ctx.java
@@ -1,6 +1,7 @@
 package zmq;
 
 import java.io.IOException;
+import java.lang.Thread.UncaughtExceptionHandler;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
@@ -148,6 +149,12 @@ public class Ctx
     private boolean ipv6;
 
     private final Errno errno = new Errno();
+
+    // Exception handlers to receive notifications of critical exceptions in zmq.poll.Poller and handle uncaught exceptions
+    private UncaughtExceptionHandler exhandler = Thread.getDefaultUncaughtExceptionHandler();
+
+    // Exception handlers to receive notifications of exception in zmq.poll.Poller, and can be used for logging
+    private UncaughtExceptionHandler exnotification = (t, e) -> e.printStackTrace();
 
     /**
      * A class that holds the informations needed to forward channel in monitor sockets.
@@ -337,6 +344,45 @@ public class Ctx
         finally {
             slotSync.unlock();
         }
+    }
+
+    /**
+     * Set the handler invoked when a {@link zmq.poll.Poller} abruptly terminates due to an uncaught exception.<p>
+     * It default to the value of {@link Thread#getDefaultUncaughtExceptionHandler()}
+     * @param the object to use as this thread's uncaught exception handler. If null then this thread has no explicit handler.
+     */
+    public void setUncaughtExceptionHandler(UncaughtExceptionHandler handler) {
+        if  (!starting.get()) {
+            throw new IllegalStateException("Already started");
+        }
+        exhandler = handler;
+    }
+
+    /**
+     * @return The handler invoked when a {@link zmq.poll.Poller} abruptly terminates due to an uncaught exception.
+     */
+    public UncaughtExceptionHandler getUncaughtExceptionHandler() {
+        return exhandler;
+    }
+
+    /**
+     * In {@link zmq.poll.Poller#run()}, some non-fatal exceptions can be thrown. This handler will be notified, so they can
+     * be logged.<p>
+     * Default to {@link Throwable#printStackTrace()}
+     * @param handler
+     */
+    public void setNotificationExceptionHandler(UncaughtExceptionHandler handler) {
+        if  (!starting.get()) {
+            throw new IllegalStateException("Already started");
+        }
+        exnotification = handler;
+    }
+
+    /**
+     * @return The handler invoked when a non-fatal exceptions is thrown in zmq.poll.Poller#run()
+     */
+    public UncaughtExceptionHandler getNotificationExceptionHandler() {
+        return exnotification;
     }
 
     public boolean set(int option, int optval)

--- a/src/main/java/zmq/Ctx.java
+++ b/src/main/java/zmq/Ctx.java
@@ -351,7 +351,8 @@ public class Ctx
      * It default to the value of {@link Thread#getDefaultUncaughtExceptionHandler()}
      * @param the object to use as this thread's uncaught exception handler. If null then this thread has no explicit handler.
      */
-    public void setUncaughtExceptionHandler(UncaughtExceptionHandler handler) {
+    public void setUncaughtExceptionHandler(UncaughtExceptionHandler handler)
+    {
         if  (!starting.get()) {
             throw new IllegalStateException("Already started");
         }
@@ -361,7 +362,8 @@ public class Ctx
     /**
      * @return The handler invoked when a {@link zmq.poll.Poller} abruptly terminates due to an uncaught exception.
      */
-    public UncaughtExceptionHandler getUncaughtExceptionHandler() {
+    public UncaughtExceptionHandler getUncaughtExceptionHandler()
+    {
         return exhandler;
     }
 
@@ -371,7 +373,8 @@ public class Ctx
      * Default to {@link Throwable#printStackTrace()}
      * @param handler
      */
-    public void setNotificationExceptionHandler(UncaughtExceptionHandler handler) {
+    public void setNotificationExceptionHandler(UncaughtExceptionHandler handler)
+    {
         if  (!starting.get()) {
             throw new IllegalStateException("Already started");
         }
@@ -381,7 +384,8 @@ public class Ctx
     /**
      * @return The handler invoked when a non-fatal exceptions is thrown in zmq.poll.Poller#run()
      */
-    public UncaughtExceptionHandler getNotificationExceptionHandler() {
+    public UncaughtExceptionHandler getNotificationExceptionHandler()
+    {
         return exnotification;
     }
 

--- a/src/test/java/org/zeromq/TestZThread.java
+++ b/src/test/java/org/zeromq/TestZThread.java
@@ -55,6 +55,20 @@ public class TestZThread
         ctx.close();
     }
 
+    @Test(timeout = 1000)
+    public void testCriticalException() throws InterruptedException
+    {
+        final CountDownLatch stopped = new CountDownLatch(1);
+        try (final ZContext ctx = new ZContext()) {
+            ctx.setUncaughtExceptionHandler((t, e) -> stopped.countDown());
+            Socket pipe = ZThread.fork(ctx, (args, ctx1, pipe1) -> {
+                throw new Error("critical");
+            });
+            assertThat(pipe, notNullValue());
+            stopped.await();
+        }
+    }
+
     @Test
     @Ignore
     public void testClosePipe()

--- a/src/test/java/zmq/CtxTest.java
+++ b/src/test/java/zmq/CtxTest.java
@@ -38,9 +38,10 @@ public class CtxTest
 
         assertThat(ctx.checkTag(), is(false));
     }
-    
+
     @Test
-    public void testSetHandler() {
+    public void testSetHandler()
+{
         Ctx ctx = ZMQ.init(0);
         SocketBase socket = ZMQ.socket(ctx, Sockets.CLIENT.ordinal());
         Assert.assertThrows(IllegalStateException.class, () -> ctx.setNotificationExceptionHandler(null));

--- a/src/test/java/zmq/CtxTest.java
+++ b/src/test/java/zmq/CtxTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import zmq.socket.Sockets;
@@ -36,5 +37,14 @@ public class CtxTest
         ZMQ.term(ctx);
 
         assertThat(ctx.checkTag(), is(false));
+    }
+    
+    @Test
+    public void testSetHandler() {
+        Ctx ctx = ZMQ.init(0);
+        SocketBase socket = ZMQ.socket(ctx, Sockets.CLIENT.ordinal());
+        Assert.assertThrows(IllegalStateException.class, () -> ctx.setNotificationExceptionHandler(null));
+        Assert.assertThrows(IllegalStateException.class, () -> ctx.setUncaughtExceptionHandler(null));
+        ZMQ.close(socket);
     }
 }

--- a/src/test/java/zmq/poll/PollerTest.java
+++ b/src/test/java/zmq/poll/PollerTest.java
@@ -20,14 +20,15 @@ public class PollerTest
         Ctx ctx = new Ctx()
         {
             @Override
-            public Selector createSelector() {
+            public Selector createSelector()
+            {
                 selectorRef.set(super.createSelector());
                 return selectorRef.get();
             }
         };
-        ctx.setNotificationExceptionHandler((t, e) -> {
-            if (e instanceof ClosedSelectorException)
-            {
+        ctx.setNotificationExceptionHandler((t, e) ->
+        {
+            if (e instanceof ClosedSelectorException) {
                 catched.countDown();
             }
         });

--- a/src/test/java/zmq/poll/PollerTest.java
+++ b/src/test/java/zmq/poll/PollerTest.java
@@ -1,0 +1,39 @@
+package zmq.poll;
+
+import java.io.IOException;
+import java.nio.channels.ClosedSelectorException;
+import java.nio.channels.Selector;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import zmq.Ctx;
+
+public class PollerTest
+{
+    @Test(timeout = 1000)
+    public void catchNotification() throws IOException, InterruptedException
+    {
+        CountDownLatch catched = new CountDownLatch(1);
+        AtomicReference<Selector> selectorRef = new AtomicReference<>();
+        Ctx ctx = new Ctx()
+        {
+            @Override
+            public Selector createSelector() {
+                selectorRef.set(super.createSelector());
+                return selectorRef.get();
+            }
+        };
+        ctx.setNotificationExceptionHandler((t, e) -> {
+            if (e instanceof ClosedSelectorException)
+            {
+                catched.countDown();
+            }
+        });
+        Poller poller = new Poller(ctx, "test");
+        poller.start();
+        selectorRef.get().close();
+        catched.await();
+    }
+}


### PR DESCRIPTION
In zmq.poll.Poller.run(), many exceptions were generating stack dump on
stdout.

The thread could also silently die, with an out of memory as an example.
It's now possible to define two UncaughtExceptionHandler in a Ctx that
will be forwarded to the poller.

One (uncaughtExceptionHandler) will be used for the thread's
UncaughtExceptionHandler and should be used to be notify of critical
failures and generate an emergency stop.

The other (notificationExceptionHandler) can be used to replace the old
stack dump, for logging or tests.

it can only be used before any socket was created and not modifed any
more.