### PR TITLE
Upgrading build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,36 +2,23 @@ version: 2.1
 jobs:
     checkout:
         docker:
-            - image: circleci/openjdk:17-jdk-buster
+            - image: cimg/openjdk:17.0
         steps:
             - checkout
             - restore_cache:
                 key: jeromq-{{ checksum "pom.xml" }}
-            - restore_cache:
-                key: jeromq-mavendep
             - run: mkdir -p /home/circleci/.sonar/cache /home/circleci/.m2/repository
             - run:
-                command: "mvn -B dependency:resolve dependency:resolve-plugins -s .circleci/settings.xml -Pandroid,sonar,coverage,checkstyle"
-                environment:
-                    JAVA_HOME: /usr/local/openjdk-17
-                    MAVEN_OPTS: "-Xmx1024m"
+                command: "mvn -B dependency:resolve dependency:resolve-plugins sonar:help jacoco:help checkstyle:help -Psonar,versions,android -s .circleci/settings.xml"
             - persist_to_workspace:
                 root: /
                 paths:
                     - home/circleci/.m2/repository
                     - home/circleci/.sonar/cache
                     - home/circleci/project
-    jdk8:
-        docker:
-            - image: circleci/openjdk:8-buster
-        steps:
-            - persist_to_workspace:
-                root: /usr/local
-                paths:
-                    - openjdk-8
     build:
         docker:
-            - image: circleci/openjdk:17-jdk-buster
+            - image: cimg/openjdk:17.0
         steps:
             - attach_workspace:
                 at: /tmp/ws
@@ -41,18 +28,36 @@ jobs:
                     mv -n /tmp/ws/home/circleci/project/* /home/circleci/project/
                     mv -n /tmp/ws/home/circleci/project/.??* /home/circleci/project/
             - run:
-                command: mvn -B clean compile site -Pcheckstyle -Djdk.compile.home=/tmp/ws/openjdk-8 -s .circleci/settings.xml
+                command: mvn -B clean compile -Pcheckstyle -s .circleci/settings.xml
                 environment:
-                    JAVA_HOME: /usr/local/openjdk-17
                     MAVEN_OPTS: "-Xmx2048m"
             - persist_to_workspace:
                 root: /
                 paths:
                     - home/circleci/.m2/repository
                     - home/circleci/project/target
+    testsj19:
+        docker:
+            - image: cimg/openjdk:19.0
+        steps:
+            - attach_workspace:
+                  at: /tmp/ws
+            - run:
+                  command: |
+                      mv -n /tmp/ws/home/circleci/.m2 /home/circleci/
+                      mv -n /tmp/ws/home/circleci/project/* /home/circleci/project/
+                      mv -n /tmp/ws/home/circleci/project/.??* /home/circleci/project/
+            - run:
+                  command: |
+                      mkdir -p /tmp/$CIRCLE_JOB
+                      mvn -B test -Pskip -Darg.line="-Xmx2048m" -Djava.io.tmpdir="/tmp/$CIRCLE_JOB" -s .circleci/settings.xml
+                  environment:
+                      MAVEN_OPTS: "-Xmx1024m"
+            - store_test_results:
+                  path: target/surefire-reports
     testsj17:
         docker:
-            - image: circleci/openjdk:17-jdk-buster
+            - image: cimg/openjdk:17.0
         steps:
             - attach_workspace:
                 at: /tmp/ws
@@ -65,14 +70,14 @@ jobs:
                 command: |
                     # If no symbolic name, it's a PR, will run sonar
                     if [ -n "$(git symbolic-ref HEAD 2>/dev/null )" ] ; then
-                        SONAR="jacoco:report sonar:sonar -Psonar,coverage"
+                        SONAR="jacoco:report sonar:sonar -Psonar"
                         echo "Doing sonar"
                     else
                         SONAR=""
                     fi
-                    mvn -B test $SONAR -Pskip -Darg.line="-Xmx2048m" -s .circleci/settings.xml
+                    mkdir -p /tmp/$CIRCLE_JOB
+                    mvn -B test $SONAR -Pskip -Darg.line="-Xmx2048m" -Djava.io.tmpdir="/tmp/$CIRCLE_JOB" -s .circleci/settings.xml
                 environment:
-                    JAVA_HOME: /usr/local/openjdk-17
                     MAVEN_OPTS: "-Xmx1024m"
             - store_test_results:
                 path: target/surefire-reports
@@ -81,9 +86,10 @@ jobs:
                 paths:
                     - home/circleci/.m2/repository
                     - home/circleci/.sonar/cache
+                    - home/circleci/project
     testsj11:
         docker:
-            - image: circleci/openjdk:11-buster
+            - image: cimg/openjdk:11.0
         steps:
             - attach_workspace:
                 at: /tmp/ws
@@ -95,16 +101,16 @@ jobs:
                     mv -n /tmp/ws/home/circleci/project/.??* /home/circleci/project/
             - run:
                 command: |
-                    mvn -B test -Pskip -Darg.line="-Xmx2048m" -s .circleci/settings.xml
+                    mkdir -p /tmp/$CIRCLE_JOB
+                    mvn -B test -Pskip -Darg.line="-Xmx2048m" -Djava.io.tmpdir="/tmp/$CIRCLE_JOB" -s .circleci/settings.xml
                 environment:
-                    JAVA_HOME: /usr/local/openjdk-11
                     MAVEN_OPTS: "-Xmx512m"
             - store_test_results:
                 path: target/surefire-reports
             #don't persist_to_workspace, can't be done in parallel with testsj13
     testsj8:
         docker:
-            - image: circleci/openjdk:8-buster
+            - image: cimg/openjdk:8.0
         steps:
             - attach_workspace:
                 at: /tmp/ws
@@ -116,16 +122,15 @@ jobs:
                     mv -n /tmp/ws/home/circleci/project/.??* /home/circleci/project/
             - run:
                 command: |
-                    mvn -B test -Pskip -Darg.line="-Xmx2048m" -s .circleci/settings.xml
+                    mvn -B test -Pskip -Darg.line="-Xmx2048m" -Djava.io.tmpdir="/tmp/$CIRCLE_JOB" -s .circleci/settings.xml
                 environment:
-                    JAVA_HOME: /usr/local/openjdk-8
                     MAVEN_OPTS: "-Xmx512m"
             - store_test_results:
                 path: target/surefire-reports
             #don't persist_to_workspace, can't be done in parallel with testsj13
     testsandroid:
         docker:
-            - image: circleci/openjdk:17-jdk-buster
+            - image: cimg/openjdk:17.0
         steps:
             - attach_workspace:
                 at: /tmp/ws
@@ -139,11 +144,10 @@ jobs:
                 command: |
                     mvn -B test -Pskip,android -Darg.line="-Xmx2048m" -s .circleci/settings.xml -Dmaven.test.skip=true
                 environment:
-                    JAVA_HOME: /usr/local/openjdk-17
                     MAVEN_OPTS: "-Xmx2048m"
     publish:
         docker:
-            - image: circleci/openjdk:17-jdk-buster
+            - image: cimg/openjdk:17.0
         steps:
             - attach_workspace:
                 at: /tmp/ws
@@ -165,7 +169,6 @@ jobs:
                     echo "publishing jobs: $PUBLISH"
                     mvn -B $PUBLISH -Pskip -Dmaven.test.skip=true -Dmaven.javadoc.skip=false -s .circleci/settings.xml
                 environment:
-                    JAVA_HOME: /usr/local/openjdk-17
                     MAVEN_OPTS: "-Xmx2048m"
             - store_artifacts:
                 path: /home/circleci/.m2/repository/org/zeromq/jeromq
@@ -177,7 +180,7 @@ jobs:
                     - home/circleci/.sonar/cache
     savecache:
         docker:
-            - image: circleci/openjdk:17-jdk-buster
+            - image: cimg/openjdk:17.0
         steps:
             - attach_workspace:
                 at: /tmp/ws
@@ -188,22 +191,17 @@ jobs:
                     mv /tmp/ws/home/circleci/.sonar /home/circleci/
             - save_cache:
                 paths:
+                    - /home/circleci/.m2/repository
                     - /home/circleci/.sonar/cache
                 key: jeromq-{{ checksum "pom.xml" }}
-            - save_cache:
-                paths:
-                    - /home/circleci/.m2/repository
-                key: jeromq-mavendep
 workflows:
   version: 2.1
   build_and_test:
     jobs:
       - checkout
-      - jdk8
       - build:
           requires:
               - checkout
-              - jdk8
       - testsj8:
           requires:
               - build
@@ -213,6 +211,9 @@ workflows:
       - testsj17:
           requires:
               - build
+      - testsj19:
+            requires:
+                - build
       - testsandroid:
           requires:
               - build
@@ -221,6 +222,8 @@ workflows:
               - testsj8
               - testsj11
               - testsj17
+              - testsj19
+              - testsandroid
       - savecache:
           requires:
               - publish

--- a/pom.xml
+++ b/pom.xml
@@ -24,19 +24,16 @@
   </developers>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
-    <!-- Indirection needed to keep optionnal jacoco settings and external argument lines-->
+    <jdk.target>8</jdk.target>
+    <!-- Indirection needed to keep optional jacoco settings and external argument lines-->
     <arg.line />
     <argLine>${arg.line}</argLine>
-    <!-- Hides incompatibily in javadoc headers between java 8 and latter -->
-    <doclint>all</doclint>
   </properties>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -144,9 +141,8 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.4.1</version>
           <configuration>
-            <bootclasspath>${bootclasspath}</bootclasspath>
             <detectJavaApiLink>true</detectJavaApiLink>
             <source>${maven.compiler.source}</source>
             <tags>
@@ -161,37 +157,37 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
-          <version>1.8</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-clean-plugin</artifactId>
           <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.2.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-resources-plugin</artifactId>
-            <version>3.1.0</version>
+            <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
+          <version>3.10.1</version>
         </plugin>
         <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.5</version>
+            <version>0.8.8</version>
         </plugin>
         <plugin>
             <groupId>org.sonarsource.scanner.maven</groupId>
             <artifactId>sonar-maven-plugin</artifactId>
-            <version>3.7.0.1746</version>
+            <version>3.9.1.2184</version>
         </plugin>
         <plugin>
             <groupId>org.eluder.coveralls</groupId>
@@ -201,84 +197,84 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M3</version>
+          <version>3.0.0-M7</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.2.1</version>
         </plugin>
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
-            <version>3.1.1</version>
+            <version>3.2.2</version>
         </plugin>
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>
-            <version>3.1.1</version>
+            <version>3.4.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>5.1.1</version>
+          <version>5.1.8</version>
         </plugin>
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-site-plugin</artifactId>
-            <version>3.9.0</version>
+            <version>4.0.0-M2</version>
         </plugin>
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-project-info-reports-plugin</artifactId>
-            <version>3.1.2</version>
+            <version>3.4.1</version>
         </plugin>
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>3.1.1</version>
+            <version>3.2.1</version>
             <dependencies>
               <dependency>
                 <groupId>com.puppycrawl.tools</groupId>
                 <artifactId>checkstyle</artifactId>
-                <version>8.38</version>
+                <version>10.6.0</version>
               </dependency>
             </dependencies>
          </plugin>
          <plugin>
            <groupId>org.codehaus.mojo</groupId>
            <artifactId>animal-sniffer-maven-plugin</artifactId>
-           <version>1.20</version>
+           <version>1.22</version>
          </plugin>
          <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>versions-maven-plugin</artifactId>
-            <version>2.8.1</version>
+            <version>2.14.2</version>
         </plugin>
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-install-plugin</artifactId>
-            <version>3.0.0-M1</version>
+            <version>3.0.1</version>
         </plugin>
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.0.0-M1</version>
+            <version>3.0.0-M2</version>
         </plugin>
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.0.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.3</version>
+          <version>3.0.0-M6</version>
         </plugin>
         <plugin>
           <groupId>org.sonatype.plugins</groupId>
           <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>1.6.8</version>
+          <version>1.6.13</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -293,60 +289,23 @@
   </reporting>
   <profiles>
     <profile>
-      <!--Activate jacoco coverage -->
-      <id>coverage</id>
-        <activation>
-          <activeByDefault>false</activeByDefault>
-        </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>default-prepare-agent</id>
-                <goals>
-                  <goal>prepare-agent</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>default-report</id>
-                <phase>prepare-package</phase>
-                <goals>
-                  <goal>report</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>default-check</id>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-                <configuration>
-                  <rules>
-                    <!-- implementation is needed only for Maven 2 -->
-                    <rule implementation="org.jacoco.maven.RuleConfiguration">
-                      <element>BUNDLE</element>
-                      <limits>
-                        <!-- implementation is needed only for Maven 2 -->
-                        <limit implementation="org.jacoco.report.check.Limit">
-                          <counter>COMPLEXITY</counter>
-                          <value>COVEREDRATIO</value>
-                          <minimum>0.60</minimum>
-                        </limit>
-                      </limits>
-                    </rule>
-                  </rules>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        <plugin>
-          <groupId>org.eluder.coveralls</groupId>
-          <artifactId>coveralls-maven-plugin</artifactId>
-        </plugin>
-        </plugins>
-      </build>
+      <id>jdk8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.source>${jdk.target}</maven.compiler.source>
+        <maven.compiler.target>${jdk.target}</maven.compiler.target>
+      </properties>
+    </profile>
+    <profile>
+      <id>jdk9+</id>
+      <activation>
+        <jdk>(1.8,)</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.release>${jdk.target}</maven.compiler.release>
+      </properties>
     </profile>
     <profile>
       <!-- Used with the phase 'site' to check plugins and dependency versions -->
@@ -397,57 +356,34 @@
       </build>
     </profile>
     <profile>
-      <!-- With this profile, it's possible to used the latest jvm but still get jar compatible with pre-9 JVM.
-           It's activated when jdk.compile.home is defined. Example:
-           JAVA_HOME=$JAVA14_HOME mvn compile -Djdk.compile.home=$JAVA8_HOME !-->
-      <id>crosscompile</id>
-      <activation>
-        <property>
-          <name>jdk.compile.home</name>
-        </property>
-      </activation>
-      <properties>
-        <bootclasspath>${jdk.compile.home}/jre/lib/rt.jar</bootclasspath>
-      </properties>
+      <id>sonar</id>
       <build>
         <plugins>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <compilerArgs>
-                  <arg>-Xbootclasspath:${bootclasspath}</arg>
-              </compilerArgs>
-              <!-- needed for maven-plugin-javadoc to find the source version to use -->
-              <source>${maven.compiler.source}</source>
-              <target>${maven.compiler.target}</target>
-            </configuration>
+            <groupId>org.sonarsource.scanner.maven</groupId>
+            <artifactId>sonar-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>prepare-agent</id>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>report</id>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>
     </profile>
-    <profile>
-      <!-- The default compile settings, when jdk.compile.home is not defined -->
-      <id>nocrosscompile</id>
-      <activation>
-        <property>
-            <name>!jdk.compile.home</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <!-- needed for maven-plugin-javadoc to find the source version to use -->
-              <source>${maven.compiler.source}</source>
-              <target>${maven.compiler.target}</target>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-   </profile>
     <profile>
       <!-- Used to sign a release -->
       <id>release</id>

--- a/src/main/java/zmq/SocketBase.java
+++ b/src/main/java/zmq/SocketBase.java
@@ -378,7 +378,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
                 return false;
             }
 
-            switch(protocol) {
+            switch (protocol) {
             case inproc: {
                 Ctx.Endpoint endpoint = new Ctx.Endpoint(this, options);
                 boolean rc = registerEndpoint(addr, endpoint);


### PR DESCRIPTION
The java compliance is applied using the maven.compiler.release property.
Many plugins update.
The old circleci images was deprecated, using the new one.