### PR TITLE
Duplication of SocketChannel address resolution in zmq.io.net.tcp.TcpUtils and zmq.Utils.

### DIFF
--- a/src/main/java/zmq/io/net/Address.java
+++ b/src/main/java/zmq/io/net/Address.java
@@ -47,12 +47,21 @@ public class Address
         resolved = null;
     }
 
+    /**
+     * @param socketAddress
+     * @throws IllegalArgumentException if the SocketChannel is not an IP socket address
+     */
     public Address(SocketAddress socketAddress)
     {
-        InetSocketAddress sockAddr = (InetSocketAddress) socketAddress;
-        this.address = sockAddr.getAddress().getHostAddress() + ":" + sockAddr.getPort();
-        protocol = NetProtocol.tcp;
-        resolved = null;
+        if (socketAddress instanceof InetSocketAddress) {
+            InetSocketAddress sockAddr = (InetSocketAddress) socketAddress;
+            this.address = sockAddr.getAddress().getHostAddress() + ":" + sockAddr.getPort();
+            protocol = NetProtocol.tcp;
+            resolved = null;
+        }
+        else {
+            throw new IllegalArgumentException("Not a IP socket address");
+        }
     }
 
     @Override

--- a/src/main/java/zmq/io/net/tcp/TcpUtils.java
+++ b/src/main/java/zmq/io/net/tcp/TcpUtils.java
@@ -3,7 +3,6 @@ package zmq.io.net.tcp;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.net.SocketAddress;
 import java.nio.channels.Channel;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.ServerSocketChannel;
@@ -11,6 +10,7 @@ import java.nio.channels.SocketChannel;
 
 import zmq.ZError;
 import zmq.io.net.Address;
+import zmq.util.Utils;
 
 public class TcpUtils
 {
@@ -107,10 +107,17 @@ public class TcpUtils
         // TODO V4 enable ipv4 mapping
     }
 
+    /**
+     * Return the {@link  Address} of the channel
+     * @param channel the channel, should be a TCP socket channel
+     * @return The {@link Address} of the channel
+     * @deprecated Use {@link zmq.util.Utils#getPeerIpAddress(SocketChannel)} instead
+     * @throws ZError.IOException if the channel is closed or an I/O errors occurred
+     * @throws IllegalArgumentException if the SocketChannel is not a TCP channel
+     */
+    @Deprecated
     public static Address getPeerIpAddress(SocketChannel channel)
     {
-        SocketAddress address = channel.socket().getRemoteSocketAddress();
-
-        return new Address(address);
+        return Utils.getPeerIpAddress(channel);
     }
 }

--- a/src/main/java/zmq/util/Utils.java
+++ b/src/main/java/zmq/util/Utils.java
@@ -10,6 +10,7 @@ import java.nio.channels.SelectableChannel;
 import java.nio.channels.SocketChannel;
 import java.security.SecureRandom;
 
+import zmq.ZError;
 import zmq.io.net.Address;
 import zmq.io.net.tcp.TcpUtils;
 import zmq.util.function.Supplier;
@@ -148,18 +149,40 @@ public class Utils
         return ret && path.delete();
     }
 
+    /**
+     * Resolve the remote address of the channel.
+     * @param fd the channel, should be a TCP socket channel
+     * @return a new {@link Address}
+     * @throws ZError.IOException if the channel is closed or an I/O errors occurred
+     * @throws IllegalArgumentException if the SocketChannel is not a TCP channel
+     */
     public static Address getPeerIpAddress(SocketChannel fd)
     {
-        SocketAddress address = fd.socket().getRemoteSocketAddress();
-
-        return new Address(address);
+        try {
+            SocketAddress address = fd.getRemoteAddress();
+            return new Address(address);
+        }
+        catch (IOException e) {
+            throw new ZError.IOException(e);
+        }
     }
 
+    /**
+     * Resolve the local address of the channel.
+     * @param fd the channel, should be a TCP socket channel
+     * @return a new {@link Address}
+     * @throws ZError.IOException if the channel is closed or an I/O errors occurred
+     * @throws IllegalArgumentException if the SocketChannel is not a TCP channel
+     */
     public static Address getLocalIpAddress(SocketChannel fd)
     {
-        SocketAddress address = fd.socket().getLocalSocketAddress();
-
-        return new Address(address);
+        try {
+            SocketAddress address = fd.getLocalAddress();
+            return new Address(address);
+        }
+        catch (IOException e) {
+            throw new ZError.IOException(e);
+        }
     }
 
     public static String dump(ByteBuffer buffer, int pos, int limit)


### PR DESCRIPTION
Duplication of SocketChannel address resolution in zmq.io.net.tcp.TcpUtils and zmq.Utils.

Deprecating zmq.io.net.tcp.TcpUtils that was not used.

getPeerIpAddress and getLocalIpAddress could throw NPE throught unchecked zmq.io.net.Address::new.