### PR TITLE
Sniffing the compliance to Android API level 19 in build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
                 key: jeromq-mavendep
             - run: mkdir -p /home/circleci/.sonar/cache /home/circleci/.m2/repository
             - run:
-                command: "mvn -B dependency:resolve dependency:resolve-plugins -s .circleci/settings.xml"
+                command: "mvn -B dependency:resolve dependency:resolve-plugins -s .circleci/settings.xml -Pandroid"
                 environment:
                     JAVA_HOME: /usr/local/openjdk-15
                     MAVEN_OPTS: "-Xmx1024m"
@@ -149,7 +149,7 @@ jobs:
             #don't persist_to_workspace, can't be done in parallel with testsj13
     testsandroid:
         docker:
-            - image: circleci/android:api-29
+            - image: circleci/openjdk:13-jdk-buster
         steps:
             - attach_workspace:
                 at: /tmp/ws
@@ -161,11 +161,7 @@ jobs:
                     mv -n /tmp/ws/home/circleci/project/.??* /home/circleci/project/
             - run:
                 command: |
-                    sdkmanager --update
-                    # default android sdk is old, manually update it
-                    (cd /tmp && curl -JORL https://dl.google.com/android/repository/commandlinetools-linux-6200805_latest.zip  && sudo unzip -o commandlinetools-linux-6200805_latest.zip -d /opt/android/sdk)
-                    rm src/android/Jeromq/{,app}/build.gradle
-                    /opt/android/sdk/tools/bin/lint --showall --xml target/lint-results.xml --sources src/main/java --exitcode --disable Assert --classpath target/classes --config src/android/Jeromq/lint.xml src/main
+                    mvn -B test -Pskip,android -Darg.line="-Xmx2048m" -s .circleci/settings.xml -Dmaven.test.skip=true
     publish:
         docker:
             - image: circleci/openjdk:13-jdk-buster
@@ -248,7 +244,6 @@ workflows:
               - testsj11
               - testsj13
               #- testsj15 -- fails until https://issues.apache.org/jira/browse/FELIX-6259 is closed
-              - testsandroid
       - savecache:
           requires:
               - publish

--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,11 @@
             </dependencies>
          </plugin>
          <plugin>
+           <groupId>org.codehaus.mojo</groupId>
+           <artifactId>animal-sniffer-maven-plugin</artifactId>
+           <version>1.20</version>
+         </plugin>
+         <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>versions-maven-plugin</artifactId>
             <version>2.8.1</version>
@@ -475,6 +480,29 @@
       <properties>
         <doclint>all</doclint>
       </properties>
+    </profile>
+    <profile>
+      <id>android</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>animal-sniffer-maven-plugin</artifactId>
+            <configuration>
+              <signature>net.sf.androidscents.signature:android-api-level-19:4.4_r1</signature>
+            </configuration>
+            <executions>
+              <execution>
+                <id>test</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
    </profiles>
 </project>


### PR DESCRIPTION
As it's actually non-compliant, it's not in dependency of circle-ci until
failures are all fixed.

It can be used for a quick check with the command:

    mvn test -Pandroid -DskipTests

Lint is dropped, as it's don't check any thing and is not reliable.