### PR TITLE
Many updates to metadata handling

### DIFF
--- a/src/main/java/org/zeromq/ZCert.java
+++ b/src/main/java/org/zeromq/ZCert.java
@@ -7,6 +7,7 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Map;
 
 import org.zeromq.ZMQ.Curve;
 import org.zeromq.ZMQ.Curve.KeyPair;
@@ -154,8 +155,8 @@ public class ZCert
     {
         String now = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.ENGLISH).format(new Date());
         config.addComment(String.format("** Generated on %1$s by ZCert **", now));
-        for (String key : meta.keySet()) {
-            config.putValue("metadata/" + key, meta.get(key));
+        for (Map.Entry<String, String> e : meta.entrySet()) {
+            config.putValue("metadata/" + e.getKey(), e.getValue());
         }
     }
 

--- a/src/main/java/org/zeromq/ZSocket.java
+++ b/src/main/java/org/zeromq/ZSocket.java
@@ -179,6 +179,20 @@ public class ZSocket implements AutoCloseable
         return -1;
     }
 
+    public int sendMessage(Msg msg, int flags)
+    {
+        if (socketBase.send(msg, flags)) {
+            return msg.size();
+        }
+        mayRaise();
+        return -1;
+    }
+
+    public int sendMessage(Msg msg)
+    {
+        return sendMessage(msg, 0);
+    }
+
     /**
      * Send a frame
      *
@@ -234,6 +248,16 @@ public class ZSocket implements AutoCloseable
             return null;
         }
         return msg.data();
+    }
+
+    public Msg receiveMessage()
+    {
+        return socketBase.recv(0);
+    }
+
+    public Msg receiveMessage(int flags)
+    {
+        return socketBase.recv(flags);
     }
 
     public String receiveStringUtf8()

--- a/src/main/java/org/zeromq/util/ZMetadata.java
+++ b/src/main/java/org/zeromq/util/ZMetadata.java
@@ -1,9 +1,13 @@
 package org.zeromq.util;
 
+import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
+import java.util.Collection;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
 import org.zeromq.ZConfig;
@@ -25,29 +29,157 @@ public class ZMetadata
         this.metadata = metadata;
     }
 
-    public final Set<String> keySet()
+    public Set<String> keySet()
     {
         return metadata.keySet();
     }
 
-    public final String get(String key)
+    public String get(String key)
     {
         return metadata.get(key);
     }
 
-    public final void set(String key, String value)
+    public void set(String key, String value)
     {
-        metadata.set(key, value);
+        metadata.put(key, value);
     }
 
-    public final void remove(String key)
+    public void remove(String key)
     {
         metadata.remove(key);
     }
 
-    public final byte[] bytes()
+    public byte[] bytes()
     {
         return metadata.bytes();
+    }
+
+    public String toString()
+    {
+        return metadata.toString();
+    }
+
+    public int hashCode()
+    {
+        return metadata.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ZMetadata zMetadata = (ZMetadata) o;
+        return Objects.equals(metadata, zMetadata.metadata);
+    }
+
+    /**
+     * Returns a {@link Set} view of the properties contained in this metadata.
+     * The set is backed by the metadata, so changes to the metadata are
+     * reflected in the set, and vice-versa.  If the metadata is modified
+     * while an iteration over the set is in progress (except through
+     * the iterator's own {@code remove} operation, or through the
+     * {@code setValue} operation on a metadata property returned by the
+     * iterator) the results of the iteration are undefined.  The set
+     * supports element removal, which removes the corresponding
+     * mapping from the metadata, via the {@code Iterator.remove},
+     * {@code Set.remove}, {@code removeAll}, {@code retainAll} and
+     * {@code clear} operations.  It does not support the
+     * {@code add} or {@code addAll} operations.
+     *
+     * @return a set view of the properties contained in this metadata
+     */
+    public Set<Entry<String, String>> entrySet()
+    {
+        return metadata.entrySet();
+    }
+
+    /**
+     * Returns a {@link Collection} view of the values contained in this metadata.
+     * The collection is backed by the metadata, so changes to the map are
+     * reflected in the collection, and vice-versa.  If the metadata is
+     * modified while an iteration over the collection is in progress
+     * (except through the iterator's own {@code remove} operation),
+     * the results of the iteration are undefined.  The collection
+     * supports element removal, which removes the corresponding
+     * property from the metadata, via the {@code Iterator.remove},
+     * {@code Collection.remove}, {@code removeAll},
+     * {@code retainAll} and {@code clear} operations.  It does not
+     * support the {@code add} or {@code addAll} operations.
+     *
+     * @return a collection view of the values contained in this map
+     */
+    public Collection<String> values()
+    {
+        return metadata.values();
+    }
+
+    public void set(Metadata zapProperties)
+    {
+        metadata.set(zapProperties);
+    }
+
+    /**
+     * Returns {@code true} if this map contains no key-value mappings.
+     *
+     * @return {@code true} if this map contains no key-value mappings
+     */
+    public boolean isEmpty()
+    {
+        return metadata.isEmpty();
+    }
+
+    /**
+     * Returns {@code true} if this metada contains the property requested
+     *
+     * @param property property the name of the property to be tested.
+     * @return {@code true} if this metada contains the property
+     */
+    public boolean containsKey(String property)
+    {
+        return metadata.containsKey(property);
+    }
+
+    /**
+     * Removes all the properties.
+     * The map will be empty after this call returns.
+     */
+    public void clear()
+    {
+        metadata.clear();
+    }
+
+    /**
+     * Returns the number of properties. If it contains more properties
+     * than {@code Integer.MAX_VALUE} elements, returns {@code Integer.MAX_VALUE}.
+     *
+     * @return the number of properties
+     */
+    public int size()
+    {
+        return metadata.size();
+    }
+
+    /**
+     * Serialize metadata to an output stream, using the specifications of the ZMTP protocol
+     * <pre>
+     * property = name value
+     * name = OCTET 1*255name-char
+     * name-char = ALPHA | DIGIT | "-" | "_" | "." | "+"
+     * value = 4OCTET *OCTET       ; Size in network byte order
+     * </pre>
+     *
+     * @param stream the output stream
+     * @throws IOException           if an I/O error occurs.
+     * @throws IllegalStateException if one of the properties name size is bigger than 255
+     */
+    public void write(OutputStream stream) throws IOException
+    {
+        metadata.write(stream);
     }
 
     public static ZMetadata read(String meta)
@@ -62,8 +194,7 @@ public class ZMetadata
             return new ZMetadata(data);
         }
         catch (CharacterCodingException e) {
-            e.printStackTrace();
-            return null;
+            throw new IllegalArgumentException("Not a parsable metadata string");
         }
     }
 
@@ -78,20 +209,5 @@ public class ZMetadata
             metadata.set(entry.getKey(), entry.getValue());
         }
         return metadata;
-    }
-
-    public String toString()
-    {
-        return metadata.toString();
-    }
-
-    public int hashCode()
-    {
-        return metadata.hashCode();
-    }
-
-    public boolean equals(Object obj)
-    {
-        return metadata.equals(obj);
     }
 }

--- a/src/main/java/zmq/io/StreamEngine.java
+++ b/src/main/java/zmq/io/StreamEngine.java
@@ -281,7 +281,7 @@ public class StreamEngine implements IEngine, IPollEvents
                 assert (metadata == null);
                 // Compile metadata
                 metadata = new Metadata();
-                metadata.set(Metadata.PEER_ADDRESS, peerAddress.address());
+                metadata.put(Metadata.PEER_ADDRESS, peerAddress.address());
             }
 
             if (options.selfAddressPropertyName != null && ! options.selfAddressPropertyName.isEmpty()
@@ -289,7 +289,7 @@ public class StreamEngine implements IEngine, IPollEvents
                 if (metadata == null) {
                     metadata = new Metadata();
                 }
-                metadata.set(options.selfAddressPropertyName, selfAddress.address());
+                metadata.put(options.selfAddressPropertyName, selfAddress.address());
             }
 
             //  For raw sockets, send an initial 0-length message to the
@@ -995,7 +995,7 @@ public class StreamEngine implements IEngine, IPollEvents
         //  If we have a local_address, add it to metadata
         if (options.selfAddressPropertyName != null && ! options.selfAddressPropertyName.isEmpty()
             && selfAddress != null && !selfAddress.address().isEmpty()) {
-            metadata.set(options.selfAddressPropertyName, selfAddress.address());
+            metadata.put(options.selfAddressPropertyName, selfAddress.address());
         }
         //  Add ZAP properties.
         metadata.set(mechanism.zapProperties);

--- a/src/main/java/zmq/io/mechanism/Mechanism.java
+++ b/src/main/java/zmq/io/mechanism/Mechanism.java
@@ -81,7 +81,7 @@ public abstract class Mechanism
     private void setUserId(byte[] data)
     {
         userId = Blob.createBlob(data);
-        zapProperties.set(Metadata.USER_ID, new String(data, ZMQ.CHARSET));
+        zapProperties.put(Metadata.USER_ID, new String(data, ZMQ.CHARSET));
     }
 
     public final Blob getUserId()

--- a/src/test/java/zmq/io/MetadataTest.java
+++ b/src/test/java/zmq/io/MetadataTest.java
@@ -8,6 +8,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import org.junit.Test;
@@ -152,9 +154,18 @@ public class MetadataTest
     @Test
     public void testWriteRead() throws IOException
     {
+        Map<String, String> srcMap = new HashMap<>();
+        srcMap.put("keyEmpty", "");
+        srcMap.put("keyNull", null);
+        Metadata fromMap = new Metadata(srcMap);
+        assertThat(fromMap.get("keyEmpty"), is(""));
+        assertThat(fromMap.get("keyNull"), is(""));
+
         Metadata src = new Metadata();
-        src.set("key", "value");
-        src.set(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        src.put("key", "value");
+        src.put("keyEmpty", "");
+        src.put("keyNull", null);
+        src.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
 
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         src.write(stream);
@@ -164,5 +175,7 @@ public class MetadataTest
         dst.read(ByteBuffer.wrap(array), 0, null);
 
         assertThat(dst, is(src));
+        assertThat(dst.get("keyEmpty"), is(""));
+        assertThat(dst.get("keyNull"), is(""));
     }
 }


### PR DESCRIPTION
org.zeromq.ZSocket and org.zeromq.ZMQ.Socket can now read and write zmq.Msg directly.

Updating Metada class to provide more data access and functions. ZMetadata is updated too.
It internally now uses ConcurrentHashMap instead of the old Properties class. The Properties class ignore null values, ConcurrentHashMap reject them but ZMTP protocol allows empty values. So null values are transformed to empty strings.

Metada#set is deprecated and replaced by Metada#put, to be more consistent with Map API.

Lots of hostile final method declaration removed.