### PR TITLE
Inversion of connect/bind with authentications fails.

### DIFF
--- a/src/main/java/zmq/io/mechanism/curve/CurveServerMechanism.java
+++ b/src/main/java/zmq/io/mechanism/curve/CurveServerMechanism.java
@@ -513,6 +513,9 @@ public class CurveServerMechanism extends Mechanism
         if (statusCode != null) {
             msg.putShortString(statusCode);
         }
+        else {
+            msg.putShortString("");
+        }
 
         return 0;
     }

--- a/src/test/java/zmq/io/mechanism/MechanismTester.java
+++ b/src/test/java/zmq/io/mechanism/MechanismTester.java
@@ -1,0 +1,163 @@
+package zmq.io.mechanism;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import zmq.Ctx;
+import zmq.Helper;
+import zmq.Msg;
+import zmq.Options;
+import zmq.SocketBase;
+import zmq.ZMQ;
+import zmq.util.TestUtils;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class MechanismTester
+{
+    abstract static class TestContext
+    {
+        Ctx zctxt;
+        SocketBase server;
+        SocketBase client;
+        SocketBase zapHandler;
+        String host = "tcp://127.0.0.1:*";
+    }
+
+    static <C extends TestContext> Boolean runTest(C testCtx, boolean withzap, Function<C, Boolean> tested,
+            BiFunction<SocketBase, CompletableFuture<Boolean>, ZapHandler> zapProvider,
+            Runnable configurator) throws InterruptedException
+    {
+        testCtx.zctxt = ZMQ.createContext();
+
+        // Future to hold the result of Zap handler processing
+        // true: zap allowed the connexion
+        // false: zap refused the connexion
+        // null: zap didn't do any processing
+        CompletableFuture<Boolean> zapFuture = new CompletableFuture<>();
+        Thread zapThread;
+
+        if (withzap) {
+            testCtx.zapHandler = ZMQ.socket(testCtx.zctxt, ZMQ.ZMQ_REP);
+            ZapHandler handler = zapProvider.apply(testCtx.zapHandler, zapFuture);
+            zapThread = handler.start();
+            if (zapFuture.isDone()) {
+                // zap future should not be already finished
+                try {
+                    assertThat(zapFuture.get().toString(), false);
+                }
+                catch (InterruptedException | ExecutionException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+        }
+        else {
+            zapFuture.complete(null);
+            zapThread = null;
+            testCtx.zapHandler = null;
+        }
+        testCtx.server = ZMQ.socket(testCtx.zctxt, ZMQ.ZMQ_DEALER);
+        assertThat(testCtx.server, notNullValue());
+
+        testCtx.client = ZMQ.socket(testCtx.zctxt, ZMQ.ZMQ_DEALER);
+        assertThat(testCtx.client, notNullValue());
+
+        configurator.run();
+
+        boolean isSuccess = tested.apply(testCtx);
+
+        // Exchange messages only if both sockets are used, some tests uses a plain socket
+        if (testCtx.server != null && testCtx.client != null) {
+            if (isSuccess) {
+                Helper.bounce(testCtx.server, testCtx.client);
+            }
+            else {
+                Helper.expectBounceFail(testCtx.server, testCtx.client);
+            }
+        }
+
+        Optional.ofNullable(testCtx.client).ifPresent(ZMQ::closeZeroLinger);
+        Optional.ofNullable(testCtx.server).ifPresent(ZMQ::closeZeroLinger);
+
+        //  Wait until ZAP handler terminates
+        //Optional.ofNullable(testCtx.zapHandler).ifPresent(ZMQ::closeZeroLinger);
+        Optional.ofNullable(zapThread).ifPresent(t -> {
+            try {
+                t.interrupt();
+                t.join(5000);
+            }
+            catch (InterruptedException e) {
+                throw new IllegalStateException(e);
+            }
+        });
+
+        //  Shutdown
+        ZMQ.term(testCtx.zctxt);
+
+        try {
+            return zapFuture.get(5, TimeUnit.SECONDS);
+        }
+        catch (InterruptedException | ExecutionException | TimeoutException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public static <T extends TestContext> boolean testRawSocket(T ctx)
+    {
+        try {
+            boolean rc;
+
+            int timeout = 250;
+            ZMQ.setSocketOption(ctx.server, ZMQ.ZMQ_RCVTIMEO, timeout);
+
+            rc = ZMQ.bind(ctx.server, ctx.host);
+            assertThat(rc, is(true));
+            int port = TestUtils.port((String) ZMQ.getSocketOptionExt(ctx.server, ZMQ.ZMQ_LAST_ENDPOINT));
+
+            ZMQ.closeZeroLinger(ctx.client);
+            ctx.client = null;
+
+            try (Socket sock = new Socket("127.0.0.1", port)) {
+                // send anonymous ZMTP/1.0 greeting
+                OutputStream out = sock.getOutputStream();
+                out.write(("1" + 0x00).getBytes(ZMQ.CHARSET));
+                // send sneaky message that shouldn't be received
+                out.write(
+                        ("8" + 0x00 + "sneaky" + 0x00)
+                                .getBytes(ZMQ.CHARSET));
+
+                Msg msg = ZMQ.recv(ctx.server, 0);
+                assertThat(msg, nullValue());
+
+            }
+            return false;
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void checkOptions(Mechanisms mechanism, Consumer<Options> setOptions)
+    {
+        Options opt = new Options();
+        setOptions.accept(opt);
+        mechanism.check(opt);
+    }
+
+    private MechanismTester()
+    {
+        // static only class
+    }
+}

--- a/src/test/java/zmq/io/mechanism/SecurityCurveTest.java
+++ b/src/test/java/zmq/io/mechanism/SecurityCurveTest.java
@@ -1,403 +1,315 @@
 package zmq.io.mechanism;
 
-import static org.hamcrest.CoreMatchers.equalTo;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.junit.Test;
+
+import zmq.SocketBase;
+import zmq.ZMQ;
+import zmq.io.mechanism.curve.Curve;
+
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.net.Socket;
-
-import org.junit.Before;
-import org.junit.Test;
-
-import zmq.Ctx;
-import zmq.Helper;
-import zmq.Msg;
-import zmq.Options;
-import zmq.SocketBase;
-import zmq.ZError;
-import zmq.ZMQ;
-import zmq.io.mechanism.curve.Curve;
-import zmq.util.TestUtils;
-import zmq.util.Utils;
-import zmq.util.Z85;
-
 public class SecurityCurveTest
 {
-    private static class ZapHandler implements Runnable
+    private static class CurveTestContext extends MechanismTester.TestContext
     {
-        private final SocketBase handler;
-        private final String     clientPublic;
-
-        public ZapHandler(SocketBase handler, String clientPublic)
-        {
-            this.handler = handler;
-            this.clientPublic = clientPublic;
-        }
-
-        @SuppressWarnings("unused")
-        @Override
-        public void run()
-        {
-            //  Process ZAP requests forever
-            while (true) {
-                Msg version = ZMQ.recv(handler, 0);
-                if (version == null) {
-                    break; //  Terminating
-                }
-                Msg sequence = ZMQ.recv(handler, 0);
-                Msg domain = ZMQ.recv(handler, 0);
-                Msg address = ZMQ.recv(handler, 0);
-                Msg identity = ZMQ.recv(handler, 0);
-                Msg mechanism = ZMQ.recv(handler, 0);
-                Msg clientKey = ZMQ.recv(handler, 0);
-
-                final String clientKeyText = Z85.encode(clientKey.data(), clientKey.size());
-
-                assertThat(new String(version.data(), ZMQ.CHARSET), is("1.0"));
-                assertThat(new String(mechanism.data(), ZMQ.CHARSET), is("CURVE"));
-                assertThat(new String(identity.data(), ZMQ.CHARSET), is("IDENT"));
-
-                int ret = ZMQ.send(handler, version, ZMQ.ZMQ_SNDMORE);
-                assertThat(ret, is(3));
-                ret = ZMQ.send(handler, sequence, ZMQ.ZMQ_SNDMORE);
-                assertThat(ret, is(1));
-
-                System.out.println("Sending ZAP CURVE reply");
-                if (clientKeyText.equals(clientPublic)) {
-                    ret = ZMQ.send(handler, "200", ZMQ.ZMQ_SNDMORE);
-                    assertThat(ret, is(3));
-                    ret = ZMQ.send(handler, "OK", ZMQ.ZMQ_SNDMORE);
-                    assertThat(ret, is(2));
-                    ret = ZMQ.send(handler, "anonymous", ZMQ.ZMQ_SNDMORE);
-                    assertThat(ret, is(9));
-                    ret = ZMQ.send(handler, "", 0);
-                    assertThat(ret, is(0));
-                }
-                else {
-                    ret = ZMQ.send(handler, "400", ZMQ.ZMQ_SNDMORE);
-                    assertThat(ret, is(3));
-                    ret = ZMQ.send(handler, "Invalid client public key", ZMQ.ZMQ_SNDMORE);
-                    assertThat(ret, is(25));
-                    ret = ZMQ.send(handler, "", ZMQ.ZMQ_SNDMORE);
-                    assertThat(ret, is(0));
-                    ret = ZMQ.send(handler, "", 0);
-                    assertThat(ret, is(0));
-                }
-            }
-            ZMQ.closeZeroLinger(handler);
-        }
+        String serverPublic;
+        String serverSecret;
+        String clientPublic;
+        String clientSecret;
     }
 
-    private String connectionString;
-
-    @Before
-    public void before() throws Exception
+    private Boolean runTest(boolean withzap, Function<CurveTestContext, Boolean> tested) throws InterruptedException
     {
-        int port = Utils.findOpenPort();
-        connectionString = "tcp://127.0.0.1:" + port;
-    }
-
-    @Test
-    public void testPlainCurveKeys() throws Exception
-    {
-        byte[][] serverKeyPair = new Curve().keypair();
-        byte[] serverPublicKey = serverKeyPair[0];
-        byte[] serverSecretKey = serverKeyPair[1];
-
-        byte[][] clientKeyPair = new Curve().keypair();
-        byte[] clientPublicKey = clientKeyPair[0];
-        byte[] clientSecretKey = clientKeyPair[1];
-
-        Ctx context = ZMQ.createContext();
-
-        SocketBase server = context.createSocket(ZMQ.ZMQ_DEALER);
-        ZMQ.setSocketOption(server, ZMQ.ZMQ_CURVE_SERVER, true);
-        ZMQ.setSocketOption(server, ZMQ.ZMQ_CURVE_SECRETKEY, serverSecretKey);
-        server.bind(connectionString);
-
-        SocketBase client = context.createSocket(ZMQ.ZMQ_DEALER);
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_CURVE_SERVERKEY, serverPublicKey);
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_CURVE_PUBLICKEY, clientPublicKey);
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_CURVE_SECRETKEY, clientSecretKey);
-        client.connect(connectionString);
-
-        byte[] testBytes = "hello-world".getBytes();
-
-        ZMQ.send(client, testBytes, 0);
-
-        byte[] recv = ZMQ.recv(server, 0).data();
-        assertThat(recv, is(equalTo(testBytes)));
-
-        server.close();
-        client.close();
-        context.terminate();
-    }
-
-    @Test
-    public void testCurveMechanismSecurity() throws IOException, InterruptedException
-    {
-        Curve cryptoBox = new Curve();
+        CurveTestContext testCtx = new CurveTestContext();
         //  Generate new keypairs for this test
-        //  We'll generate random test keys at startup
+        Curve cryptoBox = new Curve();
         String[] clientKeys = cryptoBox.keypairZ85();
-        String clientPublic = clientKeys[0];
-        String clientSecret = clientKeys[1];
+        testCtx.clientPublic = clientKeys[0];
+        testCtx.clientSecret = clientKeys[1];
 
         String[] serverKeys = cryptoBox.keypairZ85();
-        String serverPublic = serverKeys[0];
-        String serverSecret = serverKeys[1];
+        testCtx.serverPublic = serverKeys[0];
+        testCtx.serverSecret = serverKeys[1];
 
-        String host = "tcp://127.0.0.1:*";
+        BiFunction<SocketBase, CompletableFuture<Boolean>, ZapHandler> zapProvider = (s, f) -> new ZapHandler(s, f, testCtx.clientPublic);
+        Runnable configurator = () -> {
+            // Preconfigure server with valid identity, might be changed for individual tests
+            ZMQ.setSocketOption(testCtx.server, ZMQ.ZMQ_CURVE_SERVER, true);
+            ZMQ.setSocketOption(testCtx.server, ZMQ.ZMQ_CURVE_SECRETKEY, testCtx.serverSecret);
+            ZMQ.setSocketOption(testCtx.server, ZMQ.ZMQ_IDENTITY, "IDENT");
 
-        Ctx ctx = ZMQ.createContext();
+            // Preconfigure client with valid identity, might be changed for individual tests
+            ZMQ.setSocketOption(testCtx.client, ZMQ.ZMQ_CURVE_SERVERKEY, testCtx.serverPublic);
+            ZMQ.setSocketOption(testCtx.client, ZMQ.ZMQ_CURVE_PUBLICKEY, testCtx.clientPublic);
+            ZMQ.setSocketOption(testCtx.client, ZMQ.ZMQ_CURVE_SECRETKEY, testCtx.clientSecret);
+        };
 
-        //  Spawn ZAP handler
-        //  We create and bind ZAP socket in main thread to avoid case
-        //  where child thread does not start up fast enough.
-        SocketBase handler = ZMQ.socket(ctx, ZMQ.ZMQ_REP);
-        assertThat(handler, notNullValue());
-        boolean rc = ZMQ.bind(handler, "inproc://zeromq.zap.01");
+        return MechanismTester.runTest(testCtx, withzap, tested, zapProvider, configurator);
+    }
+
+    private boolean doSuccess(CurveTestContext ctx)
+    {
+        boolean rc;
+
+        rc = ZMQ.bind(ctx.server, ctx.host);
         assertThat(rc, is(true));
 
-        Thread thread = new Thread(new ZapHandler(handler, clientPublic));
-        thread.start();
-
-        //  Server socket will accept connections
-        SocketBase server = ZMQ.socket(ctx, ZMQ.ZMQ_DEALER);
-        assertThat(server, notNullValue());
-
-        ZMQ.setSocketOption(server, ZMQ.ZMQ_CURVE_SERVER, true);
-        ZMQ.setSocketOption(server, ZMQ.ZMQ_CURVE_SECRETKEY, serverSecret);
-        ZMQ.setSocketOption(server, ZMQ.ZMQ_IDENTITY, "IDENT");
-        rc = ZMQ.bind(server, host);
+        String host = (String) ZMQ.getSocketOptionExt(ctx.server, ZMQ.ZMQ_LAST_ENDPOINT);
+        rc = ZMQ.connect(ctx.client, host);
         assertThat(rc, is(true));
 
-        host = (String) ZMQ.getSocketOptionExt(server, ZMQ.ZMQ_LAST_ENDPOINT);
-        int port = TestUtils.port(host);
+        return true;
+    }
 
-        //  Check CURVE security with valid credentials
-        System.out.println("Test Correct CURVE security");
-        SocketBase client = ZMQ.socket(ctx, ZMQ.ZMQ_DEALER);
-        assertThat(client, notNullValue());
+    @Test
+    public void testSuccessWithZap() throws InterruptedException
+    {
+        assertThat(runTest(true, this::doSuccess), is(true));
+    }
 
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_CURVE_SERVERKEY, serverPublic);
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_CURVE_PUBLICKEY, clientPublic);
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_CURVE_SECRETKEY, clientSecret);
+    @Test
+    public void testSuccessNoZap() throws InterruptedException
+    {
+        assertThat(runTest(false, this::doSuccessInverted), nullValue());
+    }
 
-        rc = ZMQ.connect(client, host);
+    private boolean doSuccessInverted(CurveTestContext ctx)
+    {
+        boolean rc;
+
+        rc = ZMQ.bind(ctx.client, ctx.host);
         assertThat(rc, is(true));
 
-        Helper.bounce(server, client);
-        ZMQ.close(client);
+        String host = (String) ZMQ.getSocketOptionExt(ctx.client, ZMQ.ZMQ_LAST_ENDPOINT);
 
-        //  Check CURVE security with a garbage server key
-        //  This will be caught by the curve_server class, not passed to ZAP
-        System.out.println("Test bad server key CURVE security");
-        String garbageKey = "0000000000000000000000000000000000000000";
-        client = ZMQ.socket(ctx, ZMQ.ZMQ_DEALER);
-        assertThat(client, notNullValue());
-
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_CURVE_SERVERKEY, garbageKey);
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_CURVE_PUBLICKEY, clientPublic);
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_CURVE_SECRETKEY, clientSecret);
-
-        rc = ZMQ.connect(client, host);
+        rc = ZMQ.connect(ctx.server, host);
         assertThat(rc, is(true));
 
-        Helper.expectBounceFail(server, client);
-        ZMQ.closeZeroLinger(client);
+        return true;
+    }
 
-        //  Check CURVE security with a garbage client public key
-        //  This will be caught by the curve_server class, not passed to ZAP
-        System.out.println("Test bad client public key CURVE security");
-        client = ZMQ.socket(ctx, ZMQ.ZMQ_DEALER);
-        assertThat(client, notNullValue());
+    @Test
+    public void testSuccessInvertedWithZap() throws InterruptedException
+    {
+        assertThat(runTest(true, this::doSuccessInverted), is(true));
+    }
 
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_CURVE_SERVERKEY, serverPublic);
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_CURVE_PUBLICKEY, garbageKey);
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_CURVE_SECRETKEY, clientSecret);
+    @Test
+    public void testSuccessInvertedNoZap() throws InterruptedException
+    {
+        assertThat(runTest(false, this::doSuccessInverted), nullValue());
+    }
 
-        rc = ZMQ.connect(client, host);
-        assertThat(rc, is(true));
+    @Test
+    public void testGarbageClientSecretKeyZap() throws InterruptedException
+    {
+        Boolean zapCheck = runTest(true, ctx -> {
+            boolean rc;
+            rc = ZMQ.bind(ctx.server, ctx.host);
+            assertThat(rc, is(true));
 
-        Helper.expectBounceFail(server, client);
-        ZMQ.closeZeroLinger(client);
+            ZMQ.setSocketOption(ctx.client, ZMQ.ZMQ_CURVE_SECRETKEY, "0000000000000000000000000000000000000000");
+            String host = (String) ZMQ.getSocketOptionExt(ctx.server, ZMQ.ZMQ_LAST_ENDPOINT);
+            rc = ZMQ.connect(ctx.client, host);
 
-        //  Check CURVE security with a garbage client secret key
-        //  This will be caught by the curve_server class, not passed to ZAP
-        System.out.println("Test bad client public key CURVE security");
-        client = ZMQ.socket(ctx, ZMQ.ZMQ_DEALER);
-        assertThat(client, notNullValue());
+            assertThat(rc, is(true));
+            return false;
+        });
+        assertThat(zapCheck, nullValue());
+    }
 
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_CURVE_SERVERKEY, serverPublic);
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_CURVE_PUBLICKEY, clientPublic);
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_CURVE_SECRETKEY, garbageKey);
+    @Test
+    public void testGarbageServerSecretKeyZap() throws InterruptedException
+    {
+        Boolean zapCheck = runTest(true, ctx -> {
+            boolean rc;
 
-        rc = ZMQ.connect(client, host);
-        assertThat(rc, is(true));
+            ZMQ.setSocketOption(ctx.server, ZMQ.ZMQ_CURVE_SECRETKEY, "0000000000000000000000000000000000000000");
+            rc = ZMQ.bind(ctx.server, ctx.host);
+            assertThat(rc, is(true));
 
-        Helper.expectBounceFail(server, client);
-        ZMQ.closeZeroLinger(client);
+            String host = (String) ZMQ.getSocketOptionExt(ctx.server, ZMQ.ZMQ_LAST_ENDPOINT);
+            rc = ZMQ.connect(ctx.client, host);
+            assertThat(rc, is(true));
+            return false;
+        });
+        assertThat(zapCheck, nullValue());
+    }
 
+    @Test
+    public void testBogusClientKey() throws InterruptedException
+    {
         //  Check CURVE security with bogus client credentials
         //  This must be caught by the ZAP handler
-        String[] bogus = cryptoBox.keypairZ85();
-        String bogusPublic = bogus[0];
-        String bogusSecret = bogus[1];
+        Boolean zapCheck = runTest(true, ctx -> {
+            boolean rc;
 
-        System.out.println("Test bad client credentials CURVE security");
-        client = ZMQ.socket(ctx, ZMQ.ZMQ_DEALER);
-        assertThat(client, notNullValue());
+            rc = ZMQ.bind(ctx.server, ctx.host);
+            assertThat(rc, is(true));
 
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_CURVE_SERVERKEY, serverPublic);
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_CURVE_PUBLICKEY, bogusPublic);
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_CURVE_SECRETKEY, bogusSecret);
+            Curve cryptoBox = new Curve();
+            String[] bogus = cryptoBox.keypairZ85();
+            String bogusPublic = bogus[0];
+            String bogusSecret = bogus[1];
 
-        rc = ZMQ.connect(client, host);
-        assertThat(rc, is(true));
+            ZMQ.setSocketOption(ctx.client, ZMQ.ZMQ_CURVE_PUBLICKEY, bogusPublic);
+            ZMQ.setSocketOption(ctx.client, ZMQ.ZMQ_CURVE_SECRETKEY, bogusSecret);
+            String host = (String) ZMQ.getSocketOptionExt(ctx.server, ZMQ.ZMQ_LAST_ENDPOINT);
+            rc = ZMQ.connect(ctx.client, host);
+            assertThat(rc, is(true));
+            return false;
+        });
+        assertThat(zapCheck, is(false));
+    }
 
-        Helper.expectBounceFail(server, client);
-        ZMQ.closeZeroLinger(client);
+    @Test(timeout = 5000)
+    public void testBogusClientInvertedKey() throws InterruptedException
+    {
+        //  Check CURVE security with bogus client credentials
+        //  This must be caught by the ZAP handler
+        Boolean zapCheck = runTest(true, ctx -> {
+            boolean rc;
 
-        //  Check CURVE security with NULL client credentials
-        //  This must be caught by the curve_server class, not passed to ZAP
-        System.out.println("Test NULL client with CURVE security");
-        client = ZMQ.socket(ctx, ZMQ.ZMQ_DEALER);
-        assertThat(client, notNullValue());
+            rc = ZMQ.bind(ctx.client, ctx.host);
+            assertThat(rc, is(true));
 
-        rc = ZMQ.connect(client, host);
-        assertThat(rc, is(true));
+            Curve cryptoBox = new Curve();
+            String[] bogus = cryptoBox.keypairZ85();
+            String bogusPublic = bogus[0];
+            String bogusSecret = bogus[1];
 
-        Helper.expectBounceFail(server, client);
-        ZMQ.closeZeroLinger(client);
+            ZMQ.setSocketOption(ctx.client, ZMQ.ZMQ_CURVE_PUBLICKEY, bogusPublic);
+            ZMQ.setSocketOption(ctx.client, ZMQ.ZMQ_CURVE_SECRETKEY, bogusSecret);
+            String host = (String) ZMQ.getSocketOptionExt(ctx.client, ZMQ.ZMQ_LAST_ENDPOINT);
+            rc = ZMQ.connect(ctx.server, host);
+            assertThat(rc, is(true));
+            return false;
+        });
+        assertThat(zapCheck, is(false));
+    }
 
-        //  Check CURVE security with PLAIN client credentials
-        //  This must be caught by the curve_server class, not passed to ZAP
-        System.out.println("Test PLAIN client with CURVE security");
-        client = ZMQ.socket(ctx, ZMQ.ZMQ_DEALER);
-        assertThat(client, notNullValue());
+    @Test
+    public void testNullClient() throws InterruptedException
+    {
+        //  Check CURVE security with bogus client credentials
+        //  This must be caught by the ZAP handler
+        Boolean zapCheck = runTest(false, ctx -> {
+            boolean rc;
 
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_PLAIN_USERNAME, "user");
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_PLAIN_PASSWORD, "pass");
+            rc = ZMQ.bind(ctx.server, ctx.host);
+            assertThat(rc, is(true));
 
-        rc = ZMQ.connect(client, host);
-        assertThat(rc, is(true));
+            ZMQ.closeZeroLinger(ctx.client);
+            ctx.client = ZMQ.socket(ctx.zctxt, ZMQ.ZMQ_DEALER);
 
-        Helper.expectBounceFail(server, client);
-        ZMQ.closeZeroLinger(client);
+            String host = (String) ZMQ.getSocketOptionExt(ctx.server, ZMQ.ZMQ_LAST_ENDPOINT);
+            rc = ZMQ.connect(ctx.client, host);
+            assertThat(rc, is(true));
+            return false;
+        });
+        assertThat(zapCheck, nullValue());
+    }
 
+    @Test
+    public void testPlainClient() throws InterruptedException
+    {
+        //  Check CURVE security with bogus client credentials
+        //  This must be caught by the ZAP handler
+        Boolean zapCheck = runTest(false, ctx -> {
+            boolean rc;
+
+            rc = ZMQ.bind(ctx.server, ctx.host);
+            assertThat(rc, is(true));
+
+            ZMQ.closeZeroLinger(ctx.client);
+            ctx.client = ZMQ.socket(ctx.zctxt, ZMQ.ZMQ_DEALER);
+            ZMQ.setSocketOption(ctx.client, ZMQ.ZMQ_PLAIN_USERNAME, "user");
+            ZMQ.setSocketOption(ctx.client, ZMQ.ZMQ_PLAIN_PASSWORD, "pass");
+
+            String host = (String) ZMQ.getSocketOptionExt(ctx.server, ZMQ.ZMQ_LAST_ENDPOINT);
+            rc = ZMQ.connect(ctx.client, host);
+            assertThat(rc, is(true));
+            return false;
+        });
+        assertThat(zapCheck, nullValue());
+    }
+
+    @Test
+    public void testRawSocket() throws InterruptedException
+    {
         // Unauthenticated messages from a vanilla socket shouldn't be received
-        System.out.println("Test unauthenticated from vanilla socket CURVE security");
-
-        Socket sock = new Socket("127.0.0.1", port);
-        // send anonymous ZMTP/1.0 greeting
-        OutputStream out = sock.getOutputStream();
-        out.write(new StringBuilder().append(0x01).append(0x00).toString().getBytes(ZMQ.CHARSET));
-        // send sneaky message that shouldn't be received
-        out.write(
-                  new StringBuilder().append(0x08).append(0x00).append("sneaky").append(0x00).toString()
-                          .getBytes(ZMQ.CHARSET));
-        int timeout = 250;
-        ZMQ.setSocketOption(server, ZMQ.ZMQ_RCVTIMEO, timeout);
-
-        Msg msg = ZMQ.recv(server, 0);
-        assertThat(msg, nullValue());
-
-        sock.close();
-
-        //  Check return codes for invalid buffer sizes
-        // TODO
-        System.out.println("Test return codes for invalid buffer sizes with CURVE security");
-        client = ZMQ.socket(ctx, ZMQ.ZMQ_DEALER);
-        assertThat(client, notNullValue());
-
-        rc = ZMQ.setSocketOption(client, ZMQ.ZMQ_CURVE_SERVERKEY, new byte[123]);
-        assertThat(rc, is(false));
-        assertThat(client.errno.get(), is(ZError.EINVAL));
-
-        rc = ZMQ.setSocketOption(client, ZMQ.ZMQ_CURVE_PUBLICKEY, new byte[123]);
-        assertThat(rc, is(false));
-        assertThat(client.errno.get(), is(ZError.EINVAL));
-
-        rc = ZMQ.setSocketOption(client, ZMQ.ZMQ_CURVE_SECRETKEY, new byte[123]);
-        assertThat(rc, is(false));
-        assertThat(client.errno.get(), is(ZError.EINVAL));
-
-        ZMQ.closeZeroLinger(client);
-        ZMQ.closeZeroLinger(server);
-
-        //  Shutdown
-        ZMQ.term(ctx);
-        //  Wait until ZAP handler terminates
-        thread.join();
+        Boolean zapCheck = runTest(false, MechanismTester::testRawSocket);
+        assertThat(zapCheck, nullValue());
     }
 
     @Test(expected = IllegalStateException.class)
     public void inconsistent1()
     {
-        Options opt = new Options();
-        opt.setSocketOpt(ZMQ.ZMQ_CURVE_PUBLICKEY, new byte[32]);
-        opt.setSocketOpt(ZMQ.ZMQ_CURVE_SECRETKEY, null);
-        Mechanisms.CURVE.check(opt);
+        MechanismTester.checkOptions(Mechanisms.CURVE, opt -> {
+            opt.setSocketOpt(ZMQ.ZMQ_CURVE_PUBLICKEY, new byte[32]);
+            opt.setSocketOpt(ZMQ.ZMQ_CURVE_SECRETKEY, null);
+        });
     }
 
     @Test(expected = IllegalStateException.class)
     public void inconsistent2()
     {
-        Options opt = new Options();
-        opt.setSocketOpt(ZMQ.ZMQ_CURVE_PUBLICKEY, null);
-        opt.setSocketOpt(ZMQ.ZMQ_CURVE_SECRETKEY, new byte[32]);
-        Mechanisms.CURVE.check(opt);
+        MechanismTester.checkOptions(Mechanisms.CURVE, opt -> {
+            opt.setSocketOpt(ZMQ.ZMQ_CURVE_PUBLICKEY, null);
+            opt.setSocketOpt(ZMQ.ZMQ_CURVE_SECRETKEY, new byte[32]);
+        });
     }
 
     @Test(expected = IllegalStateException.class)
     public void inconsistent3()
     {
-        Options opt = new Options();
-        opt.setSocketOpt(ZMQ.ZMQ_CURVE_PUBLICKEY, new byte[32]);
-        opt.setSocketOpt(ZMQ.ZMQ_CURVE_SECRETKEY, new byte[31]);
-        Mechanisms.CURVE.check(opt);
+        MechanismTester.checkOptions(Mechanisms.CURVE, opt -> {
+            opt.setSocketOpt(ZMQ.ZMQ_CURVE_PUBLICKEY, new byte[32]);
+            opt.setSocketOpt(ZMQ.ZMQ_CURVE_SECRETKEY, new byte[31]);
+        });
     }
 
     @Test(expected = IllegalStateException.class)
     public void inconsistent4()
     {
-        Options opt = new Options();
-        opt.setSocketOpt(ZMQ.ZMQ_CURVE_PUBLICKEY, new byte[31]);
-        opt.setSocketOpt(ZMQ.ZMQ_CURVE_SECRETKEY, new byte[32]);
-        Mechanisms.CURVE.check(opt);
+        MechanismTester.checkOptions(Mechanisms.CURVE, opt -> {
+            opt.setSocketOpt(ZMQ.ZMQ_CURVE_PUBLICKEY, new byte[31]);
+            opt.setSocketOpt(ZMQ.ZMQ_CURVE_SECRETKEY, new byte[32]);
+        });
     }
 
     @Test(expected = IllegalStateException.class)
     public void inconsistent5()
     {
-        Options opt = new Options();
-        opt.setSocketOpt(ZMQ.ZMQ_CURVE_PUBLICKEY, new byte[32]);
-        opt.setSocketOpt(ZMQ.ZMQ_CURVE_SECRETKEY, new byte[32]);
-        opt.setSocketOpt(ZMQ.ZMQ_CURVE_SERVERKEY, new byte[31]);
-        Mechanisms.CURVE.check(opt);
+        MechanismTester.checkOptions(Mechanisms.CURVE, opt -> {
+            opt.setSocketOpt(ZMQ.ZMQ_CURVE_PUBLICKEY, new byte[32]);
+            opt.setSocketOpt(ZMQ.ZMQ_CURVE_SECRETKEY, new byte[32]);
+            opt.setSocketOpt(ZMQ.ZMQ_CURVE_SERVERKEY, new byte[31]);
+        });
     }
 
     @Test
     public void consistent1()
     {
-        Options opt = new Options();
-        opt.setSocketOpt(ZMQ.ZMQ_CURVE_PUBLICKEY, new byte[32]);
-        opt.setSocketOpt(ZMQ.ZMQ_CURVE_SECRETKEY, new byte[32]);
-        Mechanisms.CURVE.check(opt);
+        MechanismTester.checkOptions(Mechanisms.CURVE, opt -> {
+            opt.setSocketOpt(ZMQ.ZMQ_CURVE_PUBLICKEY, new byte[32]);
+            opt.setSocketOpt(ZMQ.ZMQ_CURVE_SECRETKEY, new byte[32]);
+        });
     }
 
     @Test
     public void consistent2()
     {
-        Options opt = new Options();
-        opt.setSocketOpt(ZMQ.ZMQ_CURVE_PUBLICKEY, new byte[32]);
-        opt.setSocketOpt(ZMQ.ZMQ_CURVE_SECRETKEY, new byte[32]);
-        opt.setSocketOpt(ZMQ.ZMQ_CURVE_SERVERKEY, new byte[32]);
-        Mechanisms.CURVE.check(opt);
+        MechanismTester.checkOptions(Mechanisms.CURVE, opt -> {
+            opt.setSocketOpt(ZMQ.ZMQ_CURVE_PUBLICKEY, new byte[32]);
+            opt.setSocketOpt(ZMQ.ZMQ_CURVE_SECRETKEY, new byte[32]);
+            opt.setSocketOpt(ZMQ.ZMQ_CURVE_SERVERKEY, new byte[32]);
+        });
     }
 }

--- a/src/test/java/zmq/io/mechanism/SecurityPlainTest.java
+++ b/src/test/java/zmq/io/mechanism/SecurityPlainTest.java
@@ -1,229 +1,208 @@
 package zmq.io.mechanism;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import java.io.IOException;
-import java.io.OutputStream;
-import java.net.Socket;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import org.junit.Test;
 
-import zmq.Ctx;
-import zmq.Helper;
-import zmq.Msg;
-import zmq.Options;
 import zmq.SocketBase;
 import zmq.ZMQ;
-import zmq.util.Utils;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SecurityPlainTest
 {
-    private static class ZapHandler implements Runnable
+    private static class PlainTestContext extends MechanismTester.TestContext
     {
-        private final SocketBase handler;
+        String user;
+        String password;
+    }
 
-        public ZapHandler(SocketBase handler)
-        {
-            this.handler = handler;
-        }
+    private Boolean runTest(boolean withzap, Function<PlainTestContext, Boolean> tested) throws InterruptedException
+    {
+        PlainTestContext testCtx = new PlainTestContext();
+        testCtx.user = "admin";
+        testCtx.password = "password";
 
-        @SuppressWarnings("unused")
-        @Override
-        public void run()
-        {
-            //  Process ZAP requests forever
-            while (true) {
-                Msg version = ZMQ.recv(handler, 0);
-                if (version == null) {
-                    break; //  Terminating
-                }
-                Msg sequence = ZMQ.recv(handler, 0);
-                Msg domain = ZMQ.recv(handler, 0);
-                Msg address = ZMQ.recv(handler, 0);
-                Msg identity = ZMQ.recv(handler, 0);
-                Msg mechanism = ZMQ.recv(handler, 0);
-                Msg username = ZMQ.recv(handler, 0);
-                Msg password = ZMQ.recv(handler, 0);
+        BiFunction<SocketBase, CompletableFuture<Boolean>, ZapHandler> zapProvider = (s, f) -> new ZapHandler(s, f, "admin", "password");
+        Runnable configurator = () -> {
+            ZMQ.setSocketOption(testCtx.server, ZMQ.ZMQ_IDENTITY, "IDENT");
+            ZMQ.setSocketOption(testCtx.server, ZMQ.ZMQ_PLAIN_SERVER, true);
+        };
 
-                assertThat(new String(version.data(), ZMQ.CHARSET), is("1.0"));
-                assertThat(new String(mechanism.data(), ZMQ.CHARSET), is("PLAIN"));
-                assertThat(new String(identity.data(), ZMQ.CHARSET), is("IDENT"));
+        return MechanismTester.runTest(testCtx, withzap, tested, zapProvider, configurator);
+    }
 
-                int ret = ZMQ.send(handler, version, ZMQ.ZMQ_SNDMORE);
-                assertThat(ret, is(3));
-                ret = ZMQ.send(handler, sequence, ZMQ.ZMQ_SNDMORE);
-                assertThat(ret, is(1));
+    public boolean runValid(PlainTestContext tctxt)
+    {
+        boolean rc;
 
-                System.out.println("Sending ZAP PLAIN reply");
-                if ("admin".equals(new String(username.data(), ZMQ.CHARSET))
-                        && "password".equals(new String(password.data(), ZMQ.CHARSET))) {
-                    ret = ZMQ.send(handler, "200", ZMQ.ZMQ_SNDMORE);
-                    assertThat(ret, is(3));
-                    ret = ZMQ.send(handler, "OK", ZMQ.ZMQ_SNDMORE);
-                    assertThat(ret, is(2));
-                    ret = ZMQ.send(handler, "anonymous", ZMQ.ZMQ_SNDMORE);
-                    assertThat(ret, is(9));
-                    ret = ZMQ.send(handler, "", 0);
-                    assertThat(ret, is(0));
-                }
-                else {
-                    ret = ZMQ.send(handler, "400", ZMQ.ZMQ_SNDMORE);
-                    assertThat(ret, is(3));
-                    ret = ZMQ.send(handler, "Invalid username or password", ZMQ.ZMQ_SNDMORE);
-                    assertThat(ret, is(28));
-                    ret = ZMQ.send(handler, "", ZMQ.ZMQ_SNDMORE);
-                    assertThat(ret, is(0));
-                    ret = ZMQ.send(handler, "", 0);
-                    assertThat(ret, is(0));
-                }
-            }
-            ZMQ.closeZeroLinger(handler);
-        }
+        rc = ZMQ.bind(tctxt.server, tctxt.host);
+        assertThat(rc, is(true));
+
+        String host = (String) ZMQ.getSocketOptionExt(tctxt.server, ZMQ.ZMQ_LAST_ENDPOINT);
+        ZMQ.setSocketOption(tctxt.client, ZMQ.ZMQ_PLAIN_USERNAME, tctxt.user);
+        ZMQ.setSocketOption(tctxt.client, ZMQ.ZMQ_PLAIN_PASSWORD, tctxt.password);
+
+        rc = ZMQ.connect(tctxt.client, host);
+        assertThat(rc, is(true));
+        return true;
+    }
+
+    @Test(timeout = 5000)
+    public void testNoZap() throws InterruptedException
+    {
+        //  We first test client/server with no ZAP domain
+        Boolean status = runTest(false, this::runValid);
+        assertThat(status, nullValue());
+    }
+
+    @Test(timeout = 5000)
+    public void testZap() throws InterruptedException
+    {
+        //  We first test client/server with no ZAP domain
+        Boolean status = runTest(true, this::runValid);
+        assertThat(status, is(true));
+    }
+
+    @Test(timeout = 5000)
+    public void testZapInverted() throws InterruptedException
+    {
+        //  When ZAP is not used, always accept
+        Boolean status = runTest(false, tctxt -> {
+            boolean rc;
+
+            ZMQ.setSocketOption(tctxt.client, ZMQ.ZMQ_PLAIN_USERNAME, tctxt.user);
+            ZMQ.setSocketOption(tctxt.client, ZMQ.ZMQ_PLAIN_PASSWORD, tctxt.password);
+
+            rc = ZMQ.bind(tctxt.client, tctxt.host);
+            assertThat(rc, is(true));
+
+            String host = (String) ZMQ.getSocketOptionExt(tctxt.client, ZMQ.ZMQ_LAST_ENDPOINT);
+
+            rc = ZMQ.connect(tctxt.server, host);
+            assertThat(rc, is(true));
+
+            return true;
+        });
+        assertThat(status, nullValue());
+    }
+
+    @Test(timeout = 5000)
+    public void testBothServer() throws InterruptedException
+    {
+        //  We first test client/server with no ZAP domain
+        Boolean status = runTest(true, tctxt -> {
+            boolean rc;
+
+            rc = ZMQ.bind(tctxt.server, tctxt.host);
+            assertThat(rc, is(true));
+
+            String host = (String) ZMQ.getSocketOptionExt(tctxt.server, ZMQ.ZMQ_LAST_ENDPOINT);
+            ZMQ.setSocketOption(tctxt.client, ZMQ.ZMQ_PLAIN_SERVER, true);
+
+            rc = ZMQ.connect(tctxt.client, host);
+            assertThat(rc, is(true));
+            return false;
+        });
+        assertThat(status, nullValue());
+    }
+
+    @Test(timeout = 5000)
+    public void testFailedLoginZap() throws InterruptedException
+    {
+        //  We first test client/server with no ZAP domain
+        Boolean status = runTest(true, tctxt -> {
+            boolean rc;
+
+            rc = ZMQ.bind(tctxt.server, tctxt.host);
+            assertThat(rc, is(true));
+
+            String host = (String) ZMQ.getSocketOptionExt(tctxt.server, ZMQ.ZMQ_LAST_ENDPOINT);
+            ZMQ.setSocketOption(tctxt.client, ZMQ.ZMQ_PLAIN_USERNAME, "wronguser");
+            ZMQ.setSocketOption(tctxt.client, ZMQ.ZMQ_PLAIN_PASSWORD, "wrongpass");
+
+            rc = ZMQ.connect(tctxt.client, host);
+            assertThat(rc, is(true));
+            return false;
+        });
+        assertThat(status, is(false));
+    }
+
+    @Test(timeout = 5000)
+    public void testSuccessBadPasswordNoZap() throws InterruptedException
+    {
+        //  When ZAP is not used, always accept
+        Boolean status = runTest(false, tctxt -> {
+            boolean rc;
+
+            rc = ZMQ.bind(tctxt.server, tctxt.host);
+            assertThat(rc, is(true));
+
+            String host = (String) ZMQ.getSocketOptionExt(tctxt.server, ZMQ.ZMQ_LAST_ENDPOINT);
+            ZMQ.setSocketOption(tctxt.client, ZMQ.ZMQ_PLAIN_USERNAME, "wronguser");
+            ZMQ.setSocketOption(tctxt.client, ZMQ.ZMQ_PLAIN_PASSWORD, "wrongpass");
+
+            rc = ZMQ.connect(tctxt.client, host);
+            assertThat(rc, is(true));
+            return true;
+        });
+        assertThat(status, nullValue());
     }
 
     @Test
-    public void testPlainMechanismSecurity() throws IOException, InterruptedException
+    public void testRawSocket() throws InterruptedException
     {
-        int port = Utils.findOpenPort();
-        String host = "tcp://127.0.0.1:" + port;
-
-        Ctx ctx = ZMQ.createContext();
-
-        //  Spawn ZAP handler
-        //  We create and bind ZAP socket in main thread to avoid case
-        //  where child thread does not start up fast enough.
-        SocketBase handler = ZMQ.socket(ctx, ZMQ.ZMQ_REP);
-        assertThat(handler, notNullValue());
-        boolean rc = ZMQ.bind(handler, "inproc://zeromq.zap.01");
-        assertThat(rc, is(true));
-
-        Thread thread = new Thread(new ZapHandler(handler));
-        thread.start();
-
-        //  Server socket will accept connections
-        SocketBase server = ZMQ.socket(ctx, ZMQ.ZMQ_DEALER);
-        assertThat(server, notNullValue());
-
-        ZMQ.setSocketOption(server, ZMQ.ZMQ_IDENTITY, "IDENT");
-        ZMQ.setSocketOption(server, ZMQ.ZMQ_PLAIN_SERVER, true);
-        rc = ZMQ.bind(server, host);
-        assertThat(rc, is(true));
-
-        String username = "admin";
-        String password = "password";
-        //  Check PLAIN security with correct username/password
-        System.out.println("Test Correct PLAIN security");
-        SocketBase client = ZMQ.socket(ctx, ZMQ.ZMQ_DEALER);
-        assertThat(client, notNullValue());
-
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_PLAIN_USERNAME, username);
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_PLAIN_PASSWORD, password);
-
-        rc = ZMQ.connect(client, host);
-        assertThat(rc, is(true));
-
-        Helper.bounce(server, client);
-        ZMQ.close(client);
-
-        //  Check PLAIN security with badly configured client (as_server)
-        //  This will be caught by the plain_server class, not passed to ZAP
-        System.out.println("Test badly configured PLAIN security");
-        client = ZMQ.socket(ctx, ZMQ.ZMQ_DEALER);
-        assertThat(client, notNullValue());
-
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_PLAIN_SERVER, true);
-
-        rc = ZMQ.connect(client, host);
-        assertThat(rc, is(true));
-
-        Helper.expectBounceFail(server, client);
-        ZMQ.closeZeroLinger(client);
-
-        //  Check PLAIN security -- failed authentication
-        System.out.println("Test wrong authentication PLAIN security");
-        client = ZMQ.socket(ctx, ZMQ.ZMQ_DEALER);
-        assertThat(client, notNullValue());
-
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_PLAIN_USERNAME, "wronguser");
-        ZMQ.setSocketOption(client, ZMQ.ZMQ_PLAIN_PASSWORD, "wrongpass");
-
-        rc = ZMQ.connect(client, host);
-        assertThat(rc, is(true));
-
-        Helper.expectBounceFail(server, client);
-        ZMQ.closeZeroLinger(client);
-
         // Unauthenticated messages from a vanilla socket shouldn't be received
-        System.out.println("Test unauthenticated from vanilla socket PLAIN security");
-
-        Socket sock = new Socket("127.0.0.1", port);
-        // send anonymous ZMTP/1.0 greeting
-        OutputStream out = sock.getOutputStream();
-        out.write(new StringBuilder().append(0x01).append(0x00).toString().getBytes(ZMQ.CHARSET));
-        // send sneaky message that shouldn't be received
-        out.write(
-                  new StringBuilder().append(0x08).append(0x00).append("sneaky").append(0x00).toString()
-                          .getBytes(ZMQ.CHARSET));
-        int timeout = 250;
-        ZMQ.setSocketOption(server, ZMQ.ZMQ_RCVTIMEO, timeout);
-
-        Msg msg = ZMQ.recv(server, 0);
-        assertThat(msg, nullValue());
-
-        sock.close();
-        ZMQ.closeZeroLinger(server);
-
-        //  Shutdown
-        ZMQ.term(ctx);
-        //  Wait until ZAP handler terminates
-        thread.join();
+        Boolean zapCheck = runTest(false, MechanismTester::testRawSocket);
+        assertThat(zapCheck, nullValue());
     }
 
     @Test(expected = IllegalStateException.class)
     public void inconsistent1()
     {
-        Options opt = new Options();
-        opt.setSocketOpt(ZMQ.ZMQ_PLAIN_USERNAME, null);
-        opt.setSocketOpt(ZMQ.ZMQ_PLAIN_PASSWORD, "plainPassword");
-        Mechanisms.PLAIN.check(opt);
+        MechanismTester.checkOptions(Mechanisms.PLAIN, opt -> {
+            opt.setSocketOpt(ZMQ.ZMQ_PLAIN_USERNAME, null);
+            opt.setSocketOpt(ZMQ.ZMQ_PLAIN_PASSWORD, "plainPassword");
+        });
     }
 
     @Test(expected = IllegalStateException.class)
     public void inconsistent2()
     {
-        Options opt = new Options();
-        opt.setSocketOpt(ZMQ.ZMQ_PLAIN_PASSWORD, null);
-        opt.setSocketOpt(ZMQ.ZMQ_PLAIN_USERNAME, "plainUsername");
-        Mechanisms.PLAIN.check(opt);
+        MechanismTester.checkOptions(Mechanisms.PLAIN, opt -> {
+            opt.setSocketOpt(ZMQ.ZMQ_PLAIN_USERNAME, "plainUsername");
+            opt.setSocketOpt(ZMQ.ZMQ_PLAIN_PASSWORD, null);
+        });
     }
 
     @Test(expected = IllegalStateException.class)
     public void inconsistent3()
     {
-        Options opt = new Options();
-        opt.setSocketOpt(ZMQ.ZMQ_PLAIN_USERNAME, String.format("%256d", 1));
-        opt.setSocketOpt(ZMQ.ZMQ_PLAIN_PASSWORD, "plainPassword");
-        Mechanisms.PLAIN.check(opt);
+        MechanismTester.checkOptions(Mechanisms.PLAIN, opt -> {
+            opt.setSocketOpt(ZMQ.ZMQ_PLAIN_USERNAME, String.format("%256d", 1));
+            opt.setSocketOpt(ZMQ.ZMQ_PLAIN_PASSWORD, "plainPassword");
+        });
     }
 
     @Test(expected = IllegalStateException.class)
     public void inconsistent4()
     {
-        Options opt = new Options();
-        opt.setSocketOpt(ZMQ.ZMQ_PLAIN_USERNAME, "plainUsername");
-        opt.setSocketOpt(ZMQ.ZMQ_PLAIN_PASSWORD, String.format("%256d", 1));
-        Mechanisms.PLAIN.check(opt);
+        MechanismTester.checkOptions(Mechanisms.PLAIN, opt -> {
+            opt.setSocketOpt(ZMQ.ZMQ_PLAIN_USERNAME, "plainUsername");
+            opt.setSocketOpt(ZMQ.ZMQ_PLAIN_PASSWORD, String.format("%256d", 1));
+        });
     }
 
     @Test
     public void consistent()
     {
-        Options opt = new Options();
-        opt.setSocketOpt(ZMQ.ZMQ_PLAIN_USERNAME, "plainUsername");
-        opt.setSocketOpt(ZMQ.ZMQ_PLAIN_PASSWORD, "plainPassword");
-        Mechanisms.PLAIN.check(opt);
+        MechanismTester.checkOptions(Mechanisms.PLAIN, opt -> {
+            opt.setSocketOpt(ZMQ.ZMQ_PLAIN_USERNAME, "plainUsername");
+            opt.setSocketOpt(ZMQ.ZMQ_PLAIN_PASSWORD, "plainPassword");
+        });
     }
 }

--- a/src/test/java/zmq/io/mechanism/ZapHandler.java
+++ b/src/test/java/zmq/io/mechanism/ZapHandler.java
@@ -1,0 +1,190 @@
+package zmq.io.mechanism;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import zmq.Msg;
+import zmq.SocketBase;
+import zmq.ZMQ;
+import zmq.util.Z85;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ZapHandler implements Runnable
+{
+    private final SocketBase handler;
+    private final String     mechanism;
+    private final String     clientPublic;
+    private final String     username;
+    private final String     password;
+    private final CompletableFuture<Boolean> zapFuture;
+
+    public ZapHandler(SocketBase handler, CompletableFuture<Boolean> zapFuture, String clientPublic)
+    {
+        this.handler = handler;
+        this.clientPublic = clientPublic;
+        this.zapFuture = zapFuture;
+        this.username = null;
+        this.password = null;
+        this.mechanism = "CURVE";
+    }
+
+    public ZapHandler(SocketBase handler, CompletableFuture<Boolean> zapFuture, String username, String password)
+    {
+        this.handler = handler;
+        this.clientPublic = null;
+        this.zapFuture = zapFuture;
+        this.username = username;
+        this.password = password;
+        this.mechanism = "PLAIN";
+    }
+
+    public ZapHandler(SocketBase handler, CompletableFuture<Boolean> zapFuture)
+    {
+        this.handler = handler;
+        this.clientPublic = null;
+        this.zapFuture = zapFuture;
+        this.username = null;
+        this.password = null;
+        this.mechanism = "NULL";
+    }
+
+    public Thread start() throws InterruptedException
+    {
+        CountDownLatch zapStarted = new CountDownLatch(1);
+        //  Spawn ZAP handler
+        Thread zapThread = new Thread(() -> {
+            try {
+                assertThat(handler, notNullValue());
+                boolean rc = ZMQ.bind(handler, "inproc://zeromq.zap.01");
+                assertThat(rc, is(true));
+            }
+            catch (Exception | AssertionError ex) {
+                ex.printStackTrace();
+                zapFuture.completeExceptionally(ex);
+            }
+            finally {
+                zapStarted.countDown();
+            }
+            run();
+        });
+        zapThread.setUncaughtExceptionHandler((t, e) -> {
+            e.printStackTrace();
+            zapFuture.completeExceptionally(e);
+        });
+        zapThread.setName("ZAPHANDLER");
+        zapThread.start();
+        assertThat(zapStarted.await(5, TimeUnit.SECONDS), is(true));
+        return zapThread;
+    }
+
+    @Override
+    public void run()
+    {
+        //  Process ZAP requests forever
+        try {
+            while (true) {
+                Msg version = ZMQ.recv(handler, 0);
+                if (version != null) {
+                    assertThat("No more message", version.hasMore());
+                    assertThat(new String(version.data(), ZMQ.CHARSET), is("1.0"));
+                    Msg sequence = ZMQ.recv(handler, 0);
+                    assertThat("No more message", sequence.hasMore());
+                    Msg domain = ZMQ.recv(handler, 0);
+                    assertThat("No more message", domain.hasMore());
+                    String clientDomain = new String(domain.data(), ZMQ.CHARSET);
+                    Msg address = ZMQ.recv(handler, 0);
+                    assertThat("No more message", address.hasMore());
+                    Msg identity = ZMQ.recv(handler, 0);
+                    assertThat("No more message", identity.hasMore());
+                    assertThat(new String(identity.data(), ZMQ.CHARSET), is("IDENT"));
+                    Msg mechanismMsg = ZMQ.recv(handler, 0);
+                    assertThat("No more message",  "NULL".equals(mechanism) || mechanismMsg.hasMore());
+                    String clientMechanism = new String(mechanismMsg.data(), ZMQ.CHARSET);
+                    assertThat(clientMechanism, is(mechanism));
+
+                    String clientKeyText = null;
+                    String clientUsername = null;
+                    String clientPassword = null;
+                    if ("CURVE".equals(mechanism)) {
+                        Msg clientKey = ZMQ.recv(handler, 0);
+                        assertThat("More message", ! clientKey.hasMore());
+                        clientKeyText = Z85.encode(clientKey.data(), clientKey.size());
+                    }
+                    else if ("PLAIN".equals(mechanism)) {
+                        Msg username = ZMQ.recv(handler, 0);
+                        assertThat("No more message", username.hasMore());
+                        Msg password = ZMQ.recv(handler, 0);
+                        assertThat("No more message", ! password.hasMore());
+                        clientUsername = new String(username.data(), ZMQ.CHARSET);
+                        clientPassword = new String(password.data(), ZMQ.CHARSET);
+                    }
+
+                    int ret = ZMQ.send(handler, version, ZMQ.ZMQ_SNDMORE);
+                    assertThat(ret, is(3));
+                    ret = ZMQ.send(handler, sequence, ZMQ.ZMQ_SNDMORE);
+                    assertThat(ret, is(1));
+
+                    boolean authentified;
+                    String errorMessage;
+                    String userId;
+                    if ("CURVE".equals(mechanism)) {
+                        authentified = clientKeyText.equals(clientPublic);
+                        errorMessage = "Invalid client public key";
+                        userId = clientPublic;
+                    }
+                    else if ("PLAIN".equals(mechanism)) {
+                        authentified = username.equals(clientUsername) && password.equals(clientPassword);
+                        errorMessage = "Invalid username or password";
+                        userId = clientUsername;
+                    }
+                    else if ("NULL".equals(mechanism)) {
+                        authentified = "TEST".equals(clientDomain);
+                        errorMessage = "BAD DOMAIN";
+                        userId = "";
+                    }
+                    else {
+                        authentified = false;
+                        errorMessage = "Unknown mechanism";
+                        userId = "";
+                    }
+                    ret = ZMQ.send(handler, authentified ? "200" : "400", ZMQ.ZMQ_SNDMORE);
+                    assertThat(ret, is(3));
+                    if (authentified) {
+                        ret = ZMQ.send(handler, "OK", ZMQ.ZMQ_SNDMORE);
+                        assertThat(ret, is(2));
+                        ret = ZMQ.send(handler, userId, ZMQ.ZMQ_SNDMORE);
+                        assertThat(ret, is(userId.length()));
+                    }
+                     else {
+                        ret = ZMQ.send(handler, errorMessage, ZMQ.ZMQ_SNDMORE);
+                        assertThat(ret, is(errorMessage.length()));
+                        ret = ZMQ.send(handler, "", ZMQ.ZMQ_SNDMORE);
+                        assertThat(ret, is(0));
+                    }
+                    ret = ZMQ.send(handler, "", 0);
+                    assertThat(ret, is(0));
+                    if (! zapFuture.isDone()) {
+                        zapFuture.complete(authentified);
+                    }
+                }
+                else {
+                    if (! zapFuture.isDone()) {
+                        zapFuture.complete(null);
+                    }
+                    break;
+                }
+            }
+        }
+        catch (Exception | AssertionError ex) {
+            ex.printStackTrace();
+            zapFuture.completeExceptionally(ex);
+        }
+       finally {
+            ZMQ.closeZeroLinger(handler);
+        }
+    }
+}


### PR DESCRIPTION
When doing PLAIN or CURVE authentication, the logic can be exchanged.

The client is doing the bind, and the server doing the connect. That was not handled, a connect socket was not expected to reuse the session, and so found an already configured zapPipe. It’s now handled.

Some error message was not returning any message, the specification says that an empty error should be returned instead.

Big rewrite of the tests for mechanisms, the big test function is splited and more code is shared.