### PR TITLE
API 33

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,43 +108,6 @@ jobs:
             - store_test_results:
                 path: target/surefire-reports
             #don't persist_to_workspace, can't be done in parallel with testsj13
-    testsj8:
-        docker:
-            - image: cimg/openjdk:8.0
-        steps:
-            - attach_workspace:
-                at: /tmp/ws
-            - run:
-                command: |
-                    mv -n /tmp/ws/home/circleci/.m2 /home/circleci/
-                    mv -n /tmp/ws/home/circleci/.sonar /home/circleci/
-                    mv -n /tmp/ws/home/circleci/project/* /home/circleci/project/
-                    mv -n /tmp/ws/home/circleci/project/.??* /home/circleci/project/
-            - run:
-                command: |
-                    mvn -B test -Pskip -Darg.line="-Xmx2048m" -Djava.io.tmpdir="/tmp/$CIRCLE_JOB" -s .circleci/settings.xml
-                environment:
-                    MAVEN_OPTS: "-Xmx512m"
-            - store_test_results:
-                path: target/surefire-reports
-            #don't persist_to_workspace, can't be done in parallel with testsj13
-    testsandroid:
-        docker:
-            - image: cimg/openjdk:21.0
-        steps:
-            - attach_workspace:
-                at: /tmp/ws
-            - run:
-                command: |
-                    mv -n /tmp/ws/home/circleci/.m2 /home/circleci/
-                    mv -n /tmp/ws/home/circleci/.sonar /home/circleci/
-                    mv -n /tmp/ws/home/circleci/project/* /home/circleci/project/
-                    mv -n /tmp/ws/home/circleci/project/.??* /home/circleci/project/
-            - run:
-                command: |
-                    mvn -B test -Pskip,android -Darg.line="-Xmx2048m" -s .circleci/settings.xml -Dmaven.test.skip=true
-                environment:
-                    MAVEN_OPTS: "-Xmx2048m"
     publish:
         docker:
             - image: cimg/openjdk:21.0
@@ -206,9 +169,6 @@ workflows:
       - build:
           requires:
               - checkout
-      - testsj8:
-          requires:
-              - build
       - testsj11:
           requires:
               - build
@@ -218,16 +178,11 @@ workflows:
       - testsj21:
             requires:
                 - build
-      - testsandroid:
-          requires:
-              - build
       - publish:
           requires:
-              - testsj8
               - testsj11
               - testsj17
               - testsj21
-              - testsandroid
       - savecache:
           requires:
               - publish

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <!-- Required by reproducible builds: https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
     <project.build.outputTimestamp>0</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jdk.target>8</jdk.target>
+    <maven.compiler.release>11</maven.compiler.release>
     <!-- Indirection needed to keep optional jacoco settings and external argument lines-->
     <arg.line />
     <argLine>${arg.line}</argLine>
@@ -153,7 +153,7 @@
           <version>3.4.1</version>
           <configuration>
             <detectJavaApiLink>true</detectJavaApiLink>
-            <source>${maven.compiler.source}</source>
+            <source>${maven.compiler.release}</source>
             <tags>
               <tag>
                 <name>api.note</name>
@@ -251,11 +251,6 @@
             </dependencies>
          </plugin>
          <plugin>
-           <groupId>org.codehaus.mojo</groupId>
-           <artifactId>animal-sniffer-maven-plugin</artifactId>
-           <version>1.22</version>
-         </plugin>
-         <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>versions-maven-plugin</artifactId>
             <version>2.14.2</version>
@@ -292,25 +287,6 @@
       </plugins>
   </reporting>
   <profiles>
-    <profile>
-      <id>jdk8</id>
-      <activation>
-        <jdk>1.8</jdk>
-      </activation>
-      <properties>
-        <maven.compiler.source>${jdk.target}</maven.compiler.source>
-        <maven.compiler.target>${jdk.target}</maven.compiler.target>
-      </properties>
-    </profile>
-    <profile>
-      <id>jdk9+</id>
-      <activation>
-        <jdk>(1.8,)</jdk>
-      </activation>
-      <properties>
-        <maven.compiler.release>${jdk.target}</maven.compiler.release>
-      </properties>
-    </profile>
     <profile>
       <!-- Used with the phase 'site' to check plugins and dependency versions -->
       <id>versions</id>
@@ -402,29 +378,6 @@
                 <phase>verify</phase>
                 <goals>
                   <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>android</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>animal-sniffer-maven-plugin</artifactId>
-            <configuration>
-              <signature>net.sf.androidscents.signature:android-api-level-28:9_r6</signature>
-            </configuration>
-            <executions>
-              <execution>
-                <id>test</id>
-                <phase>test</phase>
-                <goals>
-                  <goal>check</goal>
                 </goals>
               </execution>
             </executions>

--- a/src/main/java/zmq/io/mechanism/curve/CurveServerMechanism.java
+++ b/src/main/java/zmq/io/mechanism/curve/CurveServerMechanism.java
@@ -4,6 +4,7 @@ import static zmq.io.Metadata.IDENTITY;
 import static zmq.io.Metadata.SOCKET_TYPE;
 
 import java.nio.ByteBuffer;
+import java.util.Objects;
 
 import zmq.Msg;
 import zmq.Options;
@@ -510,12 +511,7 @@ public class CurveServerMechanism extends Mechanism
         assert (statusCode == null || statusCode.length() == 3);
 
         msg.putShortString("ERROR");
-        if (statusCode != null) {
-            msg.putShortString(statusCode);
-        }
-        else {
-            msg.putShortString("");
-        }
+        msg.putShortString(Objects.requireNonNullElse(statusCode, ""));
 
         return 0;
     }

--- a/src/test/java/guide/clone.java
+++ b/src/test/java/guide/clone.java
@@ -2,6 +2,7 @@ package guide;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.zeromq.*;
 import org.zeromq.ZMQ.Poller;
@@ -206,9 +207,7 @@ public class clone
             else if (command.equals("GET")) {
                 String key = msg.popString();
                 String value = kvmap.get(key);
-                if (value != null)
-                    pipe.send(value);
-                else pipe.send("");
+                pipe.send(Objects.requireNonNullElse(value, ""));
             }
             msg.destroy();
 


### PR DESCRIPTION
The current version for Google Play is Android 13 (API level 33) as explained
at https://support.google.com/googleplay/android-developer/answer/11926878?hl=en.

The Java API that matches this version is Java 11.

But the ABI is still Java 8, for example see the problem with Buffer/ByteBuffer.

Meanwhile, to simplify developement, Google introduced “desugaring”, see
https://developer.android.com/studio/write/java11-default-support-table.

So I think API compliance checking is not needed any more, and removed all
API compliance check that breaks, but not in a meaningfull way.

Of course, support for Java 8 is dropped.
