### PR TITLE
Add JPMS module descriptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,10 @@
     <developerConnection>scm:git:git@github.com:zeromq/jeromq.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
-  <developers>
-    <developer />
-  </developers>
+  <developers/>
   <properties>
+    <!-- Required by reproducible builds: https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
+    <project.build.outputTimestamp>0</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jdk.target>8</jdk.target>
     <!-- Indirection needed to keep optional jacoco settings and external argument lines-->
@@ -87,33 +87,28 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-            <manifestEntries>
-              <Automatic-Module-Name>${groupId}.${artifactId}</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <version>6.4.0</version>
         <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Export-Package>*</Export-Package>
-          </instructions>
-        </configuration>
         <executions>
           <execution>
-            <id>bundle-manifest</id>
-            <phase>process-classes</phase>
+            <id>default-jar</id>
             <goals>
-              <goal>manifest</goal>
+              <goal>jar</goal>
             </goals>
+            <configuration>
+              <bnd>
+                Bundle-SymbolicName: $[project.groupId].$[project.artifactId]
+                Export-Package: \
+                  zmq.*, \
+                  org.zeromq.*
+                Import-Package: \
+                  com.neilalexander.*;resolution:=optional, \
+                  *
+                -jpms-module-info: $[Bundle-SymbolicName];access=0
+              </bnd>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Replaces `maven-bundle-plugin` with the more up-to-date `bnd-maven-plugin` and configures it to generate a JPMS module descriptor besides the OSGi descriptor. The descriptor can be generated even using JDK 8 (cf. [documentation](https://bnd.bndtools.org/chapters/330-jpms.html)).

Decompiling the generated descriptor we obtain:
```
org.zeromq.jeromq@0.6.0.SNAPSHOT jar:file:///home/piotr/workspace/jeromq/target/jeromq-0.6.0-SNAPSHOT.jar!/module-info.class
exports org.zeromq
exports org.zeromq.proto
exports org.zeromq.timer
exports org.zeromq.util
exports zmq
exports zmq.io
exports zmq.io.coder
exports zmq.io.coder.raw
exports zmq.io.coder.v1
exports zmq.io.coder.v2
exports zmq.io.mechanism
exports zmq.io.mechanism.curve
exports zmq.io.mechanism.gssapi
exports zmq.io.mechanism.plain
exports zmq.io.net
exports zmq.io.net.ipc
exports zmq.io.net.norm
exports zmq.io.net.pgm
exports zmq.io.net.tcp
exports zmq.io.net.tipc
exports zmq.msg
exports zmq.pipe
exports zmq.poll
exports zmq.socket
exports zmq.socket.clientserver
exports zmq.socket.pipeline
exports zmq.socket.pubsub
exports zmq.socket.radiodish
exports zmq.socket.reqrep
exports zmq.socket.scattergather
exports zmq.util
exports zmq.util.function
requires java.base
requires jnacl static
```

The generated descriptor contains one filebased module name (`jnacl`), but it is an optional module, so this should not cause problems.

I submitted a similar PR to `jnacl` (neilalexander/jnacl#24). If that PR is accepted and the `jnacl` dependency is updated, BND should switch to the proposed module name `eu.neilalexander.jnacl`.

Closes #591.