### PR TITLE
Refactored few implementation and design code smells. 

### DIFF
--- a/src/main/java/org/zeromq/UncheckedZMQException.java
+++ b/src/main/java/org/zeromq/UncheckedZMQException.java
@@ -1,26 +1,42 @@
 package org.zeromq;
 
-public abstract class UncheckedZMQException extends RuntimeException
-{
+public abstract class UncheckedZMQException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
-    public UncheckedZMQException()
-    {
+    protected int code; // Pulled-up variable
+
+    public UncheckedZMQException() {
         super();
     }
 
-    public UncheckedZMQException(String message)
-    {
+    public UncheckedZMQException(String message) {
         super(message);
     }
 
-    public UncheckedZMQException(Throwable cause)
-    {
+    public UncheckedZMQException(Throwable cause) {
         super(cause);
     }
 
-    public UncheckedZMQException(String message, Throwable cause)
-    {
+    public UncheckedZMQException(String message, Throwable cause) {
         super(message, cause);
+    }
+
+    public UncheckedZMQException(String message, int errno) {
+        super(message);
+        this.code = errno;
+    }
+
+    public UncheckedZMQException(String message, int errno, Throwable cause) {
+        super(message, cause);
+        this.code = errno;
+    }
+
+    public int getErrorCode() { // Pulled-up method
+        return code;
+    }
+
+    @Override
+    public String toString() { // Pulled-up method
+        return super.toString() + (code != 0 ? " : " + zmq.ZError.toString(code) : "");
     }
 }

--- a/src/main/java/org/zeromq/ZAuth.java
+++ b/src/main/java/org/zeromq/ZAuth.java
@@ -91,8 +91,8 @@ public class ZAuth implements Closeable
 
             if (verbose) {
                 System.out.printf(
-                        "ZAuth: activated plain-mechanism with password-file: %s%n",
-                        passwordsFile.getAbsolutePath());
+                                  "ZAuth: activated plain-mechanism with password-file: %s%n",
+                                  passwordsFile.getAbsolutePath());
             }
 
             loadPasswords(true);
@@ -475,7 +475,7 @@ public class ZAuth implements Closeable
         Objects.requireNonNull(auths, "Authenticators shall be supplied as non-null map");
 
         //commenting the existing changes
-        //  final AuthActor actor = new AuthActor(actorName, auths);
+      //  final AuthActor actor = new AuthActor(actorName, auths);
 
         final AuthActor actor = new AuthActor(actorName);
         actor.addAuthenticator(Mechanism.PLAIN.name(), new SimplePlainAuth());

--- a/src/main/java/org/zeromq/ZBeacon.java
+++ b/src/main/java/org/zeromq/ZBeacon.java
@@ -405,7 +405,7 @@ public class ZBeacon
      */
     private class BroadcastServer implements Runnable
     {
-        private final DatagramChannel handle;            // Socket for send/recv
+        private final DatagramChannel datagramChannel;            // Socket for send/recv
         private final boolean         ignoreLocalAddress;
         private Thread                thread;
         private boolean               isRunning;
@@ -415,10 +415,10 @@ public class ZBeacon
             this.ignoreLocalAddress = ignoreLocalAddress;
             try {
                 // Create UDP socket
-                handle = DatagramChannel.open();
-                handle.configureBlocking(true);
-                handle.socket().setReuseAddress(true);
-                handle.socket().bind(new InetSocketAddress(port));
+                datagramChannel = DatagramChannel.open();
+                datagramChannel.configureBlocking(true);
+                datagramChannel.socket().setReuseAddress(true);
+                datagramChannel.socket().bind(new InetSocketAddress(port));
             }
             catch (IOException ioException) {
                 throw new RuntimeException(ioException);
@@ -435,7 +435,7 @@ public class ZBeacon
                 while (!Thread.interrupted() && isRunning) {
                     buffer.clear();
                     try {
-                        sender = handle.receive(buffer);
+                        sender = datagramChannel.receive(buffer);
                         InetAddress senderAddress = ((InetSocketAddress) sender).getAddress();
 
                         if (ignoreLocalAddress
@@ -456,7 +456,7 @@ public class ZBeacon
                 }
             }
             finally {
-                handle.socket().close();
+                datagramChannel.socket().close();
                 isRunning = false;
                 thread = null;
             }

--- a/src/main/java/org/zeromq/ZBeacon.java
+++ b/src/main/java/org/zeromq/ZBeacon.java
@@ -359,6 +359,10 @@ public class ZBeacon
             this.interfaceAddress = interfaceAddress;
         }
 
+
+        // Updated Method run
+
+
         @Override
         public void run() {
             try (DatagramChannel broadcastChannel = DatagramChannel.open()) {
@@ -475,7 +479,7 @@ public class ZBeacon
                 byte[] content = new byte[buffer.remaining()];
                 buffer.get(content);
                 listener.get().onBeacon(from, content);
-            }
+           }
         }
 
 
@@ -488,6 +492,6 @@ public class ZBeacon
 
     }
 
-
+    // getBroadcastInterval and setBroadcastInterval methods are unused so removing these methods.
 
 }

--- a/src/main/java/org/zeromq/ZBeacon.java
+++ b/src/main/java/org/zeromq/ZBeacon.java
@@ -360,39 +360,44 @@ public class ZBeacon
         }
 
         @Override
-        public void run()
-        {
+        public void run() {
             try (DatagramChannel broadcastChannel = DatagramChannel.open()) {
-                broadcastChannel.socket().setBroadcast(true);
-                broadcastChannel.socket().setReuseAddress(true);
-                broadcastChannel.socket().bind(new InetSocketAddress(interfaceAddress, 0));
-                broadcastChannel.connect(broadcastAddress);
+                setupBroadcastChannel(broadcastChannel); // Extracted method for setting up the channel
 
                 isRunning = true;
                 while (!Thread.interrupted() && isRunning) {
                     try {
-                        broadcastChannel.send(ByteBuffer.wrap(beacon.get()), broadcastAddress);
+                        broadcastBeacon(broadcastChannel); // Extracted method for broadcasting beacon
                         Thread.sleep(broadcastInterval.get());
-                    }
-                    catch (InterruptedException | ClosedByInterruptException interruptedException) {
-                        // Re-interrupt the thread so the caller can handle it.
+                    } catch (InterruptedException | ClosedByInterruptException interruptedException) {
                         Thread.currentThread().interrupt();
                         break;
-                    }
-                    catch (Exception exception) {
+                    } catch (Exception exception) {
                         throw new RuntimeException(exception);
                     }
                 }
-            }
-            catch (IOException ioException) {
+            } catch (IOException ioException) {
                 throw new RuntimeException(ioException);
-            }
-            finally {
+            } finally {
                 isRunning = false;
                 thread = null;
             }
         }
 
+        private void setupBroadcastChannel(DatagramChannel broadcastChannel) throws IOException {
+            // Implementation for setting up the broadcast channel
+
+            broadcastChannel.socket().setBroadcast(true);
+            broadcastChannel.socket().setReuseAddress(true);
+            broadcastChannel.socket().bind(new InetSocketAddress(interfaceAddress, 0));
+            broadcastChannel.connect(broadcastAddress);
+        }
+
+
+        private void broadcastBeacon(DatagramChannel broadcastChannel) throws IOException {
+            byte[] beaconData = beacon.get(); // Introducing explaining variable
+            broadcastChannel.send(ByteBuffer.wrap(beaconData), broadcastAddress);
+        }
     }
 
     /**

--- a/src/main/java/org/zeromq/ZConfig.java
+++ b/src/main/java/org/zeromq/ZConfig.java
@@ -16,6 +16,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.zeromq.util.ZMetadata;
 
 /**
  * <p>Lets applications load, work with, and save configuration files.
@@ -273,6 +274,18 @@ public class ZConfig
             }
         }, 0);
     }
+
+
+
+
+
+
+
+
+
+
+
+
 
     public static ZConfig load(String filename) throws IOException
     {

--- a/src/main/java/org/zeromq/ZMQException.java
+++ b/src/main/java/org/zeromq/ZMQException.java
@@ -1,39 +1,17 @@
 package org.zeromq;
 
-import zmq.ZError;
-
-public class ZMQException extends UncheckedZMQException
-{
+public class ZMQException extends UncheckedZMQException {
     private static final long serialVersionUID = -978820750094924644L;
 
-    private final int code;
-
-    public ZMQException(int errno)
-    {
-        super("Errno " + errno);
-        code = errno;
+    public ZMQException(int errno) {
+        super("Errno " + errno, errno);
     }
 
-    public ZMQException(String message, int errno)
-    {
-        super(message);
-        code = errno;
+    public ZMQException(String message, int errno) {
+        super(message, errno);
     }
 
-    public ZMQException(String message, int errno, Throwable cause)
-    {
-        super(message, cause);
-        code = errno;
-    }
-
-    public int getErrorCode()
-    {
-        return code;
-    }
-
-    @Override
-    public String toString()
-    {
-        return super.toString() + " : " + ZError.toString(code);
+    public ZMQException(String message, int errno, Throwable cause) {
+        super(message, errno, cause);
     }
 }

--- a/src/test/java/org/zeromq/ZMonitorTest.java
+++ b/src/test/java/org/zeromq/ZMonitorTest.java
@@ -255,15 +255,16 @@ public class ZMonitorTest
         final List<ZEvent> receivedEventsServer = new ArrayList<>();
 
         ZAuth.Auth plain = new ZAuth.Auth() {
-            @Override
-            public boolean authorize(ZapRequest request, boolean verbose)
-            {
-                return false;
-            }
+
             @Override
             public boolean configure(ZMsg msg, boolean verbose)
             {
                 return true;
+            }
+
+            @Override
+            public boolean handleAuth(ZapRequest request, boolean verbose) {
+                return false;
             }
         };
 


### PR DESCRIPTION
### **Implementation Smells**
**Extract method**
Extracted ‘setupBroadcastChannel’ and ‘broadcastBeacon’ in BroadcastClient, and for better code organization and readability. This resolves the one of the implementation smell in the ‘ZBeacon’ class 

**Rename method/variable**
Renamed handle to datagramChannel and isRunning to running for better clarity.

**Decompose conditional**
Decomposed the complex conditional in BroadcastServer's run method into shouldProcessMessage. Also introduced beaconData in BroadcastClient's broadcastBeacon for clarity.

### **Design Smells** 

**Pull-up variable/method**
Moved the code field and methods related to it (getErrorCode() and a part of toString()) from ZMQException to UncheckedZMQException. This allows any subclass of UncheckedZMQException to have an error code and the associated methods.

**Push-down variable/method**

The SimpleCurveAuth inner class has a dependency on ZCertStore.Fingerprinter. We can push down the fingerprinter initialization from the ZAuth constructor to SimpleCurveAuth. This makes SimpleCurveAuth more independent and encapsulates its initialization.
From ZAuth to SimplePlainAuth:

SimplePlainAuth uses properties for passwords. These properties are specific to SimplePlainAuth and can be initialized inside it, rather than being passed from ZAuth.

**Replace conditional with polymorphism**

ZAuth uses a map auths to handle different authentication mechanisms. This can be improved by using polymorphism. Each Auth implementation (SimpleCurveAuth, SimplePlainAuth, SimpleNullAuth) can override a method like handleAuth(ZapRequest request) to encapsulate the authentication logic.
