### PR TITLE
TCP KEEPALIVE values (interval, count and idle) are now really handled.

### DIFF
--- a/src/main/java/zmq/io/net/tcp/TcpUtils.java
+++ b/src/main/java/zmq/io/net/tcp/TcpUtils.java
@@ -1,12 +1,12 @@
 package zmq.io.net.tcp;
 
 import java.io.IOException;
-import java.net.ServerSocket;
-import java.net.Socket;
 import java.net.SocketAddress;
+import java.net.SocketOption;
+import java.net.StandardSocketOptions;
 import java.nio.channels.Channel;
+import java.nio.channels.NetworkChannel;
 import java.nio.channels.SelectableChannel;
-import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 
 import zmq.ZError;
@@ -14,80 +14,99 @@ import zmq.io.net.Address;
 
 public class TcpUtils
 {
-    private static interface OptionSetter<S>
+    public static final boolean WITH_EXTENDED_KEEPALIVE = SocketOptionsProvider.WITH_EXTENDED_KEEPALIVE;
+
+    @SuppressWarnings("unchecked")
+    private static final class SocketOptionsProvider
     {
-        void setOption(S socket) throws IOException;
-    }
+        // Wrapped in an inner class, to avoid the @SuppressWarnings for the whole class
+        private static final SocketOption<Integer> TCP_KEEPCOUNT;
+        private static final SocketOption<Integer> TCP_KEEPIDLE;
+        private static final SocketOption<Integer> TCP_KEEPINTERVAL;
+        private static final boolean WITH_EXTENDED_KEEPALIVE;
+        static {
+            SocketOption<Integer> tryCount = null;
+            SocketOption<Integer> tryIdle = null;
+            SocketOption<Integer> tryInterval = null;
+
+            boolean extendedKeepAlive = false;
+            try {
+                Class<?> eso = TcpUtils.class.getClassLoader().loadClass("jdk.net.ExtendedSocketOptions");
+                tryCount = (SocketOption<Integer>) eso.getField("TCP_KEEPCOUNT").get(null);
+                tryIdle = (SocketOption<Integer>) eso.getField("TCP_KEEPIDLE").get(null);
+                tryInterval = (SocketOption<Integer>) eso.getField("TCP_KEEPINTERVAL").get(null);
+                extendedKeepAlive = true;
+            }
+            catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException e) {
+                // If failing, will keep extendedKeepAlive to false
+            }
+            TCP_KEEPCOUNT = tryCount;
+            TCP_KEEPIDLE = tryIdle;
+            TCP_KEEPINTERVAL = tryInterval;
+            WITH_EXTENDED_KEEPALIVE = extendedKeepAlive;
+        }
+   }
 
     private TcpUtils()
     {
     }
 
     // The explicit IOException is useless, but kept for API compatibility
-    public static void tuneTcpSocket(SocketChannel channel) throws IOException
+    public static void tuneTcpSocket(Channel channel) throws IOException
     {
         // Disable Nagle's algorithm. We are doing data batching on 0MQ level,
-        // so using Nagle wouldn't improve throughput in anyway, but it would
+        // so using Nagle wouldn't improve throughput in any way, but it would
         // hurt latency.
-        setOption(channel,
-                socket -> socket.setTcpNoDelay(true));
+        setOption(channel, StandardSocketOptions.TCP_NODELAY, true);
+    }
+
+    public static void tuneTcpKeepalives(Channel channel, int tcpKeepAlive, int tcpKeepAliveCnt,
+            int tcpKeepAliveIdle, int tcpKeepAliveIntvl)
+    {
+        if (tcpKeepAlive != -1) {
+            if (channel instanceof SocketChannel) {
+                setOption(channel, StandardSocketOptions.SO_KEEPALIVE, tcpKeepAlive == 1);
+            }
+            if (WITH_EXTENDED_KEEPALIVE && tcpKeepAlive == 1) {
+                setOption(channel, SocketOptionsProvider.TCP_KEEPCOUNT, tcpKeepAliveCnt);
+                setOption(channel, SocketOptionsProvider.TCP_KEEPIDLE, tcpKeepAliveIdle);
+                setOption(channel, SocketOptionsProvider.TCP_KEEPINTERVAL, tcpKeepAliveIntvl);
+            }
+        }
     }
 
     public static boolean setTcpReceiveBuffer(Channel channel, final int rcvbuf)
     {
-        setOption(channel,
-                socket -> socket.setReceiveBufferSize(rcvbuf),
-                socket -> socket.setReceiveBufferSize(rcvbuf));
+        setOption(channel, StandardSocketOptions.SO_RCVBUF, rcvbuf);
         return true;
     }
 
     public static boolean setTcpSendBuffer(Channel channel, final int sndbuf)
     {
-        setOption(channel,
-                socket -> socket.setSendBufferSize(sndbuf));
+        setOption(channel, StandardSocketOptions.SO_SNDBUF, sndbuf);
         return true;
     }
 
     public static boolean setIpTypeOfService(Channel channel, final int tos)
     {
-        setOption(channel,
-                socket -> socket.setTrafficClass(tos));
+        setOption(channel, StandardSocketOptions.SO_SNDBUF, tos);
         return true;
     }
 
     public static boolean setReuseAddress(Channel channel, final boolean reuse)
     {
-        setOption(channel,
-                socket -> socket.setReuseAddress(reuse),
-                socket -> socket.setReuseAddress(reuse));
+        setOption(channel, StandardSocketOptions.SO_REUSEADDR, reuse);
         return true;
     }
 
-    public static void tuneTcpKeepalives(SocketChannel channel, int tcpKeepAlive, int tcpKeepAliveCnt,
-            int tcpKeepAliveIdle, int tcpKeepAliveIntvl)
-    {
-        setOption(channel,
-                socket -> socket.setKeepAlive(tcpKeepAlive == 1));
-   }
-
-    /**
-     * A single setter method, used when the option doesn't apply to a {@link ServerSocket}
-     * @param channel
-     * @param setter
-     */
-    private static void setOption(Channel channel, OptionSetter<Socket> setter)
-    {
-        setOption(channel, setter, s -> { });
-    }
-
-    private static void setOption(Channel channel, OptionSetter<Socket> setter, OptionSetter<ServerSocket> serverSetter)
+    private static <T> void setOption(Channel channel, SocketOption<T> option, T value)
     {
         try {
-            if (channel instanceof ServerSocketChannel) {
-                serverSetter.setOption(((ServerSocketChannel) channel).socket());
+            if (channel instanceof NetworkChannel) {
+                ((NetworkChannel) channel).setOption(option, value);
             }
-            else if (channel instanceof SocketChannel) {
-                setter.setOption(((SocketChannel) channel).socket());
+            else {
+                throw new IllegalArgumentException("Channel " + channel + " is not a network channel");
             }
         }
         catch (IOException e) {

--- a/src/test/java/zmq/io/net/tcp/KeepAliveTest.java
+++ b/src/test/java/zmq/io/net/tcp/KeepAliveTest.java
@@ -1,0 +1,56 @@
+package zmq.io.net.tcp;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketOption;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import zmq.Options;
+
+public class KeepAliveTest
+{
+    @Test
+    public void testConsistent() throws IOException
+    {
+        try {
+            int javaspec = Integer.parseInt(System.getProperty("java.specification.version"));
+            // Test fails for jvm lest that 13
+            if (javaspec >= 13) {
+                Class<?> eso = Options.class.getClassLoader().loadClass("jdk.net.ExtendedSocketOptions");
+                SocketOption<Integer> count = (SocketOption<Integer>) eso.getField("TCP_KEEPCOUNT").get(null);
+                SocketOption<Integer> idle = (SocketOption<Integer>) eso.getField("TCP_KEEPIDLE").get(null);
+                SocketOption<Integer> interval = (SocketOption<Integer>) eso.getField("TCP_KEEPINTERVAL").get(null);
+                Method socketgetOption = Socket.class.getMethod("getOption", SocketOption.class);
+                Method serversocketgetOption = ServerSocket.class.getMethod("getOption", SocketOption.class);
+                Assert.assertTrue(TcpUtils.WITH_EXTENDED_KEEPALIVE);
+
+                SocketChannel sc = SocketChannel.open();
+                TcpUtils.tuneTcpKeepalives(sc, 1, 2, 3, 4);
+                Assert.assertEquals(2, socketgetOption.invoke(sc.socket(), count));
+                Assert.assertEquals(3, socketgetOption.invoke(sc.socket(), idle));
+                Assert.assertEquals(4, socketgetOption.invoke(sc.socket(), interval));
+
+                ServerSocketChannel ssc = ServerSocketChannel.open();
+                TcpUtils.tuneTcpKeepalives(ssc, 1, 2, 3, 4);
+                Assert.assertEquals(2, serversocketgetOption.invoke(ssc.socket(), count));
+                Assert.assertEquals(3, serversocketgetOption.invoke(ssc.socket(), idle));
+                Assert.assertEquals(4, serversocketgetOption.invoke(ssc.socket(), interval));
+            }
+        }
+        catch (NumberFormatException ex) {
+            // java 1.8, not a problem as keepalive is not handled
+        }
+        catch (NoSuchMethodException | ClassNotFoundException | NoSuchFieldException | IllegalAccessException |
+                 InvocationTargetException e) {
+            // Not defined, just skip the test
+        }
+
+    }
+}


### PR DESCRIPTION
TCP KEEPALIVE values (interval, count and idle) are now really handled. But only works for JVM 13 and latter.