### PR TITLE
Improving monitor

### DIFF
--- a/doc/monitor.md
+++ b/doc/monitor.md
@@ -1,0 +1,42 @@
+# Monitor
+
+ZMQ does not provide a logging API, but instead used monitors for notifications and debug. It uses a dedicated socket that
+will receive events from all sockets using a custom serialization, which is not compatible with the one described in zmq_socket_monitor(3).
+
+Or it can also handle directly the event in the caller’s context using a hook that consumes events.
+
+There is 4 classes handling events.
+
+## zmq.ZMQ.Event
+
+It’s the low level implementation, close to the C implementation.
+
+It doesn’t try to resolve argument as types; they are simply integer that needs further processing to be resolved to
+high level objects.
+
+It provides a `zmq.ZMQ.Event.getChannel(zmq.Ctx)` to map an internal file descriptor integer value to an effective
+`java.nio.channels.SelectableChannel` object. If used through a monitoring socket, the status of the channel might be
+different from when the event was generated, as processing is asynchronous.
+
+A hook that consume those kind of events can be declared by using `zmq.SocketBase.setEventHook(ZMQ.EventConsummer consumer, int events)`
+
+A socket that will received serialized events of this kind can be declared by using `zmq.SocketBase.monitor(String addr, int events)`. 
+The address is the endpoint of an IPC PAIR socket.
+
+## org.zeromq.ZMQ.Event
+
+A first try at implement a high level wrapper. It is not very consistent and being a nested class reduces code readability.
+
+## org.zeromq.ZMonitor.ZEvent
+
+Another incomplete implementation of a high level wrapper. Again, being a nested class reduce code readability.
+It also stores the value as a String, which is not very usable and uses `System.out.println on many places.
+
+## org.zeromq.ZEvent
+
+A more advanced implementation, that return high level java object whenever possible and is more readable.
+
+A hook that consume those kind of events can be declared by using `org.zeromq.ZMQ.Socket.setEventHook(ZEvent.ZEventConsummer consumer, int events)`
+
+A socket that will received serialized events of this kind can be declared by using `org.zeromq.ZMQ.Socket.monitor(String addr, int events)`.
+The address is the endpoint of an IPC PAIR socket.

--- a/src/main/java/org/zeromq/ZEvent.java
+++ b/src/main/java/org/zeromq/ZEvent.java
@@ -1,0 +1,325 @@
+package org.zeromq;
+
+import java.nio.channels.SelectableChannel;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.zeromq.ZMQ.Socket;
+import org.zeromq.ZMonitor.Event;
+
+import zmq.ZError;
+
+/**
+ * A high level wrapper for an event that stores all value as Enum or java object instead of integer, and associate a
+ * severity with them.
+ * The events are handled using the following rules.
+ * <br/>
+ * <table>
+ *     <caption>Events list</caption>
+ *     <tr>
+ *         <th>Event</th>
+ *         <th>Value type</th>
+ *         <th>Severity level</th>
+ *     </tr>
+ *     <tr>
+ *         <td>CONNECTED</td>
+ *         <td>{@link java.nio.channels.SelectableChannel}</td>
+ *         <td>debug</td>
+ *     </tr>
+ *     <tr>
+ *         <td>CONNECT_DELAYED</td>
+ *         <td>{@link ZMQ.Error} or null if no error</td>
+ *         <td>debug</td>
+ *     </tr>
+ *     <tr>
+ *         <td>CONNECT_RETRIED</td>
+ *         <td>{@link java.time.Duration}</td>
+ *         <td>debug</td>
+ *     </tr>
+ *     <tr>
+ *         <td>LISTENING</td>
+ *         <td>{@link java.nio.channels.SelectableChannel}</td>
+ *         <td>debug</td>
+ *     </tr>
+ *     <tr>
+ *         <td>BIND_FAILED</td>
+ *         <td>{@link ZMQ.Error} or null if no error</td>
+ *         <td>error</td>
+ *     </tr>
+ *     <tr>
+ *         <td>ACCEPTED</td>
+ *         <td>{@link java.nio.channels.SelectableChannel}</td>
+ *         <td>debug</td>
+ *     </tr>
+ *     <tr>
+ *         <td>ACCEPT_FAILED</td>
+ *         <td>{@link ZMQ.Error} or null if no error</td>
+ *         <td>error</td>
+ *     </tr>
+ *     <tr>
+ *         <td>CLOSED</td>
+ *         <td>{@link java.nio.channels.SelectableChannel}</td>
+ *         <td>debug</td>
+ *     </tr>
+ *     <tr>
+ *         <td>CLOSE_FAILED</td>
+ *         <td>{@link ZMQ.Error} or null if no error</td>
+ *         <td>error</td>
+ *     </tr>
+ *     <tr>
+ *         <td>DISCONNECTED</td>
+ *         <td>{@link java.nio.channels.SelectableChannel}</td>
+ *         <td>info</td>
+ *     </tr>
+ *     <tr>
+ *         <td>MONITOR_STOPPED</td>
+ *         <td>null value</td>
+ *         <td>debug</td>
+ *     </tr>
+ *     <tr>
+ *         <td>HANDSHAKE_FAILED_NO_DETAIL</td>
+ *         <td>{@link ZMQ.Error} or null if no error</td>
+ *         <td>error</td>
+ *     </tr>
+ *     <tr>
+ *         <td>HANDSHAKE_SUCCEEDED</td>
+ *         <td>{@link ZMQ.Error} or null if no error</td>
+ *         <td>debug</td>
+ *     </tr>
+ *     <tr>
+ *         <td>HANDSHAKE_FAILED_PROTOCOL</td>
+ *         <td>{@link ZMonitor.ProtocolCode}</td>
+ *         <td>error</td>
+ *     </tr>
+ *     <tr>
+ *         <td>HANDSHAKE_FAILED_AUTH</td>
+ *         <td>{@link java.lang.Integer}</td>
+ *         <td>warn</td>
+ *     </tr>
+ *     <tr>
+ *         <td>HANDSHAKE_PROTOCOL</td>
+ *         <td>{@link java.lang.Integer}</td>
+ *         <td>debug</td>
+ *     </tr>
+ * </table>
+ */
+public class ZEvent
+{
+    /**
+     * An interface used to consume events in monitor
+     */
+    public interface ZEventConsummer extends zmq.ZMQ.EventConsummer
+    {
+        void consume(ZEvent ev);
+
+        default void consume(zmq.ZMQ.Event event)
+        {
+            consume(new ZEvent(event, SelectableChannel.class::cast));
+        }
+    }
+
+    private final Event event;
+    // To keep backward compatibility, the old value field only store integer
+    // The resolved value (Error, channel or other) is stored in resolvedValue field.
+    private final Object value;
+    private final String address;
+
+    private ZEvent(zmq.ZMQ.Event event, Function<Object, SelectableChannel> getResolveChannel)
+    {
+        this.event = ZMonitor.Event.findByCode(event.event);
+        this.address = event.addr;
+        this.value = resolve(this.event, event.arg, getResolveChannel);
+    }
+
+    static Object resolve(Event event, Object value, Function<Object, SelectableChannel> getResolveChannel)
+    {
+        switch (event) {
+        case HANDSHAKE_FAILED_PROTOCOL:
+            return ZMonitor.ProtocolCode.findByCode((Integer) value);
+        case CLOSE_FAILED:
+        case ACCEPT_FAILED:
+        case BIND_FAILED:
+        case HANDSHAKE_FAILED_NO_DETAIL:
+        case CONNECT_DELAYED:
+        case HANDSHAKE_SUCCEEDED:
+            return ZMQ.Error.findByCode((Integer) value);
+        case HANDSHAKE_FAILED_AUTH:
+        case HANDSHAKE_PROTOCOL:
+            return value;
+        case CONNECTED:
+        case LISTENING:
+        case ACCEPTED:
+        case CLOSED:
+        case DISCONNECTED:
+            return getResolveChannel.apply(value);
+        case CONNECT_RETRIED:
+            return Duration.ofMillis((Integer) value);
+        case MONITOR_STOPPED:
+            return null;
+        default:
+            assert false : "Unhandled event " + event;
+            return null;
+        }
+    }
+
+    public Event getEvent()
+    {
+        return event;
+    }
+
+    /**
+     * Return the value of the event as a high level java object.
+     * It returns objects of type:
+     * <ul>
+     * <li> {@link org.zeromq.ZMonitor.ProtocolCode} for a handshake protocol error.</li>
+     * <li> {@link org.zeromq.ZMQ.Error} for any other error.</li>
+     * <li> {@link Duration} when associated with a delay.</li>
+     * <li> null when no relevant value available.</li>
+     * </ul>
+     * @param <M> The expected type of the returned object
+     * @return The resolved value.
+     */
+    @SuppressWarnings("unchecked")
+    public <M> M getValue()
+    {
+        return (M) value;
+    }
+
+    public String getAddress()
+    {
+        return address;
+    }
+
+    /**
+     * Used to check if the event is an error.
+     * <p>
+     * Generally, any event that define the errno is
+     * considered as an error.
+     * @return true if the event was an error
+     */
+    public boolean isError()
+    {
+        switch (event) {
+        case BIND_FAILED:
+        case ACCEPT_FAILED:
+        case CLOSE_FAILED:
+        case HANDSHAKE_FAILED_NO_DETAIL:
+        case HANDSHAKE_FAILED_PROTOCOL:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    /**
+     * Used to check if the event is a warning.
+     * <p>
+     * Generally, any event that return an authentication failure is
+     * considered as a warning.
+     * @return true if the event was a warning
+     */
+    public boolean isWarn()
+    {
+        return event == Event.HANDSHAKE_FAILED_AUTH;
+    }
+
+    /**
+     * Used to check if the event is an information.
+     * <p>
+     * Generally, any event that return an authentication failure is
+     * considered as a warning.
+     * @return true if the event was a warning
+     */
+    public boolean isInformation()
+    {
+        return event == Event.DISCONNECTED;
+    }
+
+    /**
+     * Used to check if the event is an error.
+     * <p>
+     * Generally, any event that define the errno is
+     * considered as an error.
+     * @return true if the event was an error
+     */
+    public boolean isDebug()
+    {
+        switch (event) {
+        case CONNECTED:
+        case CONNECT_DELAYED:
+        case CONNECT_RETRIED:
+        case LISTENING:
+        case ACCEPTED:
+        case CLOSED:
+        case MONITOR_STOPPED:
+        case HANDSHAKE_SUCCEEDED:
+        case HANDSHAKE_PROTOCOL:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        else if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        else {
+            ZEvent zEvent = (ZEvent) o;
+            return event == zEvent.event && Objects.equals(value, zEvent.value) && address.equals(zEvent.address);
+        }
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(event, value, address);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "ZEvent{" + "event=" + event + ", value=" + value + ", address='" + address + '\'' + '}';
+    }
+
+    /**
+     * Receive an event from a monitor socket.
+     *
+     * @param socket the monitor socket
+     * @param flags  the flags to apply to the read operation.
+     * @return the received event or null if no message was received.
+     * @throws ZMQException In case of errors with the monitor socket
+     */
+    public static ZEvent recv(Socket socket, int flags)
+    {
+        zmq.ZMQ.Event e = zmq.ZMQ.Event.read(socket.base(), flags);
+        if (socket.errno() > 0 && socket.errno() != ZError.EAGAIN) {
+            throw new ZMQException(socket.errno());
+        }
+        else if (e == null) {
+            return null;
+        }
+        else {
+            return new ZEvent(e, o -> e.getChannel(socket.getCtx()));
+        }
+    }
+
+    /**
+     * Receive an event from a monitor socket.
+     * Does a blocking recv.
+     *
+     * @param socket the monitor socket
+     * @return the received event or null if no message was received.
+     * @throws ZMQException In case of errors with the monitor socket
+     */
+    public static ZEvent recv(ZMQ.Socket socket)
+    {
+        return recv(socket, 0);
+    }
+}

--- a/src/main/java/org/zeromq/ZMonitor.java
+++ b/src/main/java/org/zeromq/ZMonitor.java
@@ -69,6 +69,7 @@ public class ZMonitor implements Closeable
             }
         }
 
+        @SuppressWarnings("deprecation")
         public ZEvent(ZMQ.Event event)
         {
             code = event.getEvent();
@@ -417,10 +418,10 @@ public class ZMonitor implements Closeable
         @Override
         public boolean stage(Socket socket, Socket pipe, ZPoller poller, int evts)
         {
-            final ZMQ.Event event = ZMQ.Event.recv(socket);
+            final zmq.ZMQ.Event event = zmq.ZMQ.Event.read(socket.base());
             assert (event != null);
-            final int code = event.getEvent();
-            final String address = event.getAddress();
+            final int code = event.event;
+            final String address = event.addr;
             assert (address != null);
             final Event type = Event.findByCode(code);
             assert (type != null);
@@ -434,7 +435,7 @@ public class ZMonitor implements Closeable
 
             msg.add(frame);
 
-            final Object value = event.getValue();
+            final Object value = event.arg;
             if (value != null) {
                 msg.add(value.toString());
             }

--- a/src/main/java/zmq/SocketBase.java
+++ b/src/main/java/zmq/SocketBase.java
@@ -1459,7 +1459,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
             monitorSocket.setSocketOpt(ZMQ.ZMQ_LINGER, 0);
             boolean rc = monitorSocket.bind(addr);
             if (rc) {
-                return monitor(new SocketEventHandler(monitorSocket), events);
+                return setEventHook(new SocketEventHandler(monitorSocket), events);
             }
             else {
                 return false;
@@ -1475,7 +1475,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
      * @throws IllegalStateException if a previous monitor was already
      *         registered and consumer is not null.
      */
-    public final boolean monitor(ZMQ.EventConsummer consumer, int events)
+    public final boolean setEventHook(ZMQ.EventConsummer consumer, int events)
     {
         synchronized (monitor) {
             if (ctxTerminated.get()) {

--- a/src/main/java/zmq/ZMQ.java
+++ b/src/main/java/zmq/ZMQ.java
@@ -264,7 +264,7 @@ public class ZMQ
     }
 
     /**
-     * A interface used to consume events in monitor
+     * An interface used to consume events in monitor
      */
     public interface EventConsummer
     {
@@ -355,8 +355,24 @@ public class ZMQ
          */
         public SelectableChannel getChannel(SocketBase socket)
         {
+            return getChannel(socket.getCtx());
+        }
+
+        /**
+         * Resolve the channel that was associated with this event.
+         * Implementation note: to be backward compatible, {@link #arg} only store Integer value, so
+         * the channel is resolved using this call.
+         * <p>
+         * Internally socket are kept using weak values, so it's better to retrieve the channel as early
+         * as possible, otherwise it might get lost.
+         *
+         * @param ctx the socket that send the event
+         * @return the channel in the event, or null if was not a channel event.
+         */
+        public SelectableChannel getChannel(Ctx ctx)
+        {
             if (flag == VALUE_CHANNEL) {
-                return socket.getCtx().getForwardedChannel((Integer) arg);
+                return ctx.getForwardedChannel((Integer) arg);
             }
             else {
                 return null;

--- a/src/main/java/zmq/ZObject.java
+++ b/src/main/java/zmq/ZObject.java
@@ -37,7 +37,7 @@ public abstract class ZObject
         this.tid = tid;
     }
 
-    protected final Ctx getCtx()
+    public final Ctx getCtx()
     {
         return ctx;
     }

--- a/src/test/java/org/zeromq/TestEventResolution.java
+++ b/src/test/java/org/zeromq/TestEventResolution.java
@@ -1,18 +1,24 @@
 package org.zeromq;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import java.io.IOException;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SocketChannel;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.zeromq.ZMQ.Error;
 import org.zeromq.ZMonitor.ProtocolCode;
 
 import zmq.SocketBase;
+import zmq.ZError;
+import zmq.util.function.Consumer;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TestEventResolution
 {
@@ -21,170 +27,299 @@ public class TestEventResolution
         void send(SocketBase s, String addr);
     }
 
-    public ZMQ.Event make(SendEvent sender, int eventFilter)
+    private ZEvent run1(SendEvent sender, int eventFilter) throws IOException
     {
-        try (ZMQ.Context zctx = new ZMQ.Context(1);
-            ZMQ.Socket s = zctx.socket(SocketType.PUB);
-            ZMQ.Socket m = zctx.socket(SocketType.PAIR)) {
+        try (ZContext zctx = new ZContext(1);
+            ZMQ.Socket s = zctx.createSocket(SocketType.PUB);
+            ZMQ.Socket m = zctx.createSocket(SocketType.PAIR)) {
             s.monitor("inproc://TestEventResolution", eventFilter);
             m.connect("inproc://TestEventResolution");
-            sender.send(s.base(), "tcp://127.0.0.1:8000");
-            return ZMQ.Event.recv(m);
+            sender.send(s.base(), "tcp://127.0.0.1:" + Utils.findOpenPort());
+            return ZEvent.recv(m);
+        }
+    }
+
+    private ZEvent run2(SendEvent sender, int eventFilter) throws ExecutionException, InterruptedException,
+                                                                          IOException
+    {
+        CompletableFuture<ZEvent> eventFuture = new CompletableFuture<>();
+        try (ZContext zctx = new ZContext(1);
+                ZMQ.Socket s = zctx.createSocket(SocketType.PUB)) {
+            s.setEventHook(eventFuture::complete, eventFilter);
+            sender.send(s.base(), "tcp://127.0.0.1:" + Utils.findOpenPort());
+            return eventFuture.get();
+        }
+    }
+
+    private void doTest(SendEvent sender, int eventFilter, Consumer<ZEvent> check)
+            throws ExecutionException, InterruptedException, IOException
+    {
+        ZEvent event1 = run1(sender, eventFilter);
+        assertThat(event1.getAddress(), startsWith("tcp://127.0.0.1:"));
+        check.accept(event1);
+        ZEvent event2 = run2(sender, eventFilter);
+        assertThat(event1.getAddress(), startsWith("tcp://127.0.0.1:"));
+        check.accept(event2);
+    }
+
+    @Test(timeout = 1000)
+    public void testFailed()
+    {
+        ZContext zctx = new ZContext(1);
+        ZMQ.Socket m = zctx.createSocket(SocketType.PAIR);
+        m.connect("inproc://TestEventResolution");
+        zctx.close();
+        ZMQException ex = Assert.assertThrows(ZMQException.class, () -> ZEvent.recv(m));
+        assertThat(ex.getErrorCode(), is(ZError.ETERM));
+    }
+
+    @Test(timeout = 1000)
+    public void testEventHandshakeFailedProtocol() throws ExecutionException, InterruptedException, IOException
+    {
+        doTest((s, a) -> s.eventHandshakeFailedProtocol(a, zmq.ZMQ.ZMQ_PROTOCOL_ERROR_ZMTP_UNEXPECTED_COMMAND),
+                zmq.ZMQ.ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL,
+                ev -> {
+                    ProtocolCode protocol = ev.getValue();
+                    assertThat(protocol, is(ProtocolCode.ZMQ_PROTOCOL_ERROR_ZMTP_UNEXPECTED_COMMAND));
+                    assertThat(ev.isError(), is(true));
+                    assertThat(ev.isWarn(), is(false));
+                    assertThat(ev.isInformation(), is(false));
+                    assertThat(ev.isDebug(), is(false));
+                });
+    }
+
+    @Test(timeout = 1000)
+    public void testEventHandshakeFailedAuth() throws ExecutionException, InterruptedException, IOException
+    {
+        doTest((s, a) -> s.eventHandshakeFailedAuth(a, 200),
+                zmq.ZMQ.ZMQ_EVENT_HANDSHAKE_FAILED_AUTH,
+                ev -> {
+                    int statusCode = ev.getValue();
+                    assertThat(statusCode, is(200));
+                    assertThat(ev.isError(), is(false));
+                    assertThat(ev.isWarn(), is(true));
+                    assertThat(ev.isInformation(), is(false));
+                    assertThat(ev.isDebug(), is(false));
+                });
+    }
+
+    @Test(timeout = 1000)
+    public void testEventDisconnected() throws IOException, ExecutionException, InterruptedException
+    {
+        try (SelectableChannel sc = SocketChannel.open()) {
+            doTest((s, a) -> s.eventDisconnected(a, sc),
+                    zmq.ZMQ.ZMQ_EVENT_DISCONNECTED,
+                    ev -> {
+                        Object value = ev.getValue();
+                        assertThat(value, is(sc));
+                        assertThat(ev.isError(), is(false));
+                        assertThat(ev.isWarn(), is(false));
+                        assertThat(ev.isInformation(), is(true));
+                        assertThat(ev.isDebug(), is(false));
+                    });
         }
     }
 
     @Test(timeout = 1000)
-    public void testEventHandshakeFailedProtocol()
+    public void testEventClosed() throws IOException, ExecutionException, InterruptedException
     {
-        ZMQ.Event ev = make((s, a) -> s.eventHandshakeFailedProtocol(a, zmq.ZMQ.ZMQ_PROTOCOL_ERROR_ZMTP_UNEXPECTED_COMMAND), zmq.ZMQ.ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL);
-        ProtocolCode protocol = ev.resolveValue();
-        assertThat(protocol, is(ProtocolCode.ZMQ_PROTOCOL_ERROR_ZMTP_UNEXPECTED_COMMAND));
-        assertThat(ev.isError(), is(true));
-        assertThat(ev.isWarn(), is(false));
+        try (SelectableChannel sc = SocketChannel.open()) {
+            doTest((s, a) -> s.eventClosed(a, sc), zmq.ZMQ.ZMQ_EVENT_CLOSED,
+                    ev -> {
+                        Object value = ev.getValue();
+                        assertThat(value, is(sc));
+                        assertThat(ev.isError(), is(false));
+                        assertThat(ev.isWarn(), is(false));
+                        assertThat(ev.isInformation(), is(false));
+                        assertThat(ev.isDebug(), is(true));
+                    });
+        }
     }
 
     @Test(timeout = 1000)
-    public void testEventHandshakeFailedAuth()
+    public void testEventListening() throws IOException, ExecutionException, InterruptedException
     {
-        ZMQ.Event ev = make((s, a) -> s.eventHandshakeFailedAuth(a, 200), zmq.ZMQ.ZMQ_EVENT_HANDSHAKE_FAILED_AUTH);
-        int statusCode = ev.resolveValue();
-        assertThat(statusCode, is(200));
+        try (SelectableChannel sc = SocketChannel.open()) {
+            doTest((s, a) -> s.eventListening(a, sc),
+                    zmq.ZMQ.ZMQ_EVENT_LISTENING,
+                    ev -> {
+                        Object value = ev.getValue();
+                        assertThat(value, is(sc));
+                        assertThat(ev.isError(), is(false));
+                        assertThat(ev.isWarn(), is(false));
+                        assertThat(ev.isInformation(), is(false));
+                        assertThat(ev.isDebug(), is(true));
+                    });
+        }
+    }
+
+    @Test(timeout = 1000)
+    public void testEventConnected() throws IOException, ExecutionException, InterruptedException
+    {
+        try (SelectableChannel sc = SocketChannel.open()) {
+            doTest((s, a) -> s.eventConnected(a, sc),
+                    zmq.ZMQ.ZMQ_EVENT_CONNECTED,
+                    ev -> {
+                        Object value = ev.getValue();
+                        assertThat(value, is(sc));
+                        assertThat(ev.isError(), is(false));
+                        assertThat(ev.isWarn(), is(false));
+                        assertThat(ev.isInformation(), is(false));
+                        assertThat(ev.isDebug(), is(true));
+                    });
+        }
+    }
+
+    @Test(timeout = 1000)
+    public void testEventAccepted() throws IOException, ExecutionException, InterruptedException
+    {
+        try (SelectableChannel sc = SocketChannel.open()) {
+            doTest((s, a) -> s.eventAccepted(a, sc),
+                    zmq.ZMQ.ZMQ_EVENT_ACCEPTED,
+                    ev -> {
+                        Object value = ev.getValue();
+                        assertThat(value, is(sc));
+                        assertThat(ev.isError(), is(false));
+                        assertThat(ev.isWarn(), is(false));
+                        assertThat(ev.isInformation(), is(false));
+                        assertThat(ev.isDebug(), is(true));
+                    });
+        }
+    }
+
+    @Test(timeout = 1000)
+    public void testEventConnectDelayed() throws ExecutionException, InterruptedException, IOException
+    {
+        doTest((s, a) -> s.eventConnectDelayed(a, -1),
+                zmq.ZMQ.ZMQ_EVENT_CONNECT_DELAYED,
+                ev -> {
+                    Object value = ev.getValue();
+                    assertThat(value, is(Error.NOERROR));
+                    assertThat(ev.isError(), is(false));
+                    assertThat(ev.isWarn(), is(false));
+                    assertThat(ev.isInformation(), is(false));
+                    assertThat(ev.isDebug(), is(true));
+                });
+    }
+
+    @Test(timeout = 1000)
+    public void testEventConnectRetried() throws ExecutionException, InterruptedException, IOException
+    {
+        doTest((s, a) -> s.eventConnectRetried(a, 10),
+                zmq.ZMQ.ZMQ_EVENT_CONNECT_RETRIED,
+                ev -> {
+                    Object value = ev.getValue();
+                    assertThat(value, is(Duration.ofMillis(10)));
+                    assertThat(ev.isError(), is(false));
+                    assertThat(ev.isWarn(), is(false));
+                    assertThat(ev.isInformation(), is(false));
+                    assertThat(ev.isDebug(), is(true));
+                });
+    }
+
+    @Test(timeout = 1000)
+    public void testEventCloseFailed() throws ExecutionException, InterruptedException, IOException
+    {
+        doTest((s, a) -> s.eventCloseFailed(a, Error.EINTR.getCode()),
+                zmq.ZMQ.ZMQ_EVENT_CLOSE_FAILED,
+                ev -> {
+                    Error err = ev.getValue();
+                    assertThat(err, is(Error.EINTR));
+                    assertThat(ev.isError(), is(true));
+                    assertThat(ev.isWarn(), is(false));
+                    assertThat(ev.isInformation(), is(false));
+                    assertThat(ev.isDebug(), is(false));
+                });
+     }
+
+    @Test(timeout = 1000)
+    public void testEventAcceptFailed() throws ExecutionException, InterruptedException, IOException
+    {
+        doTest((s, a) -> s.eventAcceptFailed(a, Error.EINTR.getCode()),
+                zmq.ZMQ.ZMQ_EVENT_ACCEPT_FAILED,
+                ev -> {
+                    Error err = ev.getValue();
+                    assertThat(err, is(Error.EINTR));
+                    assertThat(ev.isError(), is(true));
+                    assertThat(ev.isWarn(), is(false));
+                    assertThat(ev.isInformation(), is(false));
+                    assertThat(ev.isDebug(), is(false));
+                });
+    }
+
+    @Test(timeout = 1000)
+    public void testEventBindFailed() throws ExecutionException, InterruptedException, IOException
+    {
+        doTest((s, a) -> s.eventBindFailed(a, Error.EADDRNOTAVAIL.getCode()),
+                zmq.ZMQ.ZMQ_EVENT_BIND_FAILED,
+                ev -> {
+                    Error err = ev.getValue();
+                    assertThat(err, is(Error.EADDRNOTAVAIL));
+                    assertThat(ev.isError(), is(true));
+                    assertThat(ev.isWarn(), is(false));
+                    assertThat(ev.isInformation(), is(false));
+                    assertThat(ev.isDebug(), is(false));
+                });
+    }
+
+    @Test(timeout = 1000)
+    public void testEventHandshaken() throws ExecutionException, InterruptedException, IOException
+    {
+        doTest((s, a) -> s.eventHandshaken(a, -1),
+                zmq.ZMQ.ZMQ_EVENT_HANDSHAKE_PROTOCOL,
+                ev -> {
+                    int zmtp = ev.getValue();
+                    assertThat(zmtp, is(-1));
+                    assertThat(ev.isError(), is(false));
+                    assertThat(ev.isWarn(), is(false));
+                    assertThat(ev.isInformation(), is(false));
+                    assertThat(ev.isDebug(), is(true));
+                });
+    }
+
+    @Test(timeout = 1000)
+    public void testEventHandshakeSucceeded() throws ExecutionException, InterruptedException, IOException
+    {
+        doTest((s, a) -> s.eventHandshakeSucceeded(a, 0),
+                zmq.ZMQ.ZMQ_EVENT_HANDSHAKE_SUCCEEDED,
+                ev -> {
+                    Error err = ev.getValue();
+                    assertThat(err, is(Error.NOERROR));
+                    assertThat(ev.isError(), is(false));
+                    assertThat(ev.isWarn(), is(false));
+                    assertThat(ev.isInformation(), is(false));
+                    assertThat(ev.isDebug(), is(true));
+                });
+    }
+
+    @Test(timeout = 1000)
+    public void testEventHandshakeFailedNoDetail() throws ExecutionException, InterruptedException, IOException
+    {
+        doTest((s, a) -> s.eventHandshakeFailedNoDetail(a, Error.EFAULT.getCode()),
+                zmq.ZMQ.ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL,
+                ev -> {
+                    Error err = ev.getValue();
+                    assertThat(err, is(Error.EFAULT));
+                    assertThat(ev.isError(), is(true));
+                    assertThat(ev.isWarn(), is(false));
+                    assertThat(ev.isInformation(), is(false));
+                    assertThat(ev.isDebug(), is(false));
+                });
+    }
+
+    @Test(timeout = 1000)
+    public void testMonitorStop() throws ExecutionException, InterruptedException
+    {
+        CompletableFuture<ZEvent> eventFuture = new CompletableFuture<>();
+        try (ZContext zctx = new ZContext(1);
+             ZMQ.Socket s = zctx.createSocket(SocketType.PUB)) {
+            s.setEventHook(eventFuture::complete, zmq.ZMQ.ZMQ_EVENT_MONITOR_STOPPED);
+        }
+        ZEvent ev = eventFuture.get();
+        assertThat(ev.getEvent(), is(ZMonitor.Event.MONITOR_STOPPED));
         assertThat(ev.isError(), is(false));
-        assertThat(ev.isWarn(), is(true));
-    }
-
-    @Test(timeout = 1000)
-    public void testEventDisconnected() throws IOException
-    {
-        SelectableChannel sc = SocketChannel.open();
-        ZMQ.Event ev = make((s, a) -> s.eventDisconnected(a, sc), zmq.ZMQ.ZMQ_EVENT_DISCONNECTED);
-        Object value = ev.resolveValue();
-        assertThat(value, is(sc));
-        assertThat(ev.isError(), is(false));
         assertThat(ev.isWarn(), is(false));
-    }
-
-    @Test(timeout = 1000)
-    public void testEventClosed() throws IOException
-    {
-        SelectableChannel sc = SocketChannel.open();
-        ZMQ.Event ev = make((s, a) -> s.eventClosed(a, sc), zmq.ZMQ.ZMQ_EVENT_CLOSED);
-        Object value = ev.resolveValue();
-        assertThat(value, is(sc));
-        assertThat(ev.isError(), is(false));
-        assertThat(ev.isWarn(), is(false));
-    }
-
-    @Test(timeout = 1000)
-    public void testEventListening() throws IOException
-    {
-        SelectableChannel sc = SocketChannel.open();
-        ZMQ.Event ev = make((s, a) -> s.eventListening(a, sc), zmq.ZMQ.ZMQ_EVENT_LISTENING);
-        Object value = ev.resolveValue();
-        assertThat(value, is(sc));
-        assertThat(ev.isError(), is(false));
-        assertThat(ev.isWarn(), is(false));
-    }
-
-    @Test(timeout = 1000)
-    public void testEventConnected() throws IOException
-    {
-        SelectableChannel sc = SocketChannel.open();
-        ZMQ.Event ev = make((s, a) -> s.eventConnected(a, sc), zmq.ZMQ.ZMQ_EVENT_CONNECTED);
-        Object value = ev.resolveValue();
-        assertThat(value, is(sc));
-        assertThat(ev.isError(), is(false));
-        assertThat(ev.isWarn(), is(false));
-    }
-
-    @Test(timeout = 1000)
-    public void testEventAccepted() throws IOException
-    {
-        SelectableChannel sc = SocketChannel.open();
-        ZMQ.Event ev = make((s, a) -> s.eventAccepted(a, sc), zmq.ZMQ.ZMQ_EVENT_ACCEPTED);
-        Object value = ev.resolveValue();
-        assertThat(value, is(sc));
-        assertThat(ev.isError(), is(false));
-        assertThat(ev.isWarn(), is(false));
-    }
-
-    @Test(timeout = 1000)
-    public void testEventConnectDelayed()
-    {
-        ZMQ.Event ev = make((s, a) -> s.eventConnectDelayed(a, -1), zmq.ZMQ.ZMQ_EVENT_CONNECT_DELAYED);
-        Object value = ev.resolveValue();
-        assertThat(value, nullValue());
-        assertThat(ev.isError(), is(false));
-        assertThat(ev.isWarn(), is(false));
-    }
-
-    @Test(timeout = 1000)
-    public void testEventConnectRetried()
-    {
-        ZMQ.Event ev = make((s, a) -> s.eventConnectRetried(a, 10), zmq.ZMQ.ZMQ_EVENT_CONNECT_RETRIED);
-        Object value = ev.resolveValue();
-        assertThat(value, is(10));
-        assertThat(ev.isError(), is(false));
-        assertThat(ev.isWarn(), is(false));
-    }
-
-    @Test(timeout = 1000)
-    public void testEventCloseFailed()
-    {
-        ZMQ.Event ev = make((s, a) -> s.eventCloseFailed(a, Error.EINTR.getCode()), zmq.ZMQ.ZMQ_EVENT_CLOSE_FAILED);
-        Error err = ev.resolveValue();
-        assertThat(err, is(Error.EINTR));
-        assertThat(ev.isError(), is(true));
-        assertThat(ev.isWarn(), is(false));
-    }
-
-    @Test(timeout = 1000)
-    public void testEventAcceptFailed()
-    {
-        ZMQ.Event ev = make((s, a) -> s.eventAcceptFailed(a, Error.EINTR.getCode()), zmq.ZMQ.ZMQ_EVENT_ACCEPT_FAILED);
-        Error err = ev.resolveValue();
-        assertThat(err, is(Error.EINTR));
-        assertThat(ev.isError(), is(true));
-        assertThat(ev.isWarn(), is(false));
-    }
-
-    @Test(timeout = 1000)
-    public void testEventBindFailed()
-    {
-        ZMQ.Event ev = make((s, a) -> s.eventBindFailed(a, Error.EADDRNOTAVAIL.getCode()), zmq.ZMQ.ZMQ_EVENT_BIND_FAILED);
-        Error err = ev.resolveValue();
-        assertThat(err, is(Error.EADDRNOTAVAIL));
-        assertThat(ev.isError(), is(true));
-        assertThat(ev.isWarn(), is(false));
-    }
-
-    @Test(timeout = 1000)
-    public void testEventHandshaken()
-    {
-        ZMQ.Event ev = make((s, a) -> s.eventHandshaken(a, -1), zmq.ZMQ.ZMQ_EVENT_HANDSHAKE_PROTOCOL);
-        int zmtp = ev.resolveValue();
-        assertThat(zmtp, is(-1));
-        assertThat(ev.isError(), is(false));
-        assertThat(ev.isWarn(), is(false));
-    }
-
-    @Test(timeout = 1000)
-    public void testEventHandshakeSucceeded()
-    {
-        ZMQ.Event ev = make((s, a) -> s.eventHandshakeSucceeded(a, 0), zmq.ZMQ.ZMQ_EVENT_HANDSHAKE_SUCCEEDED);
-        Object value = ev.resolveValue();
-        assertThat(value, nullValue());
-        assertThat(ev.isError(), is(false));
-        assertThat(ev.isWarn(), is(false));
-    }
-
-    @Test(timeout = 1000)
-    public void testEventHandshakeFailedNoDetail()
-    {
-        ZMQ.Event ev = make((s, a) -> s.eventHandshakeFailedNoDetail(a, Error.EFAULT.getCode()), zmq.ZMQ.ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL);
-        Error err = ev.resolveValue();
-        assertThat(err, is(Error.EFAULT));
-        assertThat(ev.isError(), is(true));
-        assertThat(ev.isWarn(), is(false));
+        assertThat(ev.isInformation(), is(false));
+        assertThat(ev.isDebug(), is(true));
     }
 }

--- a/src/test/java/org/zeromq/TestEvents.java
+++ b/src/test/java/org/zeromq/TestEvents.java
@@ -1,49 +1,65 @@
 package org.zeromq;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 
 import org.junit.Test;
 import org.zeromq.ZMQ.Context;
 import org.zeromq.ZMQ.Socket;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 public class TestEvents
 {
     @Test
+    public void testEventConnectedContext()
+    {
+        try (Context context = new Context(1);
+             Socket helper = context.socket(SocketType.REQ);
+             Socket socket = context.socket(SocketType.REP);
+             Socket monitor = context.socket(SocketType.PAIR)
+        ) {
+            int port = helper.bindToRandomPort("tcp://127.0.0.1");
+
+            monitor.setReceiveTimeOut(100);
+
+            assertTrue(socket.monitor("inproc://monitor.socket", ZMQ.EVENT_CONNECTED));
+            monitor.connect("inproc://monitor.socket");
+
+            socket.connect("tcp://127.0.0.1:" + port);
+            ZMQ.Event event = ZMQ.Event.recv(monitor);
+            assertNotNull("No event was received", event);
+            assertEquals(ZMQ.EVENT_CONNECTED, event.getEvent());
+        }
+    }
+
+    @Test
     public void testEventConnected()
     {
-        Context context = ZMQ.context(1);
-        ZMQ.Event event;
+        try (ZContext context = new ZContext(1);
+            Socket helper = context.createSocket(SocketType.REQ);
+            Socket socket = context.createSocket(SocketType.REP);
+            Socket monitor = context.createSocket(SocketType.PAIR)
+        ) {
+            int port = helper.bindToRandomPort("tcp://127.0.0.1");
 
-        Socket helper = context.socket(SocketType.REQ);
-        int port = helper.bindToRandomPort("tcp://127.0.0.1");
+            monitor.setReceiveTimeOut(100);
 
-        Socket socket = context.socket(SocketType.REP);
-        Socket monitor = context.socket(SocketType.PAIR);
-        monitor.setReceiveTimeOut(100);
+            assertTrue(socket.monitor("inproc://monitor.socket", ZMQ.EVENT_CONNECTED));
+            monitor.connect("inproc://monitor.socket");
 
-        assertTrue(socket.monitor("inproc://monitor.socket", ZMQ.EVENT_CONNECTED));
-        monitor.connect("inproc://monitor.socket");
-
-        socket.connect("tcp://127.0.0.1:" + port);
-        event = ZMQ.Event.recv(monitor);
-        assertNotNull("No event was received", event);
-        assertEquals(ZMQ.EVENT_CONNECTED, event.getEvent());
-
-        helper.close();
-        socket.close();
-        monitor.close();
-        context.term();
+            socket.connect("tcp://127.0.0.1:" + port);
+            ZMQ.Event event = ZMQ.Event.recv(monitor);
+            assertNotNull("No event was received", event);
+            assertEquals(ZMQ.EVENT_CONNECTED, event.getEvent());
+        }
     }
 
     @Test
     public void testEventConnectDelayed() throws IOException
     {
         Context context = ZMQ.context(1);
-        ZMQ.Event event;
 
         Socket socket = context.socket(SocketType.REP);
         Socket monitor = context.socket(SocketType.PAIR);
@@ -55,7 +71,7 @@ public class TestEvents
         int randomPort = Utils.findOpenPort();
 
         socket.connect("tcp://127.0.0.1:" + randomPort);
-        event = ZMQ.Event.recv(monitor);
+        ZMQ.Event event = ZMQ.Event.recv(monitor);
         assertNotNull("No event was received", event);
         assertEquals(ZMQ.EVENT_CONNECT_DELAYED, event.getEvent());
 
@@ -93,93 +109,77 @@ public class TestEvents
     @Test
     public void testEventListening()
     {
-        Context context = ZMQ.context(1);
-        ZMQ.Event event;
+        try (ZContext context = new ZContext(1);
+                Socket socket = context.createSocket(SocketType.REP);
+                Socket monitor = context.createSocket(SocketType.PAIR)
+        ) {
+            monitor.setReceiveTimeOut(100);
 
-        Socket socket = context.socket(SocketType.REP);
-        Socket monitor = context.socket(SocketType.PAIR);
-        monitor.setReceiveTimeOut(100);
+            assertTrue(socket.monitor("inproc://monitor.socket", ZMQ.EVENT_LISTENING));
+            monitor.connect("inproc://monitor.socket");
 
-        assertTrue(socket.monitor("inproc://monitor.socket", ZMQ.EVENT_LISTENING));
-        monitor.connect("inproc://monitor.socket");
-
-        socket.bindToRandomPort("tcp://127.0.0.1");
-        event = ZMQ.Event.recv(monitor);
-        assertNotNull("No event was received", event);
-        assertEquals(ZMQ.EVENT_LISTENING, event.getEvent());
-
-        socket.close();
-        monitor.close();
-        context.term();
+            socket.bindToRandomPort("tcp://127.0.0.1");
+            ZMQ.Event event = ZMQ.Event.recv(monitor);
+            assertNotNull("No event was received", event);
+            assertEquals(ZMQ.EVENT_LISTENING, event.getEvent());
+        }
     }
 
     @Test
     public void testEventBindFailed()
     {
-        Context context = ZMQ.context(1);
-        ZMQ.Event event;
+        try (ZContext context = new ZContext(1);
+                Socket helper = context.createSocket(SocketType.REP);
+                Socket socket = context.createSocket(SocketType.REP);
+                Socket monitor = context.createSocket(SocketType.PAIR)
+        ) {
+            ZMQ.Event event;
 
-        Socket helper = context.socket(SocketType.REP);
-        int port = helper.bindToRandomPort("tcp://127.0.0.1");
+            int port = helper.bindToRandomPort("tcp://127.0.0.1");
+            monitor.setReceiveTimeOut(100);
 
-        Socket socket = context.socket(SocketType.REP);
-        Socket monitor = context.socket(SocketType.PAIR);
-        monitor.setReceiveTimeOut(100);
+            assertTrue(socket.monitor("inproc://monitor.socket", ZMQ.EVENT_BIND_FAILED));
+            monitor.connect("inproc://monitor.socket");
 
-        assertTrue(socket.monitor("inproc://monitor.socket", ZMQ.EVENT_BIND_FAILED));
-        monitor.connect("inproc://monitor.socket");
-
-        try {
             socket.bind("tcp://127.0.0.1:" + port);
+            event = ZMQ.Event.recv(monitor);
+            assertNotNull("No event was received", event);
+            assertEquals(ZMQ.EVENT_BIND_FAILED, event.getEvent());
         }
-        catch (ZMQException ex) {
-        }
-        event = ZMQ.Event.recv(monitor);
-        assertNotNull("No event was received", event);
-        assertEquals(ZMQ.EVENT_BIND_FAILED, event.getEvent());
-
-        helper.close();
-        socket.close();
-        monitor.close();
-        context.term();
     }
 
     @Test
     public void testEventAccepted()
     {
-        Context context = ZMQ.context(1);
-        ZMQ.Event event;
+        try (ZContext context = new ZContext(1);
+                Socket helper = context.createSocket(SocketType.REP);
+                Socket socket = context.createSocket(SocketType.REP);
+                Socket monitor = context.createSocket(SocketType.PAIR)
+        ) {
+            ZMQ.Event event;
+            monitor.setReceiveTimeOut(100);
 
-        Socket socket = context.socket(SocketType.REP);
-        Socket monitor = context.socket(SocketType.PAIR);
-        Socket helper = context.socket(SocketType.REQ);
-        monitor.setReceiveTimeOut(100);
+            assertTrue(socket.monitor("inproc://monitor.socket", ZMQ.EVENT_ACCEPTED));
+            monitor.connect("inproc://monitor.socket");
 
-        assertTrue(socket.monitor("inproc://monitor.socket", ZMQ.EVENT_ACCEPTED));
-        monitor.connect("inproc://monitor.socket");
+            int port = socket.bindToRandomPort("tcp://127.0.0.1");
 
-        int port = socket.bindToRandomPort("tcp://127.0.0.1");
-
-        helper.connect("tcp://127.0.0.1:" + port);
-        event = ZMQ.Event.recv(monitor);
-        assertNotNull("No event was received", event);
-        assertEquals(ZMQ.EVENT_ACCEPTED, event.getEvent());
-
-        helper.close();
-        socket.close();
-        monitor.close();
-        context.term();
+            helper.connect("tcp://127.0.0.1:" + port);
+            event = ZMQ.Event.recv(monitor);
+            assertNotNull("No event was received", event);
+            assertEquals(ZMQ.EVENT_ACCEPTED, event.getEvent());
+        }
     }
 
     @Test
     public void testEventClosed()
     {
-        Context context = ZMQ.context(1);
-        Socket monitor = context.socket(SocketType.PAIR);
-        try {
+        try (ZContext context = new ZContext(1);
+             Socket monitor = context.createSocket(SocketType.PAIR)
+        ) {
             ZMQ.Event event;
 
-            Socket socket = context.socket(SocketType.REP);
+            Socket socket = context.createSocket(SocketType.REP);
             monitor.setReceiveTimeOut(100);
 
             socket.bindToRandomPort("tcp://127.0.0.1");
@@ -193,39 +193,32 @@ public class TestEvents
             assertEquals(ZMQ.EVENT_CLOSED, event.getEvent());
 
         }
-        finally {
-            monitor.close();
-            context.term();
-        }
     }
 
     @Test
     public void testEventDisconnected()
     {
-        Context context = ZMQ.context(1);
-        ZMQ.Event event;
+        try (ZContext context = new ZContext(1);
+             Socket socket = context.createSocket(SocketType.REP);
+             Socket monitor = context.createSocket(SocketType.PAIR);
+             Socket helper = context.createSocket(SocketType.REQ)
+        ) {
+            ZMQ.Event event;
+            monitor.setReceiveTimeOut(100);
 
-        Socket socket = context.socket(SocketType.REP);
-        Socket monitor = context.socket(SocketType.PAIR);
-        Socket helper = context.socket(SocketType.REQ);
-        monitor.setReceiveTimeOut(100);
+            int port = socket.bindToRandomPort("tcp://127.0.0.1");
+            helper.connect("tcp://127.0.0.1:" + port);
 
-        int port = socket.bindToRandomPort("tcp://127.0.0.1");
-        helper.connect("tcp://127.0.0.1:" + port);
+            assertTrue(socket.monitor("inproc://monitor.socket", ZMQ.EVENT_DISCONNECTED));
+            monitor.connect("inproc://monitor.socket");
 
-        assertTrue(socket.monitor("inproc://monitor.socket", ZMQ.EVENT_DISCONNECTED));
-        monitor.connect("inproc://monitor.socket");
+            zmq.ZMQ.sleep(1);
 
-        zmq.ZMQ.sleep(1);
-
-        helper.close();
-        event = ZMQ.Event.recv(monitor);
-        assertNotNull("No event was received", event);
-        assertEquals(ZMQ.EVENT_DISCONNECTED, event.getEvent());
-
-        socket.close();
-        monitor.close();
-        context.term();
+            helper.close();
+            event = ZMQ.Event.recv(monitor);
+            assertNotNull("No event was received", event);
+            assertEquals(ZMQ.EVENT_DISCONNECTED, event.getEvent());
+        }
     }
 
     @Test

--- a/src/test/java/zmq/TestMonitor.java
+++ b/src/test/java/zmq/TestMonitor.java
@@ -250,7 +250,7 @@ public class TestMonitor
         CountDownLatch listeningLatch = new CountDownLatch(1);
         CountDownLatch closedLatch = new CountDownLatch(1);
         CountDownLatch stoppedLatch = new CountDownLatch(1);
-        boolean rc = rep.monitor(e -> {
+        boolean rc = rep.setEventHook(e -> {
             switch (e.event) {
             case ZMQ.ZMQ_EVENT_LISTENING:
                 assertThat(Thread.currentThread().getName(), is("Time-limited test"));
@@ -289,17 +289,16 @@ public class TestMonitor
         assertThat(ctx, notNullValue());
         SocketBase rep = ZMQ.socket(ctx, ZMQ.ZMQ_REP);
         assertThat(rep, notNullValue());
-        boolean rc = rep.monitor(e -> {
+        boolean rc = rep.setEventHook(e -> {
             assertThat(e.event, is(ZMQ.ZMQ_EVENT_MONITOR_STOPPED));
             assertThat(Thread.currentThread().getName(), is("Time-limited test"));
         }, ZMQ.ZMQ_EVENT_ALL);
         assertThat(rc, is(true));
-        rc = rep.monitor((String) null, ZMQ.ZMQ_EVENT_ALL);
+        rc = rep.monitor(null, ZMQ.ZMQ_EVENT_ALL);
         assertThat(rc, is(true));
         rc = ZMQ.bind(rep, addr);
         assertThat(rc, is(true));
         rep.close();
-        assertThat(rc, is(true));
         ctx.terminate();
     }
 }


### PR DESCRIPTION
Renaming zmq.SocketBase#monitor to zmq.SocketBase#setEventHook, to avoid
ambiguity with socket.monitor(null, events).

Adding a new org.zeromq.ZEvent, that provides a cleaner non compatible
implementation.

Adding org.zeromq.ZMQ.Socket#setEventHook, to provides an high level API
to handle events.
