### PR TITLE
mark Ctx `terminating` flag volatile

### DIFF
--- a/src/main/java/zmq/Ctx.java
+++ b/src/main/java/zmq/Ctx.java
@@ -96,7 +96,7 @@ public class Ctx
     private final AtomicBoolean starting = new AtomicBoolean(true);
 
     //  If true, zmq_term was already called.
-    private boolean terminating;
+    private volatile boolean terminating;
 
     //  Synchronization of accesses to global slot-related data:
     //  sockets, emptySlots, terminating. It also synchronizes


### PR DESCRIPTION
I've seen issues where calling `Ctx.terminate()` can hang. It likely traces back to this flag not being marked `volatile`, so that when the reaper thread reaps the last socket, it fails to read the updated value for `terminating`, making it so that [this line](https://github.com/smacke/jeromq/blob/573f3d2f9424b2b4a02f27547610c4c9c013c01e/src/main/java/zmq/Ctx.java#L311) blocks forever.