### PR TITLE
Network protocols as ServiceProvider.

### DIFF
--- a/src/main/java/zmq/SocketBase.java
+++ b/src/main/java/zmq/SocketBase.java
@@ -396,8 +396,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
                 return false;
             }
 
-            switch (protocol) {
-            case inproc: {
+            if (protocol == NetProtocol.inproc) {
                 Ctx.Endpoint endpoint = new Ctx.Endpoint(this, options);
                 boolean rc = registerEndpoint(addr, endpoint);
                 if (rc) {
@@ -410,21 +409,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
                 }
                 return rc;
             }
-            case pgm:
-                // continue
-            case epgm:
-                // continue
-            case norm:
-                //  For convenience's sake, bind can be used interchangeable with
-                //  connect for PGM, EPGM and NORM transports.
-                return connect(addr);
-            case tcp:
-                // continue
-            case ipc:
-                // continue
-            case tipc: {
-                //  Remaining transports require to be run in an I/O thread, so at this
-                //  point we'll choose one.
+            else if (protocol.wantsIOThread()) {
                 IOThread ioThread = chooseIoThread(options.affinity);
                 if (ioThread == null) {
                     errno.set(ZError.EMTHREAD);
@@ -445,8 +430,10 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
                 addEndpoint(options.lastEndpoint, listener, null);
                 return true;
             }
-            default:
-                throw new IllegalArgumentException(addr);
+            else {
+                //  For convenience's sake, bind can be used interchangeable with
+                //  connect for PGM, EPGM and NORM transports.
+                return connect(addr);
             }
         }
         finally {

--- a/src/main/java/zmq/SocketBase.java
+++ b/src/main/java/zmq/SocketBase.java
@@ -539,7 +539,8 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
             ZObject[] parents = {this, peer.socket == null ? this : peer.socket};
 
             boolean conflate = options.conflate && (options.type == ZMQ.ZMQ_DEALER || options.type == ZMQ.ZMQ_PULL
-                                                            || options.type == ZMQ.ZMQ_PUSH || options.type == ZMQ.ZMQ_PUB || options.type == ZMQ.ZMQ_SUB);
+                                                    || options.type == ZMQ.ZMQ_PUSH || options.type == ZMQ.ZMQ_PUB
+                                                    || options.type == ZMQ.ZMQ_SUB);
 
             int[] hwms = {conflate ? -1 : sndhwm, conflate ? -1 : rcvhwm};
             boolean[] conflates = {conflate, conflate};
@@ -624,7 +625,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
         }
 
         boolean isSingleConnect = options.type == ZMQ.ZMQ_DEALER || options.type == ZMQ.ZMQ_SUB
-                                          || options.type == ZMQ.ZMQ_REQ;
+                                  || options.type == ZMQ.ZMQ_REQ;
 
         if (isSingleConnect) {
             if (endpoints.hasValues(addr)) {
@@ -660,7 +661,8 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
             //  Create a bi-directional pipe.
             ZObject[] parents = {this, session};
             boolean conflate = options.conflate && (options.type == ZMQ.ZMQ_DEALER || options.type == ZMQ.ZMQ_PULL
-                                                            || options.type == ZMQ.ZMQ_PUSH || options.type == ZMQ.ZMQ_PUB || options.type == ZMQ.ZMQ_SUB);
+                                                    || options.type == ZMQ.ZMQ_PUSH || options.type == ZMQ.ZMQ_PUB
+                                                    || options.type == ZMQ.ZMQ_SUB);
 
             int[] hwms = {conflate ? -1 : options.sendHwm, conflate ? -1 : options.recvHwm};
             boolean[] conflates = {conflate, conflate};

--- a/src/main/java/zmq/SocketBase.java
+++ b/src/main/java/zmq/SocketBase.java
@@ -211,7 +211,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
         try {
             //  First check out whether the protcol is something we are aware of.
             NetProtocol proto = NetProtocol.getProtocol(protocol);
-            if (!proto.valid) {
+            if (!proto.isValid()) {
                 errno.set(ZError.EPROTONOSUPPORT);
                 return proto;
             }
@@ -507,7 +507,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
         String address = uri.getAddress();
 
         NetProtocol protocol = checkProtocol(uri.getProtocol());
-        if (protocol == null || !protocol.valid) {
+        if (protocol == null || !protocol.isValid()) {
             return false;
         }
 
@@ -539,7 +539,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
             ZObject[] parents = {this, peer.socket == null ? this : peer.socket};
 
             boolean conflate = options.conflate && (options.type == ZMQ.ZMQ_DEALER || options.type == ZMQ.ZMQ_PULL
-                    || options.type == ZMQ.ZMQ_PUSH || options.type == ZMQ.ZMQ_PUB || options.type == ZMQ.ZMQ_SUB);
+                                                            || options.type == ZMQ.ZMQ_PUSH || options.type == ZMQ.ZMQ_PUB || options.type == ZMQ.ZMQ_SUB);
 
             int[] hwms = {conflate ? -1 : sndhwm, conflate ? -1 : rcvhwm};
             boolean[] conflates = {conflate, conflate};
@@ -624,7 +624,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
         }
 
         boolean isSingleConnect = options.type == ZMQ.ZMQ_DEALER || options.type == ZMQ.ZMQ_SUB
-                || options.type == ZMQ.ZMQ_REQ;
+                                          || options.type == ZMQ.ZMQ_REQ;
 
         if (isSingleConnect) {
             if (endpoints.hasValues(addr)) {
@@ -660,7 +660,7 @@ public abstract class SocketBase extends Own implements IPollEvents, Pipe.IPipeE
             //  Create a bi-directional pipe.
             ZObject[] parents = {this, session};
             boolean conflate = options.conflate && (options.type == ZMQ.ZMQ_DEALER || options.type == ZMQ.ZMQ_PULL
-                    || options.type == ZMQ.ZMQ_PUSH || options.type == ZMQ.ZMQ_PUB || options.type == ZMQ.ZMQ_SUB);
+                                                            || options.type == ZMQ.ZMQ_PUSH || options.type == ZMQ.ZMQ_PUB || options.type == ZMQ.ZMQ_SUB);
 
             int[] hwms = {conflate ? -1 : options.sendHwm, conflate ? -1 : options.recvHwm};
             boolean[] conflates = {conflate, conflate};

--- a/src/main/java/zmq/io/SessionBase.java
+++ b/src/main/java/zmq/io/SessionBase.java
@@ -15,13 +15,6 @@ import zmq.io.StreamEngine.ErrorReason;
 import zmq.io.mechanism.Mechanisms;
 import zmq.io.net.Address;
 import zmq.io.net.NetProtocol;
-import zmq.io.net.ipc.IpcConnecter;
-import zmq.io.net.norm.NormEngine;
-import zmq.io.net.pgm.PgmReceiver;
-import zmq.io.net.pgm.PgmSender;
-import zmq.io.net.tcp.SocksConnecter;
-import zmq.io.net.tcp.TcpConnecter;
-import zmq.io.net.tipc.TipcConnecter;
 import zmq.pipe.Pipe;
 import zmq.poll.IPollEvents;
 
@@ -523,85 +516,7 @@ public class SessionBase extends Own implements Pipe.IPipeEvents, IPollEvents
             errno.set(ZError.EPROTONOSUPPORT);
             return;
         }
-        switch (protocol) {
-        case tcp:
-            if (options.socksProxyAddress != null) {
-                Address proxyAddress = new Address(NetProtocol.tcp, options.socksProxyAddress);
-                SocksConnecter connecter = new SocksConnecter(ioThread, this, options, addr, proxyAddress, wait);
-                launchChild(connecter);
-            }
-            else {
-                TcpConnecter connecter = new TcpConnecter(ioThread, this, options, addr, wait);
-                launchChild(connecter);
-            }
-            break;
-        case ipc: {
-            IpcConnecter connecter = new IpcConnecter(ioThread, this, options, addr, wait);
-            launchChild(connecter);
-        }
-            break;
-
-        case tipc: {
-            TipcConnecter connecter = new TipcConnecter(ioThread, this, options, addr, wait);
-            launchChild(connecter);
-        }
-            break;
-
-        case pgm:
-        case epgm: {
-            assert (options.type == ZMQ.ZMQ_PUB || options.type == ZMQ.ZMQ_XPUB || options.type == ZMQ.ZMQ_SUB
-                    || options.type == ZMQ.ZMQ_XSUB);
-
-            //  For EPGM transport with UDP encapsulation of PGM is used.
-            boolean udpEncapsulation = protocol == NetProtocol.epgm;
-
-            //  At this point we'll create message pipes to the session straight
-            //  away. There's no point in delaying it as no concept of 'connect'
-            //  exists with PGM anyway.
-            if (options.type == ZMQ.ZMQ_PUB || options.type == ZMQ.ZMQ_XPUB) {
-                //  PGM sender.
-                PgmSender pgmSender = new PgmSender(ioThread, options);
-                boolean rc = pgmSender.init(udpEncapsulation, addr);
-                assert (rc);
-                sendAttach(this, pgmSender);
-            }
-            else {
-                //  PGM receiver.
-                PgmReceiver pgmReceiver = new PgmReceiver(ioThread, options);
-                boolean rc = pgmReceiver.init(udpEncapsulation, addr);
-                assert (rc);
-                sendAttach(this, pgmReceiver);
-
-            }
-        }
-            break;
-
-        case norm: {
-            //  At this point we'll create message pipes to the session straight
-            //  away. There's no point in delaying it as no concept of 'connect'
-            //  exists with NORM anyway.
-            if (options.type == ZMQ.ZMQ_PUB || options.type == ZMQ.ZMQ_XPUB) {
-                //  NORM sender.
-                NormEngine normSender = new NormEngine(ioThread, options);
-                boolean rc = normSender.init(addr, true, false);
-                assert (rc);
-                sendAttach(this, normSender);
-            }
-            else {
-                //  NORM receiver.
-                NormEngine normReceiver = new NormEngine(ioThread, options);
-                boolean rc = normReceiver.init(addr, false, true);
-                assert (rc);
-                sendAttach(this, normReceiver);
-
-            }
-        }
-            break;
-
-        default:
-            assert (false);
-            break;
-        }
+        protocol.startConnecting(options, ioThread, this, addr, wait, this::launchChild, null);
     }
 
     public String getEndpoint()

--- a/src/main/java/zmq/io/net/Address.java
+++ b/src/main/java/zmq/io/net/Address.java
@@ -53,16 +53,10 @@ public class Address
      */
     public Address(SocketAddress socketAddress)
     {
-        if (socketAddress instanceof InetSocketAddress) {
-            InetSocketAddress sockAddr = (InetSocketAddress) socketAddress;
-            this.address = sockAddr.getAddress().getHostAddress() + ":" + sockAddr.getPort();
-            protocol = NetProtocol.tcp;
-            resolved = null;
-        }
-        else {
-            throw new IllegalArgumentException("Not a IP socket address");
-        }
-    }
+        protocol = NetProtocol.findByAddress(socketAddress);
+        address = protocol.formatSocketAddress(socketAddress);
+        resolved = null;
+     }
 
     @Override
     public String toString()

--- a/src/main/java/zmq/io/net/NetProtocol.java
+++ b/src/main/java/zmq/io/net/NetProtocol.java
@@ -1,5 +1,6 @@
 package zmq.io.net;
 
+import java.net.SocketAddress;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
@@ -128,6 +129,16 @@ public enum NetProtocol
         }
     }
 
+    public static NetProtocol findByAddress(SocketAddress socketAddress)
+    {
+        for (Map.Entry<NetProtocol, NetworkProtocolProvider> e : providers.entrySet()) {
+            if (e.getValue().handleAdress(socketAddress)) {
+                return e.getKey();
+            }
+        }
+        throw new IllegalArgumentException("Unhandled address protocol " + socketAddress);
+    }
+
     public final boolean  subscribe2all;
     public final boolean  isMulticast;
     private final Set<Integer> compatibles;
@@ -179,5 +190,10 @@ public enum NetProtocol
             throw new IllegalArgumentException("Unsupported network protocol " + this);
         }
         return protocolProvider;
+    }
+
+    String formatSocketAddress(SocketAddress socketAddress)
+    {
+        return resolve().formatSocketAddress(socketAddress);
     }
 }

--- a/src/main/java/zmq/io/net/NetProtocol.java
+++ b/src/main/java/zmq/io/net/NetProtocol.java
@@ -1,101 +1,89 @@
 package zmq.io.net;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import zmq.Options;
+import zmq.Own;
 import zmq.SocketBase;
+import zmq.io.IEngine;
 import zmq.io.IOThread;
+import zmq.io.SessionBase;
 import zmq.io.net.Address.IZAddress;
-import zmq.io.net.ipc.IpcAddress;
-import zmq.io.net.ipc.IpcListener;
-import zmq.io.net.tcp.TcpAddress;
-import zmq.io.net.tcp.TcpListener;
-import zmq.io.net.tipc.TipcListener;
+import zmq.io.net.inproc.InprocNetworkProtocolProvider;
+import zmq.io.net.ipc.IpcNetworkProtocolProvider;
+import zmq.io.net.norm.NormNetworkProtocolProvider;
+import zmq.io.net.pgm.EpgmNetworkProtocolProvider;
+import zmq.io.net.pgm.PgmNetworkProtocolProvider;
+import zmq.io.net.tcp.TcpNetworkProtocolProvider;
+import zmq.io.net.tipc.TipcNetworkProtocolProvider;
 import zmq.socket.Sockets;
 
 public enum NetProtocol
 {
-    inproc(true, false, false),
-    ipc(true, false, false)
+    inproc(false, false),
+    ipc(false, false)
     {
-        @Override
-        public Listener getListener(IOThread ioThread, SocketBase socket,
-                                    Options options)
-        {
-            return new IpcListener(ioThread, socket, options);
-        }
-
         @Override
         public void resolve(Address paddr, boolean ipv6)
         {
             paddr.resolve(ipv6);
         }
-
-        @Override
-        public IZAddress zresolve(String addr, boolean ipv6)
-        {
-            return new IpcAddress(addr);
-        }
-
     },
-    tcp(true, false, false)
+    tcp(false, false)
     {
-        @Override
-        public Listener getListener(IOThread ioThread, SocketBase socket,
-                                    Options options)
-        {
-            return new TcpListener(ioThread, socket, options);
-        }
-
         @Override
         public void resolve(Address paddr, boolean ipv6)
         {
             paddr.resolve(ipv6);
         }
-
-        @Override
-        public IZAddress zresolve(String addr, boolean ipv6)
-        {
-            return  new TcpAddress(addr, ipv6);
-        }
-
     },
     //  PGM does not support subscription forwarding; ask for all data to be
     //  sent to this pipe. (same for NORM, currently?)
-    pgm(false, true, true, Sockets.PUB, Sockets.SUB, Sockets.XPUB, Sockets.XPUB),
-    epgm(false, true, true, Sockets.PUB, Sockets.SUB, Sockets.XPUB, Sockets.XPUB),
-    tipc(false, false, false)
+    pgm(true, true, Sockets.PUB, Sockets.SUB, Sockets.XPUB, Sockets.XPUB),
+    epgm(true, true, Sockets.PUB, Sockets.SUB, Sockets.XPUB, Sockets.XPUB),
+    tipc(false, false)
     {
-        @Override
-        public Listener getListener(IOThread ioThread, SocketBase socket,
-                                    Options options)
-        {
-            return new TipcListener(ioThread, socket, options);
-        }
-
         @Override
         public void resolve(Address paddr, boolean ipv6)
         {
             paddr.resolve(ipv6);
         }
-
     },
-    norm(false, true, true);
+    norm(true, true),
+    ;
 
-    public final boolean  valid;
+    private static final Map<NetProtocol,NetworkProtocolProvider > providers;
+    static {
+        providers = new HashMap<>(NetProtocol.values().length);
+        providers.put(NetProtocol.tcp, new TcpNetworkProtocolProvider());
+        providers.put(NetProtocol.ipc, new IpcNetworkProtocolProvider());
+        providers.put(NetProtocol.tipc, new TipcNetworkProtocolProvider());
+        providers.put(NetProtocol.norm, new NormNetworkProtocolProvider());
+        providers.put(NetProtocol.inproc, new InprocNetworkProtocolProvider());
+        providers.put(NetProtocol.pgm, new PgmNetworkProtocolProvider());
+        providers.put(NetProtocol.epgm, new EpgmNetworkProtocolProvider());
+    }
+
     public final boolean  subscribe2all;
     public final boolean  isMulticast;
     private final Set<Integer> compatibles;
 
-    NetProtocol(boolean implemented, boolean subscribe2all, boolean isMulticast, Sockets... compatibles)
+    private NetProtocol(boolean subscribe2all, boolean isMulticast, Sockets... compatibles)
     {
-        valid = implemented;
         this.compatibles = Arrays.stream(compatibles).map(Sockets::ordinal).collect(Collectors.toSet());
         this.subscribe2all = subscribe2all;
         this.isMulticast = isMulticast;
+    }
+    
+    public boolean isValid() {
+        return providers.containsKey(this) && providers.get(this).isValid();
     }
 
     /**
@@ -120,7 +108,7 @@ public enum NetProtocol
 
     public Listener getListener(IOThread ioThread, SocketBase socket, Options options)
     {
-        return null;
+        return providers.get(this).getListener(ioThread, socket, options);
     }
 
     public void resolve(Address paddr, boolean ipv6)
@@ -130,6 +118,11 @@ public enum NetProtocol
 
     public IZAddress zresolve(String addr, boolean ipv6)
     {
-        return null;
+        return providers.get(this).zresolve(addr, ipv6);
+    }
+
+    public void startConnecting(Options options, IOThread ioThread, SessionBase session, Address addr,
+                                         boolean delayedStart, Consumer<Own> launchChild, BiConsumer<SessionBase, IEngine> sendAttach) {
+        providers.get(this).startConnecting(options, ioThread, session, addr, delayedStart, launchChild, sendAttach);
     }
 }

--- a/src/main/java/zmq/io/net/NetProtocol.java
+++ b/src/main/java/zmq/io/net/NetProtocol.java
@@ -192,8 +192,13 @@ public enum NetProtocol
         return protocolProvider;
     }
 
-    String formatSocketAddress(SocketAddress socketAddress)
+    public String formatSocketAddress(SocketAddress socketAddress)
     {
         return resolve().formatSocketAddress(socketAddress);
+    }
+
+    public boolean wantsIOThread()
+    {
+        return resolve().wantsIOThread();
     }
 }

--- a/src/main/java/zmq/io/net/NetProtocol.java
+++ b/src/main/java/zmq/io/net/NetProtocol.java
@@ -28,7 +28,7 @@ import zmq.socket.Sockets;
 public enum NetProtocol
 {
     inproc(false, false),
-    ipc(false, false)
+    tcp(false, false)
     {
         @Override
         public void resolve(Address paddr, boolean ipv6)
@@ -36,7 +36,7 @@ public enum NetProtocol
             paddr.resolve(ipv6);
         }
     },
-    tcp(false, false)
+    udp(true, true)
     {
         @Override
         public void resolve(Address paddr, boolean ipv6)
@@ -48,6 +48,17 @@ public enum NetProtocol
     //  sent to this pipe. (same for NORM, currently?)
     pgm(true, true, Sockets.PUB, Sockets.SUB, Sockets.XPUB, Sockets.XPUB),
     epgm(true, true, Sockets.PUB, Sockets.SUB, Sockets.XPUB, Sockets.XPUB),
+    norm(true, true),
+    ws(true, true),
+    wss(true, true),
+    ipc(false, false)
+    {
+        @Override
+        public void resolve(Address paddr, boolean ipv6)
+        {
+            paddr.resolve(ipv6);
+        }
+    },
     tipc(false, false)
     {
         @Override
@@ -56,7 +67,7 @@ public enum NetProtocol
             paddr.resolve(ipv6);
         }
     },
-    norm(true, true),
+    vmci(true, true),
     ;
 
     private static final Map<NetProtocol,NetworkProtocolProvider > providers;
@@ -75,13 +86,13 @@ public enum NetProtocol
     public final boolean  isMulticast;
     private final Set<Integer> compatibles;
 
-    private NetProtocol(boolean subscribe2all, boolean isMulticast, Sockets... compatibles)
+    NetProtocol(boolean subscribe2all, boolean isMulticast, Sockets... compatibles)
     {
         this.compatibles = Arrays.stream(compatibles).map(Sockets::ordinal).collect(Collectors.toSet());
         this.subscribe2all = subscribe2all;
         this.isMulticast = isMulticast;
     }
-    
+
     public boolean isValid() {
         return providers.containsKey(this) && providers.get(this).isValid();
     }

--- a/src/main/java/zmq/io/net/NetProtocol.java
+++ b/src/main/java/zmq/io/net/NetProtocol.java
@@ -67,10 +67,9 @@ public enum NetProtocol
             paddr.resolve(ipv6);
         }
     },
-    vmci(true, true),
-    ;
+    vmci(true, true);
 
-    private static final Map<NetProtocol,NetworkProtocolProvider > providers;
+    private static final Map<NetProtocol, NetworkProtocolProvider> providers;
     static {
         providers = new HashMap<>(NetProtocol.values().length);
         providers.put(NetProtocol.tcp, new TcpNetworkProtocolProvider());
@@ -93,7 +92,8 @@ public enum NetProtocol
         this.isMulticast = isMulticast;
     }
 
-    public boolean isValid() {
+    public boolean isValid()
+    {
         return providers.containsKey(this) && providers.get(this).isValid();
     }
 
@@ -133,7 +133,8 @@ public enum NetProtocol
     }
 
     public void startConnecting(Options options, IOThread ioThread, SessionBase session, Address addr,
-                                         boolean delayedStart, Consumer<Own> launchChild, BiConsumer<SessionBase, IEngine> sendAttach) {
+                                         boolean delayedStart, Consumer<Own> launchChild, BiConsumer<SessionBase, IEngine> sendAttach)
+    {
         providers.get(this).startConnecting(options, ioThread, session, addr, delayedStart, launchChild, sendAttach);
     }
 }

--- a/src/main/java/zmq/io/net/NetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/NetworkProtocolProvider.java
@@ -1,0 +1,23 @@
+package zmq.io.net;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import zmq.Options;
+import zmq.Own;
+import zmq.SocketBase;
+import zmq.io.IEngine;
+import zmq.io.IOThread;
+import zmq.io.SessionBase;
+import zmq.io.net.Address.IZAddress;
+
+public interface NetworkProtocolProvider {
+    boolean handleProtocol(NetProtocol protocol);
+    public Listener getListener(IOThread ioThread, SocketBase socket,
+                                Options options);
+    public IZAddress zresolve(String addr, boolean ipv6);
+    public abstract void startConnecting(Options options, IOThread ioThread, SessionBase session, Address addr,
+                                         boolean delayedStart, Consumer<Own> launchChild, BiConsumer<SessionBase, IEngine> sendAttach);
+    boolean isValid();
+
+}

--- a/src/main/java/zmq/io/net/NetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/NetworkProtocolProvider.java
@@ -1,5 +1,6 @@
 package zmq.io.net;
 
+import java.net.SocketAddress;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -18,5 +19,16 @@ public interface NetworkProtocolProvider
     IZAddress zresolve(String addr, boolean ipv6);
     void startConnecting(Options options, IOThread ioThread, SessionBase session, Address addr, boolean delayedStart,
             Consumer<Own> launchChild, BiConsumer<SessionBase, IEngine> sendAttach);
-    boolean isValid();
+    default boolean isValid()
+    {
+        return false;
+    }
+    default boolean handleAdress(SocketAddress socketAddress)
+    {
+        return false;
+    }
+    default String formatSocketAddress(SocketAddress socketAddress)
+    {
+        throw new IllegalArgumentException("Unhandled address protocol " + socketAddress);
+    }
 }

--- a/src/main/java/zmq/io/net/NetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/NetworkProtocolProvider.java
@@ -13,11 +13,10 @@ import zmq.io.net.Address.IZAddress;
 
 public interface NetworkProtocolProvider {
     boolean handleProtocol(NetProtocol protocol);
-    public Listener getListener(IOThread ioThread, SocketBase socket,
-                                Options options);
-    public IZAddress zresolve(String addr, boolean ipv6);
-    public abstract void startConnecting(Options options, IOThread ioThread, SessionBase session, Address addr,
-                                         boolean delayedStart, Consumer<Own> launchChild, BiConsumer<SessionBase, IEngine> sendAttach);
+    Listener getListener(IOThread ioThread, SocketBase socket, Options options);
+    IZAddress zresolve(String addr, boolean ipv6);
+    void startConnecting(Options options, IOThread ioThread, SessionBase session, Address addr, boolean delayedStart,
+            Consumer<Own> launchChild, BiConsumer<SessionBase, IEngine> sendAttach);
     boolean isValid();
 
 }

--- a/src/main/java/zmq/io/net/NetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/NetworkProtocolProvider.java
@@ -31,4 +31,5 @@ public interface NetworkProtocolProvider
     {
         throw new IllegalArgumentException("Unhandled address protocol " + socketAddress);
     }
+    boolean wantsIOThread();
 }

--- a/src/main/java/zmq/io/net/NetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/NetworkProtocolProvider.java
@@ -11,12 +11,12 @@ import zmq.io.IOThread;
 import zmq.io.SessionBase;
 import zmq.io.net.Address.IZAddress;
 
-public interface NetworkProtocolProvider {
+public interface NetworkProtocolProvider
+{
     boolean handleProtocol(NetProtocol protocol);
     Listener getListener(IOThread ioThread, SocketBase socket, Options options);
     IZAddress zresolve(String addr, boolean ipv6);
     void startConnecting(Options options, IOThread ioThread, SessionBase session, Address addr, boolean delayedStart,
             Consumer<Own> launchChild, BiConsumer<SessionBase, IEngine> sendAttach);
     boolean isValid();
-
 }

--- a/src/main/java/zmq/io/net/inproc/InprocNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/inproc/InprocNetworkProtocolProvider.java
@@ -1,0 +1,49 @@
+package zmq.io.net.inproc;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import zmq.Options;
+import zmq.Own;
+import zmq.SocketBase;
+import zmq.io.IEngine;
+import zmq.io.IOThread;
+import zmq.io.SessionBase;
+import zmq.io.net.Address;
+import zmq.io.net.Address.IZAddress;
+import zmq.io.net.Listener;
+import zmq.io.net.NetProtocol;
+import zmq.io.net.NetworkProtocolProvider;
+
+public class InprocNetworkProtocolProvider implements NetworkProtocolProvider {
+
+    @Override
+    public boolean handleProtocol(NetProtocol protocol) {
+        return protocol == NetProtocol.inproc;
+    }
+
+    @Override
+    public Listener getListener(IOThread ioThread, SocketBase socket,
+                                Options options) {
+        return null;
+    }
+
+    @Override
+    public IZAddress zresolve(String addr, boolean ipv6) {
+        return null;
+    }
+
+    @Override
+    public void startConnecting(Options options, IOThread ioThread,
+                                SessionBase session, Address addr,
+                                boolean delayedStart, Consumer<Own> launchChild,
+                                BiConsumer<SessionBase, IEngine> sendAttach) {
+        assert false;
+    }
+
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+
+}

--- a/src/main/java/zmq/io/net/inproc/InprocNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/inproc/InprocNetworkProtocolProvider.java
@@ -15,21 +15,24 @@ import zmq.io.net.Listener;
 import zmq.io.net.NetProtocol;
 import zmq.io.net.NetworkProtocolProvider;
 
-public class InprocNetworkProtocolProvider implements NetworkProtocolProvider {
-
+public class InprocNetworkProtocolProvider implements NetworkProtocolProvider
+{
     @Override
-    public boolean handleProtocol(NetProtocol protocol) {
+    public boolean handleProtocol(NetProtocol protocol)
+    {
         return protocol == NetProtocol.inproc;
     }
 
     @Override
     public Listener getListener(IOThread ioThread, SocketBase socket,
-                                Options options) {
+                                Options options)
+    {
         return null;
     }
 
     @Override
-    public IZAddress zresolve(String addr, boolean ipv6) {
+    public IZAddress zresolve(String addr, boolean ipv6)
+    {
         return null;
     }
 
@@ -37,13 +40,14 @@ public class InprocNetworkProtocolProvider implements NetworkProtocolProvider {
     public void startConnecting(Options options, IOThread ioThread,
                                 SessionBase session, Address addr,
                                 boolean delayedStart, Consumer<Own> launchChild,
-                                BiConsumer<SessionBase, IEngine> sendAttach) {
+                                BiConsumer<SessionBase, IEngine> sendAttach)
+    {
         assert false;
     }
 
     @Override
-    public boolean isValid() {
+    public boolean isValid()
+    {
         return true;
     }
-
 }

--- a/src/main/java/zmq/io/net/inproc/InprocNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/inproc/InprocNetworkProtocolProvider.java
@@ -50,4 +50,10 @@ public class InprocNetworkProtocolProvider implements NetworkProtocolProvider
     {
         return true;
     }
+
+    @Override
+    public boolean wantsIOThread()
+    {
+        return false;
+    }
 }

--- a/src/main/java/zmq/io/net/ipc/IpcNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/ipc/IpcNetworkProtocolProvider.java
@@ -1,0 +1,48 @@
+package zmq.io.net.ipc;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import zmq.Options;
+import zmq.Own;
+import zmq.SocketBase;
+import zmq.io.IEngine;
+import zmq.io.IOThread;
+import zmq.io.SessionBase;
+import zmq.io.net.Address;
+import zmq.io.net.Address.IZAddress;
+import zmq.io.net.Listener;
+import zmq.io.net.NetProtocol;
+import zmq.io.net.NetworkProtocolProvider;
+
+public class IpcNetworkProtocolProvider implements NetworkProtocolProvider {
+    @Override
+    public boolean handleProtocol(NetProtocol protocol) {
+        return protocol == NetProtocol.ipc;
+    }
+
+    @Override
+    public Listener getListener(IOThread ioThread, SocketBase socket,
+                                Options options) {
+        return new IpcListener(ioThread, socket, options);
+    }
+
+    @Override
+    public IZAddress zresolve(String addr, boolean ipv6) {
+        return new IpcAddress(addr);
+    }
+
+    @Override
+    public void startConnecting(Options options, IOThread ioThread,
+                                SessionBase session, Address addr,
+                                boolean delayedStart, Consumer<Own> launchChild,
+                                BiConsumer<SessionBase, IEngine> sendAttach) {
+        IpcConnecter connecter = new IpcConnecter(ioThread, session, options, addr, delayedStart);
+        launchChild.accept(connecter);
+    }
+
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+}

--- a/src/main/java/zmq/io/net/ipc/IpcNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/ipc/IpcNetworkProtocolProvider.java
@@ -51,4 +51,10 @@ public class IpcNetworkProtocolProvider implements NetworkProtocolProvider
     {
         return true;
     }
+
+    @Override
+    public boolean wantsIOThread()
+    {
+        return true;
+    }
 }

--- a/src/main/java/zmq/io/net/ipc/IpcNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/ipc/IpcNetworkProtocolProvider.java
@@ -15,20 +15,24 @@ import zmq.io.net.Listener;
 import zmq.io.net.NetProtocol;
 import zmq.io.net.NetworkProtocolProvider;
 
-public class IpcNetworkProtocolProvider implements NetworkProtocolProvider {
+public class IpcNetworkProtocolProvider implements NetworkProtocolProvider
+{
     @Override
-    public boolean handleProtocol(NetProtocol protocol) {
+    public boolean handleProtocol(NetProtocol protocol)
+    {
         return protocol == NetProtocol.ipc;
     }
 
     @Override
     public Listener getListener(IOThread ioThread, SocketBase socket,
-                                Options options) {
+                                Options options)
+    {
         return new IpcListener(ioThread, socket, options);
     }
 
     @Override
-    public IZAddress zresolve(String addr, boolean ipv6) {
+    public IZAddress zresolve(String addr, boolean ipv6)
+    {
         return new IpcAddress(addr);
     }
 
@@ -36,13 +40,15 @@ public class IpcNetworkProtocolProvider implements NetworkProtocolProvider {
     public void startConnecting(Options options, IOThread ioThread,
                                 SessionBase session, Address addr,
                                 boolean delayedStart, Consumer<Own> launchChild,
-                                BiConsumer<SessionBase, IEngine> sendAttach) {
+                                BiConsumer<SessionBase, IEngine> sendAttach)
+    {
         IpcConnecter connecter = new IpcConnecter(ioThread, session, options, addr, delayedStart);
         launchChild.accept(connecter);
     }
 
     @Override
-    public boolean isValid() {
+    public boolean isValid()
+    {
         return true;
     }
 }

--- a/src/main/java/zmq/io/net/norm/NormNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/norm/NormNetworkProtocolProvider.java
@@ -1,0 +1,69 @@
+package zmq.io.net.norm;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import zmq.Options;
+import zmq.Own;
+import zmq.SocketBase;
+import zmq.ZMQ;
+import zmq.io.IEngine;
+import zmq.io.IOThread;
+import zmq.io.SessionBase;
+import zmq.io.net.Address;
+import zmq.io.net.Address.IZAddress;
+import zmq.io.net.Listener;
+import zmq.io.net.NetProtocol;
+import zmq.io.net.NetworkProtocolProvider;
+
+public class NormNetworkProtocolProvider implements NetworkProtocolProvider {
+    @Override
+    public boolean handleProtocol(NetProtocol protocol) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public Listener getListener(IOThread ioThread, SocketBase socket,
+                                Options options) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public IZAddress zresolve(String addr, boolean ipv6) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void startConnecting(Options options, IOThread ioThread,
+                                SessionBase session, Address addr,
+                                boolean delayedStart,
+                                Consumer<Own> launchChild,
+                                BiConsumer<SessionBase, IEngine> sendAttach) {
+        //  At this point we'll create message pipes to the session straight
+        //  away. There's no point in delaying it as no concept of 'connect'
+        //  exists with NORM anyway.
+        if (options.type == ZMQ.ZMQ_PUB || options.type == ZMQ.ZMQ_XPUB) {
+            //  NORM sender.
+            NormEngine normSender = new NormEngine(ioThread, options);
+            boolean rc = normSender.init(addr, true, false);
+            assert (rc);
+            sendAttach.accept(session, normSender);
+        }
+        else {
+            //  NORM receiver.
+            NormEngine normReceiver = new NormEngine(ioThread, options);
+            boolean rc = normReceiver.init(addr, false, true);
+            assert (rc);
+            sendAttach.accept(session, normReceiver);
+        }
+    }
+
+    @Override
+    public boolean isValid() {
+        return false;
+    }
+
+}

--- a/src/main/java/zmq/io/net/norm/NormNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/norm/NormNetworkProtocolProvider.java
@@ -65,4 +65,10 @@ public class NormNetworkProtocolProvider implements NetworkProtocolProvider
             sendAttach.accept(session, normReceiver);
         }
     }
+
+    @Override
+    public boolean wantsIOThread()
+    {
+        return false;
+    }
 }

--- a/src/main/java/zmq/io/net/norm/NormNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/norm/NormNetworkProtocolProvider.java
@@ -16,22 +16,26 @@ import zmq.io.net.Listener;
 import zmq.io.net.NetProtocol;
 import zmq.io.net.NetworkProtocolProvider;
 
-public class NormNetworkProtocolProvider implements NetworkProtocolProvider {
+public class NormNetworkProtocolProvider implements NetworkProtocolProvider
+{
     @Override
-    public boolean handleProtocol(NetProtocol protocol) {
+    public boolean handleProtocol(NetProtocol protocol)
+    {
         // TODO Auto-generated method stub
         return false;
     }
 
     @Override
     public Listener getListener(IOThread ioThread, SocketBase socket,
-                                Options options) {
+                                Options options)
+    {
         // TODO Auto-generated method stub
         return null;
     }
 
     @Override
-    public IZAddress zresolve(String addr, boolean ipv6) {
+    public IZAddress zresolve(String addr, boolean ipv6)
+    {
         // TODO Auto-generated method stub
         return null;
     }
@@ -41,7 +45,8 @@ public class NormNetworkProtocolProvider implements NetworkProtocolProvider {
                                 SessionBase session, Address addr,
                                 boolean delayedStart,
                                 Consumer<Own> launchChild,
-                                BiConsumer<SessionBase, IEngine> sendAttach) {
+                                BiConsumer<SessionBase, IEngine> sendAttach)
+    {
         //  At this point we'll create message pipes to the session straight
         //  away. There's no point in delaying it as no concept of 'connect'
         //  exists with NORM anyway.
@@ -62,8 +67,8 @@ public class NormNetworkProtocolProvider implements NetworkProtocolProvider {
     }
 
     @Override
-    public boolean isValid() {
+    public boolean isValid()
+    {
         return false;
     }
-
 }

--- a/src/main/java/zmq/io/net/norm/NormNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/norm/NormNetworkProtocolProvider.java
@@ -65,10 +65,4 @@ public class NormNetworkProtocolProvider implements NetworkProtocolProvider
             sendAttach.accept(session, normReceiver);
         }
     }
-
-    @Override
-    public boolean isValid()
-    {
-        return false;
-    }
 }

--- a/src/main/java/zmq/io/net/pgm/EpgmNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/pgm/EpgmNetworkProtocolProvider.java
@@ -1,0 +1,15 @@
+package zmq.io.net.pgm;
+
+import zmq.io.net.NetProtocol;
+
+public class EpgmNetworkProtocolProvider extends PgmNetworkProtocolProvider {
+    @Override
+    public boolean handleProtocol(NetProtocol protocol) {
+        return protocol == NetProtocol.epgm;
+    }
+
+    @Override
+    protected boolean withUdpEncapsulation() {
+        return true;
+    }
+}

--- a/src/main/java/zmq/io/net/pgm/EpgmNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/pgm/EpgmNetworkProtocolProvider.java
@@ -2,14 +2,17 @@ package zmq.io.net.pgm;
 
 import zmq.io.net.NetProtocol;
 
-public class EpgmNetworkProtocolProvider extends PgmNetworkProtocolProvider {
+public class EpgmNetworkProtocolProvider extends PgmNetworkProtocolProvider
+{
     @Override
-    public boolean handleProtocol(NetProtocol protocol) {
+    public boolean handleProtocol(NetProtocol protocol)
+    {
         return protocol == NetProtocol.epgm;
     }
 
     @Override
-    protected boolean withUdpEncapsulation() {
+    protected boolean withUdpEncapsulation()
+    {
         return true;
     }
 }

--- a/src/main/java/zmq/io/net/pgm/PgmNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/pgm/PgmNetworkProtocolProvider.java
@@ -1,0 +1,76 @@
+package zmq.io.net.pgm;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import zmq.Options;
+import zmq.Own;
+import zmq.SocketBase;
+import zmq.ZMQ;
+import zmq.io.IEngine;
+import zmq.io.IOThread;
+import zmq.io.SessionBase;
+import zmq.io.net.Address;
+import zmq.io.net.Address.IZAddress;
+import zmq.io.net.Listener;
+import zmq.io.net.NetProtocol;
+import zmq.io.net.NetworkProtocolProvider;
+
+public class PgmNetworkProtocolProvider implements NetworkProtocolProvider {
+
+    @Override
+    public boolean handleProtocol(NetProtocol protocol) {
+        return protocol == NetProtocol.pgm;
+    }
+
+    @Override
+    public Listener getListener(IOThread ioThread, SocketBase socket,
+                                Options options) {
+        return null;
+    }
+
+    @Override
+    public IZAddress zresolve(String addr, boolean ipv6) {
+        return null;
+    }
+
+    @Override
+    public void startConnecting(Options options, IOThread ioThread,
+                                SessionBase session, Address addr,
+                                boolean delayedStart, Consumer<Own> launchChild,
+                                BiConsumer<SessionBase, IEngine> sendAttach) {
+        assert (options.type == ZMQ.ZMQ_PUB || options.type == ZMQ.ZMQ_XPUB || options.type == ZMQ.ZMQ_SUB
+                        || options.type == ZMQ.ZMQ_XSUB);
+
+                //  For EPGM transport with UDP encapsulation of PGM is used.
+                boolean udpEncapsulation = withUdpEncapsulation();
+
+                //  At this point we'll create message pipes to the session straight
+                //  away. There's no point in delaying it as no concept of 'connect'
+                //  exists with PGM anyway.
+                if (options.type == ZMQ.ZMQ_PUB || options.type == ZMQ.ZMQ_XPUB) {
+                    //  PGM sender.
+                    PgmSender pgmSender = new PgmSender(ioThread, options);
+                    boolean rc = pgmSender.init(udpEncapsulation, addr);
+                    assert (rc);
+                    sendAttach.accept(session, pgmSender);
+                }
+                else {
+                    //  PGM receiver.
+                    PgmReceiver pgmReceiver = new PgmReceiver(ioThread, options);
+                    boolean rc = pgmReceiver.init(udpEncapsulation, addr);
+                    assert (rc);
+                    sendAttach.accept(session, pgmReceiver);
+                }
+    }
+    
+    protected boolean withUdpEncapsulation() {
+        return false;
+    }
+
+    @Override
+    public boolean isValid() {
+        return false;
+    }
+
+}

--- a/src/main/java/zmq/io/net/pgm/PgmNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/pgm/PgmNetworkProtocolProvider.java
@@ -72,4 +72,10 @@ public class PgmNetworkProtocolProvider implements NetworkProtocolProvider
     {
         return false;
     }
+
+    @Override
+    public boolean wantsIOThread()
+    {
+        return false;
+    }
 }

--- a/src/main/java/zmq/io/net/pgm/PgmNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/pgm/PgmNetworkProtocolProvider.java
@@ -72,10 +72,4 @@ public class PgmNetworkProtocolProvider implements NetworkProtocolProvider
     {
         return false;
     }
-
-    @Override
-    public boolean isValid()
-    {
-        return false;
-    }
 }

--- a/src/main/java/zmq/io/net/pgm/PgmNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/pgm/PgmNetworkProtocolProvider.java
@@ -16,21 +16,24 @@ import zmq.io.net.Listener;
 import zmq.io.net.NetProtocol;
 import zmq.io.net.NetworkProtocolProvider;
 
-public class PgmNetworkProtocolProvider implements NetworkProtocolProvider {
-
+public class PgmNetworkProtocolProvider implements NetworkProtocolProvider
+{
     @Override
-    public boolean handleProtocol(NetProtocol protocol) {
+    public boolean handleProtocol(NetProtocol protocol)
+    {
         return protocol == NetProtocol.pgm;
     }
 
     @Override
     public Listener getListener(IOThread ioThread, SocketBase socket,
-                                Options options) {
+                                Options options)
+    {
         return null;
     }
 
     @Override
-    public IZAddress zresolve(String addr, boolean ipv6) {
+    public IZAddress zresolve(String addr, boolean ipv6)
+    {
         return null;
     }
 
@@ -38,7 +41,8 @@ public class PgmNetworkProtocolProvider implements NetworkProtocolProvider {
     public void startConnecting(Options options, IOThread ioThread,
                                 SessionBase session, Address addr,
                                 boolean delayedStart, Consumer<Own> launchChild,
-                                BiConsumer<SessionBase, IEngine> sendAttach) {
+                                BiConsumer<SessionBase, IEngine> sendAttach)
+    {
         assert (options.type == ZMQ.ZMQ_PUB || options.type == ZMQ.ZMQ_XPUB || options.type == ZMQ.ZMQ_SUB
                         || options.type == ZMQ.ZMQ_XSUB);
 
@@ -63,14 +67,15 @@ public class PgmNetworkProtocolProvider implements NetworkProtocolProvider {
                     sendAttach.accept(session, pgmReceiver);
                 }
     }
-    
-    protected boolean withUdpEncapsulation() {
+
+    protected boolean withUdpEncapsulation()
+    {
         return false;
     }
 
     @Override
-    public boolean isValid() {
+    public boolean isValid()
+    {
         return false;
     }
-
 }

--- a/src/main/java/zmq/io/net/tcp/TcpAddress.java
+++ b/src/main/java/zmq/io/net/tcp/TcpAddress.java
@@ -57,7 +57,9 @@ public class TcpAddress implements Address.IZAddress
         if (address.getAddress() instanceof Inet6Address) {
             return StandardProtocolFamily.INET6;
         }
-        return StandardProtocolFamily.INET;
+        else {
+            return StandardProtocolFamily.INET;
+        }
     }
 
     // The opposite to resolve()

--- a/src/main/java/zmq/io/net/tcp/TcpConnecter.java
+++ b/src/main/java/zmq/io/net/tcp/TcpConnecter.java
@@ -176,14 +176,13 @@ public class TcpConnecter extends Own implements IPollEvents
         try {
             boolean rc = open();
 
+            handle = ioObject.addFd(fd);
             //  Connect may succeed in synchronous manner.
             if (rc) {
-                handle = ioObject.addFd(fd);
                 connectEvent();
             }
             //  Connection establishment may be delayed. Poll for its completion.
             else {
-                handle = ioObject.addFd(fd);
                 ioObject.setPollConnect(handle);
                 socket.eventConnectDelayed(addr.toString(), -1);
             }
@@ -295,10 +294,7 @@ public class TcpConnecter extends Own implements IPollEvents
         boolean rc;
         try {
             rc = fd.connect(sa);
-            if (rc) {
-                //  Connect was successful immediately.
-            }
-            else {
+            if (! rc) {
                 //  Translate error codes indicating asynchronous connect has been
                 //  launched to a uniform EINPROGRESS.
                 errno.set(ZError.EINPROGRESS);

--- a/src/main/java/zmq/io/net/tcp/TcpNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/tcp/TcpNetworkProtocolProvider.java
@@ -1,0 +1,55 @@
+package zmq.io.net.tcp;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import zmq.Options;
+import zmq.Own;
+import zmq.SocketBase;
+import zmq.io.IEngine;
+import zmq.io.IOThread;
+import zmq.io.SessionBase;
+import zmq.io.net.Address;
+import zmq.io.net.Address.IZAddress;
+import zmq.io.net.Listener;
+import zmq.io.net.NetProtocol;
+import zmq.io.net.NetworkProtocolProvider;
+
+public class TcpNetworkProtocolProvider implements NetworkProtocolProvider {
+    @Override
+    public boolean handleProtocol(NetProtocol protocol) {
+        return protocol == NetProtocol.tcp;
+    }
+
+    @Override
+    public Listener getListener(IOThread ioThread, SocketBase socket,
+                                Options options) {
+        return new TcpListener(ioThread, socket, options);
+    }
+
+    @Override
+    public IZAddress zresolve(String addr, boolean ipv6) {
+        return new TcpAddress(addr, ipv6);
+    }
+
+    @Override
+    public void startConnecting(Options options, IOThread ioThread,
+                                SessionBase session, Address addr,
+                                boolean delayedStart, Consumer<Own> launchChild,
+                                BiConsumer<SessionBase, IEngine> sendAttach) {
+        if (options.socksProxyAddress != null) {
+            Address proxyAddress = new Address(NetProtocol.tcp, options.socksProxyAddress);
+            SocksConnecter connecter = new SocksConnecter(ioThread, session, options, addr, proxyAddress, delayedStart);
+            launchChild.accept(connecter);
+        }
+        else {
+            TcpConnecter connecter = new TcpConnecter(ioThread, session, options, addr, delayedStart);
+            launchChild.accept(connecter);
+        }
+    }
+
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+}

--- a/src/main/java/zmq/io/net/tcp/TcpNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/tcp/TcpNetworkProtocolProvider.java
@@ -15,20 +15,24 @@ import zmq.io.net.Listener;
 import zmq.io.net.NetProtocol;
 import zmq.io.net.NetworkProtocolProvider;
 
-public class TcpNetworkProtocolProvider implements NetworkProtocolProvider {
+public class TcpNetworkProtocolProvider implements NetworkProtocolProvider
+{
     @Override
-    public boolean handleProtocol(NetProtocol protocol) {
+    public boolean handleProtocol(NetProtocol protocol)
+    {
         return protocol == NetProtocol.tcp;
     }
 
     @Override
     public Listener getListener(IOThread ioThread, SocketBase socket,
-                                Options options) {
+                                Options options)
+    {
         return new TcpListener(ioThread, socket, options);
     }
 
     @Override
-    public IZAddress zresolve(String addr, boolean ipv6) {
+    public IZAddress zresolve(String addr, boolean ipv6)
+    {
         return new TcpAddress(addr, ipv6);
     }
 
@@ -36,7 +40,8 @@ public class TcpNetworkProtocolProvider implements NetworkProtocolProvider {
     public void startConnecting(Options options, IOThread ioThread,
                                 SessionBase session, Address addr,
                                 boolean delayedStart, Consumer<Own> launchChild,
-                                BiConsumer<SessionBase, IEngine> sendAttach) {
+                                BiConsumer<SessionBase, IEngine> sendAttach)
+    {
         if (options.socksProxyAddress != null) {
             Address proxyAddress = new Address(NetProtocol.tcp, options.socksProxyAddress);
             SocksConnecter connecter = new SocksConnecter(ioThread, session, options, addr, proxyAddress, delayedStart);
@@ -49,7 +54,8 @@ public class TcpNetworkProtocolProvider implements NetworkProtocolProvider {
     }
 
     @Override
-    public boolean isValid() {
+    public boolean isValid()
+    {
         return true;
     }
 }

--- a/src/main/java/zmq/io/net/tcp/TcpNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/tcp/TcpNetworkProtocolProvider.java
@@ -73,4 +73,10 @@ public class TcpNetworkProtocolProvider implements NetworkProtocolProvider
         InetSocketAddress isa = (InetSocketAddress) socketAddress;
         return isa.getAddress().getHostAddress() + ":" + isa.getPort();
     }
+
+    @Override
+    public boolean wantsIOThread()
+    {
+        return true;
+    }
 }

--- a/src/main/java/zmq/io/net/tcp/TcpNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/tcp/TcpNetworkProtocolProvider.java
@@ -1,5 +1,7 @@
 package zmq.io.net.tcp;
 
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -57,5 +59,18 @@ public class TcpNetworkProtocolProvider implements NetworkProtocolProvider
     public boolean isValid()
     {
         return true;
+    }
+
+    @Override
+    public boolean handleAdress(SocketAddress socketAddress)
+    {
+        return socketAddress instanceof InetSocketAddress;
+    }
+
+    @Override
+    public String formatSocketAddress(SocketAddress socketAddress)
+    {
+        InetSocketAddress isa = (InetSocketAddress) socketAddress;
+        return isa.getAddress().getHostAddress() + ":" + isa.getPort();
     }
 }

--- a/src/main/java/zmq/io/net/tipc/TipcNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/tipc/TipcNetworkProtocolProvider.java
@@ -1,0 +1,51 @@
+package zmq.io.net.tipc;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import zmq.Options;
+import zmq.Own;
+import zmq.SocketBase;
+import zmq.io.IEngine;
+import zmq.io.IOThread;
+import zmq.io.SessionBase;
+import zmq.io.net.Address;
+import zmq.io.net.Address.IZAddress;
+import zmq.io.net.Listener;
+import zmq.io.net.NetProtocol;
+import zmq.io.net.NetworkProtocolProvider;
+
+public class TipcNetworkProtocolProvider implements NetworkProtocolProvider {
+    @Override
+    public boolean handleProtocol(NetProtocol protocol) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public Listener getListener(IOThread ioThread, SocketBase socket,
+                                Options options) {
+        return new TipcListener(ioThread, socket, options);
+    }
+
+    @Override
+    public IZAddress zresolve(String addr, boolean ipv6) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void startConnecting(Options options, IOThread ioThread,
+                                SessionBase session, Address addr,
+                                boolean delayedStart, Consumer<Own> launchChild,
+                                BiConsumer<SessionBase, IEngine> sendAttach) {
+        TipcConnecter connecter = new TipcConnecter(ioThread, session, options, addr, delayedStart);
+        launchChild.accept(connecter);
+    }
+
+    @Override
+    public boolean isValid() {
+        return false;
+    }
+
+}

--- a/src/main/java/zmq/io/net/tipc/TipcNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/tipc/TipcNetworkProtocolProvider.java
@@ -47,10 +47,4 @@ public class TipcNetworkProtocolProvider implements NetworkProtocolProvider
         TipcConnecter connecter = new TipcConnecter(ioThread, session, options, addr, delayedStart);
         launchChild.accept(connecter);
     }
-
-    @Override
-    public boolean isValid()
-    {
-        return false;
-    }
 }

--- a/src/main/java/zmq/io/net/tipc/TipcNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/tipc/TipcNetworkProtocolProvider.java
@@ -15,21 +15,25 @@ import zmq.io.net.Listener;
 import zmq.io.net.NetProtocol;
 import zmq.io.net.NetworkProtocolProvider;
 
-public class TipcNetworkProtocolProvider implements NetworkProtocolProvider {
+public class TipcNetworkProtocolProvider implements NetworkProtocolProvider
+{
     @Override
-    public boolean handleProtocol(NetProtocol protocol) {
+    public boolean handleProtocol(NetProtocol protocol)
+    {
         // TODO Auto-generated method stub
         return false;
     }
 
     @Override
     public Listener getListener(IOThread ioThread, SocketBase socket,
-                                Options options) {
+                                Options options)
+    {
         return new TipcListener(ioThread, socket, options);
     }
 
     @Override
-    public IZAddress zresolve(String addr, boolean ipv6) {
+    public IZAddress zresolve(String addr, boolean ipv6)
+    {
         // TODO Auto-generated method stub
         return null;
     }
@@ -38,14 +42,15 @@ public class TipcNetworkProtocolProvider implements NetworkProtocolProvider {
     public void startConnecting(Options options, IOThread ioThread,
                                 SessionBase session, Address addr,
                                 boolean delayedStart, Consumer<Own> launchChild,
-                                BiConsumer<SessionBase, IEngine> sendAttach) {
+                                BiConsumer<SessionBase, IEngine> sendAttach)
+    {
         TipcConnecter connecter = new TipcConnecter(ioThread, session, options, addr, delayedStart);
         launchChild.accept(connecter);
     }
 
     @Override
-    public boolean isValid() {
+    public boolean isValid()
+    {
         return false;
     }
-
 }

--- a/src/main/java/zmq/io/net/tipc/TipcNetworkProtocolProvider.java
+++ b/src/main/java/zmq/io/net/tipc/TipcNetworkProtocolProvider.java
@@ -47,4 +47,10 @@ public class TipcNetworkProtocolProvider implements NetworkProtocolProvider
         TipcConnecter connecter = new TipcConnecter(ioThread, session, options, addr, delayedStart);
         launchChild.accept(connecter);
     }
+
+    @Override
+    public boolean wantsIOThread()
+    {
+        return true;
+    }
 }

--- a/src/main/resources/META-INF/services/zmq.io.net.NetworkProtocolProvider
+++ b/src/main/resources/META-INF/services/zmq.io.net.NetworkProtocolProvider
@@ -1,0 +1,7 @@
+zmq.io.net.inproc.InprocNetworkProtocolProvider
+zmq.io.net.ipc.IpcNetworkProtocolProvider
+zmq.io.net.norm.NormNetworkProtocolProvider
+zmq.io.net.pgm.EpgmNetworkProtocolProvider
+zmq.io.net.pgm.PgmNetworkProtocolProvider
+zmq.io.net.tcp.TcpNetworkProtocolProvider
+zmq.io.net.tipc.TipcNetworkProtocolProvider


### PR DESCRIPTION
Protocols are now implemented using ServiceLoader API. It allows easier decoupling of protocol and implementations, or adding new protocols.