### PR TITLE
Raising supported Android API to level 28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -483,7 +483,7 @@
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>animal-sniffer-maven-plugin</artifactId>
             <configuration>
-              <signature>net.sf.androidscents.signature:android-api-level-19:4.4_r1</signature>
+              <signature>net.sf.androidscents.signature:android-api-level-28:9_r6</signature>
             </configuration>
             <executions>
               <execution>


### PR DESCRIPTION
Raising supported Android API to level 28, which the lowest level of supported API on Google Play at the time of this commit.