### PR TITLE
NPE with org.zeromq.ZMQ.Event.recv(socket, DONTWAIT)

### DIFF
--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -4285,6 +4285,9 @@ public class ZMQ
         public static Event recv(Socket socket, int flags)
         {
             zmq.ZMQ.Event e = zmq.ZMQ.Event.read(socket.base, flags);
+            if (e == null) {
+                return null;
+            }
             Object resolvedValue;
             switch (e.event) {
             case zmq.ZMQ.ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL:
@@ -4305,6 +4308,7 @@ public class ZMQ
                 break;
             case zmq.ZMQ.ZMQ_EVENT_CONNECT_DELAYED:
             case zmq.ZMQ.ZMQ_EVENT_HANDSHAKE_SUCCEEDED:
+            case zmq.ZMQ.ZMQ_EVENT_MONITOR_STOPPED:
                 resolvedValue = null;
                 break;
             default:


### PR DESCRIPTION
With org.zeromq.ZMQ.Event.recv(socket, DONTWAIT), if they is no more event to receive,
it throws an NPE although the javadoc says it should return null. Fixed.

Also don’t resolve event value for ZMQ_EVENT_MONITOR_STOPPED, it’s a constant.