### PR TITLE
fix to issue 940 by seting key=null on setKey, added test

### DIFF
--- a/src/test/java/guide/kvmsg.java
+++ b/src/test/java/guide/kvmsg.java
@@ -179,6 +179,7 @@ public class kvmsg
         System.arraycopy(key.getBytes(ZMQ.CHARSET), 0, msg, 0, key.length());
         frame[FRAME_KEY] = msg;
         present[FRAME_KEY] = true;
+        this.key = null;
     }
 
     //  Set message getKey using printf format

--- a/src/test/java/guide/kvmsgTest.java
+++ b/src/test/java/guide/kvmsgTest.java
@@ -1,0 +1,17 @@
+package guide;
+
+import org.junit.Test;
+
+public class kvmsgTest
+{
+   @Test
+   public void showKmsgIssueTest()
+   {
+       kvmsg msg = new kvmsg(0);
+       msg.setKey("mykey");
+       kvmsg clone = msg.dup();
+       clone.setKey(clone.getKey() + "theirkey");
+       // This should pass but does not in 0.5.3:  Reported in jeromq issue #940
+       assert(clone.getKey().equals("mykeytheirkey"));
+   }
+}


### PR DESCRIPTION
Without the change the test fails.