### PR TITLE
Adding a socket option to define a metadata record name to store the self address

### DIFF
--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -2767,6 +2767,31 @@ public class ZMQ
         }
 
         /**
+         * The ZMQ_SELFADDR_PROPERTY_NAME option shall retrieve the metadata record used to store the self address.
+         * The returned value MAY be null or empty.
+         *
+         * @return the meta record name
+         * @see #setSelfAddressPropertyName(String)
+         */
+        public String getSelfAddressPropertyName()
+        {
+            return (String) base.getSocketOptx(zmq.ZMQ.ZMQ_SELFADDR_PROPERTY_NAME);
+        }
+
+        /**
+         * Sets the field name where the self address will be stored.
+         * If set to null or empty string, it will not be stored
+         *
+         * @param recordName the name of the field
+         * @return true if the option was set
+         * @see #getSelfAddressPropertyName()
+         */
+        public boolean setSelfAddressPropertyName(String recordName)
+        {
+            return setSocketOpt(zmq.ZMQ.ZMQ_SELFADDR_PROPERTY_NAME, recordName);
+        }
+
+        /**
          * Defines whether the socket will act as server for PLAIN security, see zmq_plain(7).
          * A value of true means the socket will act as PLAIN server.
          * A value of false means the socket will not act as PLAIN server,

--- a/src/main/java/zmq/Options.java
+++ b/src/main/java/zmq/Options.java
@@ -186,6 +186,9 @@ public class Options
 
     public final Errno errno = new Errno();
 
+    // A metadata record name where the self address will be stored if defined
+    public String selfAddressPropertyName;
+
     public Options()
     {
         sendHwm = 1000;
@@ -249,6 +252,8 @@ public class Options
         asType = -1;
 
         peerLastRoutingId = 0;
+
+        selfAddressPropertyName = null;
     }
 
     @SuppressWarnings("deprecation")
@@ -621,6 +626,10 @@ public class Options
             this.asType = (Integer) optval;
             return true;
 
+        case ZMQ.ZMQ_SELFADDR_PROPERTY_NAME:
+            this.selfAddressPropertyName = parseString(option, optval);
+            return true;
+
         default:
             throw new IllegalArgumentException("Unknown Option " + option);
         }
@@ -871,6 +880,9 @@ public class Options
 
         case ZMQ.ZMQ_AS_TYPE:
             return asType;
+
+        case ZMQ.ZMQ_SELFADDR_PROPERTY_NAME:
+            return selfAddressPropertyName;
 
         default:
             throw new IllegalArgumentException("option=" + option);

--- a/src/main/java/zmq/ZMQ.java
+++ b/src/main/java/zmq/ZMQ.java
@@ -141,6 +141,7 @@ public class ZMQ
     public static final int ZMQ_AS_TYPE                  = 80;
     public static final int ZMQ_DISCONNECT_MSG           = 81;
     public static final int ZMQ_HICCUP_MSG               = 82;
+    public static final int ZMQ_SELFADDR_PROPERTY_NAME   = 83;
 
     /* Custom options */
     @Deprecated

--- a/src/main/java/zmq/io/StreamEngine.java
+++ b/src/main/java/zmq/io/StreamEngine.java
@@ -168,6 +168,7 @@ public class StreamEngine implements IEngine, IPollEvents
     private SocketBase socket;
 
     private final Address peerAddress;
+    private final Address selfAddress;
 
     private final Errno errno;
 
@@ -196,6 +197,7 @@ public class StreamEngine implements IEngine, IPollEvents
         }
 
         peerAddress = Utils.getPeerIpAddress(fd);
+        selfAddress = Utils.getLocalIpAddress(fd);
 
         heartbeatTimeout = heartbeatTimeout();
         heartbeatContext = Arrays.copyOf(options.heartbeatContext, options.heartbeatContext.length);
@@ -280,6 +282,14 @@ public class StreamEngine implements IEngine, IPollEvents
                 // Compile metadata
                 metadata = new Metadata();
                 metadata.set(Metadata.PEER_ADDRESS, peerAddress.address());
+            }
+
+            if (options.selfAddressPropertyName != null && ! options.selfAddressPropertyName.isEmpty()
+                && selfAddress != null && !selfAddress.address().isEmpty()) {
+                if (metadata == null) {
+                    metadata = new Metadata();
+                }
+                metadata.set(options.selfAddressPropertyName, selfAddress.address());
             }
 
             //  For raw sockets, send an initial 0-length message to the
@@ -981,6 +991,11 @@ public class StreamEngine implements IEngine, IPollEvents
         //  If we have a peer_address, add it to metadata
         if (peerAddress != null && !peerAddress.address().isEmpty()) {
             metadata.set(Metadata.PEER_ADDRESS, peerAddress.address());
+        }
+        //  If we have a local_address, add it to metadata
+        if (options.selfAddressPropertyName != null && ! options.selfAddressPropertyName.isEmpty()
+            && selfAddress != null && !selfAddress.address().isEmpty()) {
+            metadata.set(options.selfAddressPropertyName, selfAddress.address());
         }
         //  Add ZAP properties.
         metadata.set(mechanism.zapProperties);

--- a/src/main/java/zmq/util/Utils.java
+++ b/src/main/java/zmq/util/Utils.java
@@ -155,6 +155,13 @@ public class Utils
         return new Address(address);
     }
 
+    public static Address getLocalIpAddress(SocketChannel fd)
+    {
+        SocketAddress address = fd.socket().getLocalSocketAddress();
+
+        return new Address(address);
+    }
+
     public static String dump(ByteBuffer buffer, int pos, int limit)
     {
         int oldpos = buffer.position();

--- a/src/test/java/org/zeromq/TestZMQ.java
+++ b/src/test/java/org/zeromq/TestZMQ.java
@@ -1359,4 +1359,18 @@ public class TestZMQ
 
         socket.close();
     }
+
+    @Test
+    public void testSocketLocalAddressPropertyName()
+    {
+        try (final Socket socket = ctx.socket(SocketType.XPUB)) {
+            assertThat(socket, notNullValue());
+
+            boolean rc = socket.setSelfAddressPropertyName("X-LocalAddress");
+            assertThat(rc, is(true));
+
+            String propertyName = socket.getSelfAddressPropertyName();
+            assertThat(propertyName, is("X-LocalAddress"));
+        }
+    }
 }

--- a/src/test/java/zmq/OptionsTest.java
+++ b/src/test/java/zmq/OptionsTest.java
@@ -346,5 +346,6 @@ public class OptionsTest
         assertThat(options.getSocketOpt(ZMQ.ZMQ_HEARTBEAT_TTL), is((Object) options.heartbeatTtl));
         assertThat(options.getSocketOpt(ZMQ.ZMQ_SELECTOR_PROVIDERCHOOSER), nullValue());
         assertThat(options.getSocketOpt(ZMQ.ZMQ_IDENTITY), is(new byte[0]));
+        assertThat(options.getSocketOpt(ZMQ.ZMQ_SELFADDR_PROPERTY_NAME), nullValue());
     }
 }

--- a/src/test/java/zmq/io/MetadataTest.java
+++ b/src/test/java/zmq/io/MetadataTest.java
@@ -108,6 +108,8 @@ public class MetadataTest
 
         ZMQ.setSocketOption(server, ZMQ.ZMQ_ZAP_DOMAIN, "DOMAIN");
 
+        ZMQ.setSocketOption(server, ZMQ.ZMQ_SELFADDR_PROPERTY_NAME, "X-Local-Address");
+
         rc = ZMQ.bind(server, host);
         assertThat(rc, is(true));
 
@@ -134,6 +136,9 @@ public class MetadataTest
 
         prop = ZMQ.getMessageMetadata(msg, "Hello");
         assertThat(prop, is("World"));
+
+        prop = ZMQ.getMessageMetadata(msg, "X-Local-Address");
+        assertThat(prop, is("127.0.0.1:" + port));
 
         ZMQ.closeZeroLinger(server);
         ZMQ.closeZeroLinger(client);


### PR DESCRIPTION
Adding a socket option to define a metadata record name where the effective self address used will be stored.

If null (the default) or empty, it will not be stored.

It can be useful in two cases

— when listening with "IP:*", the port is not known
— when listening with "*:XX", the effective address used by the socket is not known.

Allowing to store the effective used address might be useful for auditing.