### PR TITLE
fix: issue 721 deadlock bug

### DIFF
--- a/src/main/java/zmq/Command.java
+++ b/src/main/java/zmq/Command.java
@@ -49,6 +49,8 @@ public class Command
         //  Transfers the ownership of the closed socket
         //  to the reaper thread.
         REAP,
+        //  Sent by non-reaper socket to reaper to check destroy.
+        REAP_ACK,
         //  Closed socket notifies the reaper that it's already deallocated.
         REAPED,
         // TODO V4 provide a description for Command#INPROC_CONNECTED

--- a/src/main/java/zmq/SocketBase.java
+++ b/src/main/java/zmq/SocketBase.java
@@ -1140,7 +1140,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
         checkDestroy();
     }
 
-	private final void setCtxTerminated()
+    private final void setCtxTerminated()
     {
         ctxTerminated.set(true);
     }

--- a/src/main/java/zmq/SocketBase.java
+++ b/src/main/java/zmq/SocketBase.java
@@ -1135,8 +1135,14 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
 
         //  Initialize the termination and check whether it can be deallocated
         //  immediately.
+        setCtxTerminated();
         terminate();
         checkDestroy();
+    }
+
+	private final void setCtxTerminated()
+    {
+        ctxTerminated = true;
     }
 
     //  Processes commands sent to this socket (if any). If timeout is -1,
@@ -1212,7 +1218,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
         try {
             monitorSync.lock();
             stopMonitor();
-            ctxTerminated = true;
+            setCtxTerminated();
         }
         finally {
             monitorSync.unlock();

--- a/src/main/java/zmq/ZObject.java
+++ b/src/main/java/zmq/ZObject.java
@@ -107,6 +107,10 @@ public abstract class ZObject
             processReap((SocketBase) cmd.arg);
             break;
 
+        case REAP_ACK:
+            processReapAck();
+            break;
+
         case REAPED:
             processReaped();
             break;
@@ -280,6 +284,12 @@ public abstract class ZObject
         sendCommand(cmd);
     }
 
+    protected final void sendReapAck()
+    {
+        Command cmd = new Command(this, Command.Type.REAP_ACK);
+        sendCommand(cmd);
+    }
+
     protected final void sendReaped()
     {
         Command cmd = new Command(ctx.getReaper(), Command.Type.REAPED);
@@ -372,6 +382,10 @@ public abstract class ZObject
     protected void processReap(SocketBase socket)
     {
         throw new UnsupportedOperationException();
+    }
+
+    protected void processReapAck()
+    {
     }
 
     protected void processReaped()


### PR DESCRIPTION
**what is the problem**

Hi all. I am using jeromq in a multithreaded environment. but I have a problem same as #721.

I have two threads in my system. One for `sub` recivier, another for `pub` sender. In the recv thread, I directly called `socket.recv()` to recv messages, which will block the thread until a message is received.

When I tried to call `context.close()`, I expect this function call will interrupt recv function, so that I can stop the recv thread directly. In most cases, it worked well. However, there are still hangs.

**how it happened**

I will use the following code to illustrate the problem.

```java
import org.zeromq.SocketType;
import org.zeromq.ZContext;
import org.zeromq.ZMQ;
import org.zeromq.ZMQException;
import zmq.ZError;

public class TestA {
    public static void main(String[] args) throws InterruptedException {
        while(true) {
            Receiver recv = new Receiver();
            recv.run();
            Thread.sleep(100);
            recv.term();
            recv.join();
            break;
        }
    }

    static class Receiver {
        private Thread t;
        private ZContext context = new ZContext();
        public void run() {
            t = new Thread(new Runnable() {
                public void run() {     // run a thread to do recv operation
                    System.out.println("recv start.");
                    ZMQ.Socket socket = context.createSocket(SocketType.SUB);
                    socket.setLinger(0);
                    socket.connect("tcp://127.0.0.1:7899");
                    try {
                        socket.recv();
                    } catch (ZMQException e) {
                        if(e.getErrorCode() != ZError.ETERM) {
                            e.printStackTrace();
                        }
                    }
                    System.out.println("recv end.");
                }
            }, "Receiver");
            t.start();
        }

        public void term() {
            System.out.println("term start.");
            context.close();        // close the context
            System.out.println("term end.");
        }

        public void join() throws InterruptedException {
            t.join();
        }
    }
}
```

Using jeromq-0.5.3-SNAPSHOT which is compiled from master branch(`commit 2a3645dbe6161774faa5011c132907c1be3c768`).

There is a `sub` socket, and it calls recv in a single thread. Call `context.close()` in another thread to interrupt `socket.recv()`. `sub` socket's `STOP` command and this socket's `owned` socket's `TERM_ACK` command will be processed by reaper or this `sub` socket's recv function. But, if `sub` thread received `TERM_ACK` command, and then `socket.termAcks` equals to 0, `sub` socket will call `processDestroy` function which will set `sub` socket's `destroyed` field from `false` to `true`. 

But there is no `checkDestroy` function call with in `sub` socket's recv function. So at this point, reaper is waiting for `REAPED` command to remove `sub` socket from reaper, and `this.termMailbox.recv(-1L)` which is called by `context.close()` is waiting for `DONE` message which is sent by reaper's `processReaped` function. Clearly there is a deadlock here.

So this is the reason why `context.close()` hangs occasionally, and only hangs with recv socket.

**how to fix it**

```diff
diff --git a/src/main/java/zmq/SocketBase.java b/src/main/java/zmq/SocketBase.java
index 2de11bf..49f8548 100644
--- a/src/main/java/zmq/SocketBase.java
+++ b/src/main/java/zmq/SocketBase.java
@@ -1135,10 +1135,16 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE

         //  Initialize the termination and check whether it can be deallocated
         //  immediately.
+        setCtxTerminated();
         terminate();
         checkDestroy();
     }

+       private final void setCtxTerminated()
+    {
+        ctxTerminated = true;
+    }
+
     //  Processes commands sent to this socket (if any). If timeout is -1,
     //  returns only after at least one command was processed.
     //  If throttle argument is true, commands are processed at most once
@@ -1212,7 +1218,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
         try {
             monitorSync.lock();
             stopMonitor();
-            ctxTerminated = true;
+            setCtxTerminated();
         }
         finally {
             monitorSync.unlock();
```

I think the root cause of the hang is, when a socket send `REAP` message to reaper, the reaper should takes over the processing of commands of this socket completely. But after called `processReap -> startReaping`, the socket can still recving, and currently progressed recv operation will not be interrupted. If socket is still recving, it may receive commands that should have been handled by reaper (such as the last `TERM_ACK`). 

Reaper will call `inEvent` to process commands:

```java
@Override
    public final void inEvent()
    {
        //  This function is invoked only once the socket is running in the context
        //  of the reaper thread. Process any commands from other threads/sockets
        //  that may be available at the moment. Ultimately, the socket will
        //  be destroyed.

        lock();

        try {
            //  If the socket is thread safe we need to unsignal the reaper signaler
            if (threadSafe) {
                reaperSignaler.recv();
            }

            processCommands(0, false, null);

        }
        finally {
            unlock();
        }

        checkDestroy();
    }
```

Common sockets will directly call `processCommands` in `recv` function:

```java
public final Msg recv(int flags, AtomicBoolean canceled)
    {
        lock();

        try {
            //  Check whether the library haven't been shut down yet.
            if (ctxTerminated) {
                errno.set(ZError.ETERM);
                return null;
            }

            ......
            while (true) {
                if (!processCommands(block ? timeout : 0, false, canceled)) {
                    return null;
                }
                ......
            }

            extractFlags(msg);
            return msg;
        }
        finally {
            unlock();
        }
    }
```

So I just force common socket don't recv messages when reaping, and this will solve the problem.