### PR TITLE
Peer socket should be allow to receive hiccup message

### DIFF
--- a/src/main/java/zmq/socket/Peer.java
+++ b/src/main/java/zmq/socket/Peer.java
@@ -14,6 +14,7 @@ public class Peer extends Server
         options.type = ZMQ.ZMQ_PEER;
         options.canSendHelloMsg = true;
         options.canReceiveDisconnectMsg = true;
+        options.canReceiveHiccupMsg = true;
     }
 
     @Override


### PR DESCRIPTION
Because peer socket behave both like client (and server), it should be allowed, like client, to receive a hiccup message.

When a peer socket is the initiator of the connection (calling socket.connect), it should know when there is a disconnect in the connection, just like client.