### PR TITLE
Ctx can now be provided a thread factory

### DIFF
--- a/src/main/java/org/zeromq/ZContext.java
+++ b/src/main/java/org/zeromq/ZContext.java
@@ -14,6 +14,7 @@ import org.zeromq.ZMQ.Poller;
 import org.zeromq.ZMQ.Socket;
 
 import zmq.util.Draft;
+import zmq.util.function.BiFunction;
 
 /**
  * ZContext provides a high-level ZeroMQ context management class
@@ -371,6 +372,7 @@ public class ZContext implements Closeable
      * Set the handler invoked when a {@link zmq.poll.Poller} abruptly terminates due to an uncaught exception.<p>
      * It default to the value of {@link Thread#getDefaultUncaughtExceptionHandler()}
      * @param handler The object to use as this thread's uncaught exception handler. If null then this thread has no explicit handler.
+     * @throws IllegalStateException If context was already initialized by the creation of a socket
      */
     public void setUncaughtExceptionHandler(UncaughtExceptionHandler handler)
     {
@@ -390,6 +392,7 @@ public class ZContext implements Closeable
      * be logged.<p>
      * Default to {@link Throwable#printStackTrace()}
      * @param handler The object to use as this thread's handler for recoverable exceptions notifications.
+     * @throws IllegalStateException If context was already initialized by the creation of a socket
      */
     public void setNotificationExceptionHandler(UncaughtExceptionHandler handler)
     {
@@ -402,6 +405,27 @@ public class ZContext implements Closeable
     public UncaughtExceptionHandler getNotificationExceptionHandler()
     {
         return context.getNotificationExceptionHandler();
+    }
+
+    /**
+     * Used to define a custom thread factory. It can be used to create thread that will be bounded to a CPU for
+     * performance or tweaks the created thread. It the UncaughtExceptionHandler is not set, the created thread UncaughtExceptionHandler
+     * will not be changed, so the factory can also be used to set it.
+     *
+     * @param threadFactory the thread factory used by {@link zmq.poll.Poller}
+     * @throws IllegalStateException If context was already initialized by the creation of a socket
+     */
+    public void setThreadFactor(BiFunction<Runnable, String, Thread> threadFactory)
+    {
+        context.setThreadFactor(threadFactory);
+    }
+
+    /**
+     * @return the current thread factory
+     */
+    public BiFunction<Runnable, String, Thread> getThreadFactory()
+    {
+        return context.getThreadFactory();
     }
 
     /**

--- a/src/main/java/org/zeromq/ZMQ.java
+++ b/src/main/java/org/zeromq/ZMQ.java
@@ -28,6 +28,7 @@ import zmq.io.net.SelectorProviderChooser;
 import zmq.msg.MsgAllocator;
 import zmq.util.Draft;
 import zmq.util.Z85;
+import zmq.util.function.BiFunction;
 
 /**
  * <p>The ØMQ lightweight messaging kernel is a library which extends the standard socket interfaces
@@ -569,6 +570,7 @@ public class ZMQ
 
         /**
          * Set the size of the 0MQ thread pool to handle I/O operations.
+         * @throws IllegalStateException If context was already initialized by the creation of a socket
          */
         public boolean setIOThreads(int ioThreads)
         {
@@ -585,6 +587,7 @@ public class ZMQ
 
         /**
          * Sets the maximum number of sockets allowed on the context
+         * @throws IllegalStateException If context was already initialized by the creation of a socket
          */
         public boolean setMaxSockets(int maxSockets)
         {
@@ -629,6 +632,7 @@ public class ZMQ
          * Set the handler invoked when a {@link zmq.poll.Poller} abruptly terminates due to an uncaught exception.<p>
          * It default to the value of {@link Thread#getDefaultUncaughtExceptionHandler()}
          * @param handler The object to use as this thread's uncaught exception handler. If null then this thread has no explicit handler.
+         * @throws IllegalStateException If context was already initialized by the creation of a socket
          */
         public void setUncaughtExceptionHandler(UncaughtExceptionHandler handler)
         {
@@ -648,6 +652,7 @@ public class ZMQ
          * be logged.<p>
          * Default to {@link Throwable#printStackTrace()}
          * @param handler The object to use as this thread's handler for recoverable exceptions notifications.
+         * @throws IllegalStateException If context was already initialized by the creation of a socket
          */
         public void setNotificationExceptionHandler(UncaughtExceptionHandler handler)
         {
@@ -660,6 +665,27 @@ public class ZMQ
         public UncaughtExceptionHandler getNotificationExceptionHandler()
         {
             return ctx.getNotificationExceptionHandler();
+        }
+
+        /**
+         * Used to define a custom thread factory. It can be used to create thread that will be bounded to a CPU for
+         * performance or tweaks the created thread. It the UncaughtExceptionHandler is not set, the created thread UncaughtExceptionHandler
+         * will not be changed, so the factory can also be used to set it.
+         *
+         * @param threadFactory the thread factory used by {@link zmq.poll.Poller}
+         * @throws IllegalStateException If context was already initialized by the creation of a socket
+         */
+        public void setThreadFactor(BiFunction<Runnable, String, Thread> threadFactory)
+        {
+            ctx.setThreadFactory(threadFactory);
+        }
+
+        /**
+         * @return the current thread factory
+         */
+        public BiFunction<Runnable, String, Thread> getThreadFactory()
+        {
+            return ctx.getThreadFactory();
         }
 
         /**

--- a/src/main/java/zmq/poll/Poller.java
+++ b/src/main/java/zmq/poll/Poller.java
@@ -88,9 +88,8 @@ public final class Poller extends PollerBase implements Runnable
 
     public Poller(Ctx ctx, String name)
     {
-        super(name);
+        super(name, ctx.getThreadFactory());
         this.ctx = ctx;
-        worker.setUncaughtExceptionHandler(ctx.getUncaughtExceptionHandler());
         exnotification = ctx.getNotificationExceptionHandler();
         fdTable = new HashSet<>();
         selector = ctx.createSelector();

--- a/src/test/java/zmq/poll/PollerBaseTested.java
+++ b/src/test/java/zmq/poll/PollerBaseTested.java
@@ -6,13 +6,7 @@ class PollerBaseTested extends PollerBase
 
     PollerBaseTested()
     {
-        super("test");
-    }
-
-    @Override
-    Thread createWorker(String name)
-    {
-        return Thread.currentThread();
+        super("test", (s, r) -> Thread.currentThread());
     }
 
     void clock(long clock)

--- a/src/test/java/zmq/poll/PollerTest.java
+++ b/src/test/java/zmq/poll/PollerTest.java
@@ -1,7 +1,9 @@
 package zmq.poll;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.channels.ClosedSelectorException;
+import java.nio.channels.Pipe;
 import java.nio.channels.Selector;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
@@ -35,6 +37,51 @@ public class PollerTest
         Poller poller = new Poller(ctx, "test");
         poller.start();
         selectorRef.get().close();
+        catched.await();
+    }
+
+    @Test(timeout = 1000)
+    public void catchFailure() throws IOException, InterruptedException
+    {
+        CountDownLatch catched = new CountDownLatch(1);
+        Ctx ctx = new Ctx();
+        ctx.setUncaughtExceptionHandler((t, e) ->
+        {
+            if (e instanceof OutOfMemoryError) {
+                catched.countDown();
+            }
+        });
+        Poller poller = new Poller(ctx, "test");
+        Pipe signaler = Pipe.open();
+        try (Pipe.SourceChannel source = signaler.source();
+            Pipe.SinkChannel sink = signaler.sink()
+        ) {
+            source.configureBlocking(false);
+            Poller.Handle handle = poller.addHandle(signaler.source(), new IPollEvents()
+            {
+                @Override
+                public void inEvent()
+                {
+                    throw new OutOfMemoryError();
+                }
+            });
+            poller.setPollIn(handle);
+            poller.start();
+            sink.write(ByteBuffer.allocate(1));
+            catched.await();
+        }
+    }
+
+    @Test(timeout = 1000)
+    public void threadFactory() throws InterruptedException
+    {
+        CountDownLatch catched = new CountDownLatch(1);
+        Ctx ctx = new Ctx();
+        ctx.setThreadFactory((r, s) -> {
+            catched.countDown();
+            return new Thread(r, s);
+        });
+        new Poller(ctx, "test");
         catched.await();
     }
 }


### PR DESCRIPTION
Ctx can now be provided a thread factory, that can used to tweaks thr…eads.

The main purpose of this is to be able to bind thread to CPU using external libraries like https://github.com/OpenHFT/Java-Thread-Affinity.

The idea was suggested by issue #910

Also adding a check that prevent modifications of some settings once they have been used by Ctx initialisation.