### PR TITLE
Socket identity bigger than 127 failing

### DIFF
--- a/src/main/java/zmq/Options.java
+++ b/src/main/java/zmq/Options.java
@@ -27,8 +27,8 @@ public class Options
     public long affinity;
 
     //  Socket identity
-    public byte   identitySize;
-    public byte[] identity;    // [256];
+    public short  identitySize;
+    public byte[] identity;
 
     // Last socket endpoint resolved URI
     String lastEndpoint;
@@ -191,7 +191,6 @@ public class Options
         sendHwm = 1000;
         recvHwm = 1000;
         affinity = 0;
-        identitySize = 0;
         rate = 100;
         recoveryIvl = 10000;
         multicastHops = 1;
@@ -228,7 +227,7 @@ public class Options
         heartbeatContext = new byte[0];
 
         identity = new byte[0];
-        identitySize = (byte) identity.length;
+        identitySize = 0;
 
         curvePublicKey = new byte[CURVE_KEYSIZE];
         curveSecretKey = new byte[CURVE_KEYSIZE];
@@ -282,7 +281,7 @@ public class Options
                 throw new IllegalArgumentException("identity must not be null or less than 255 " + optval);
             }
             identity = Arrays.copyOf(val, val.length);
-            identitySize = (byte) identity.length;
+            identitySize = (short) identity.length;
             return true;
 
         case ZMQ.ZMQ_RATE:

--- a/src/test/java/zmq/OptionsTest.java
+++ b/src/test/java/zmq/OptionsTest.java
@@ -287,6 +287,22 @@ public class OptionsTest
     }
 
     @Test
+    public void testIdentityOk()
+    {
+        Options opt = new Options();
+        // Try with a big identity
+        Assert.assertTrue(opt.setSocketOpt(ZMQ.ZMQ_IDENTITY, new byte[255]));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIdentityFails()
+    {
+        Options opt = new Options();
+        // Try with a big identity
+        Assert.assertTrue(opt.setSocketOpt(ZMQ.ZMQ_IDENTITY, new byte[256]));
+    }
+
+    @Test
     public void testDefaultValue()
     {
         //        assertThat(options.getSocketOpt(ZMQ.ZMQ_DECODER), is((Object)options.decoder));
@@ -329,5 +345,6 @@ public class OptionsTest
         assertThat(options.getSocketOpt(ZMQ.ZMQ_HEARTBEAT_TIMEOUT), is((Object) options.heartbeatTimeout));
         assertThat(options.getSocketOpt(ZMQ.ZMQ_HEARTBEAT_TTL), is((Object) options.heartbeatTtl));
         assertThat(options.getSocketOpt(ZMQ.ZMQ_SELECTOR_PROVIDERCHOOSER), nullValue());
+        assertThat(options.getSocketOpt(ZMQ.ZMQ_IDENTITY), is(new byte[0]));
     }
 }


### PR DESCRIPTION
Socket identity bigger than 127 was failing when the byte array was bigger
that 127, it was stored in a byte that overflow to a negative number.