### PR TITLE
Add check for size in V2Decoder

### DIFF
--- a/jeromq-core/src/main/java/zmq/io/coder/v2/V2Decoder.java
+++ b/jeromq-core/src/main/java/zmq/io/coder/v2/V2Decoder.java
@@ -3,6 +3,7 @@ package zmq.io.coder.v2;
 import java.nio.ByteBuffer;
 
 import zmq.Msg;
+import zmq.ZError;
 import zmq.io.coder.Decoder;
 import zmq.msg.MsgAllocator;
 import zmq.util.Errno;
@@ -51,6 +52,10 @@ public class V2Decoder extends Decoder
         tmpbuf.position(0);
         tmpbuf.limit(8);
         final long size = Wire.getUInt64(tmpbuf, 0);
+        if ( size <= 0 ) {
+            errno(ZError.EPROTO);
+            return Step.Result.ERROR;
+        }
 
         Step.Result rc = sizeReady(size);
         if (rc != Step.Result.ERROR) {

--- a/jeromq-core/src/test/java/org/zeromq/ByteBuffersTest.java
+++ b/jeromq-core/src/test/java/org/zeromq/ByteBuffersTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -234,5 +235,94 @@ public class ByteBuffersTest
                 ignore.printStackTrace();
             }
         }
+    }
+
+    @Test
+    public void testByteBufferZMQExploitPayload() throws IOException
+    {
+        int port = Utils.findOpenPort();
+        ZMQ.Context context = new ZMQ.Context(1);
+
+        ZMQ.Socket push = null;
+        ZMQ.Socket pull = null;
+        ByteBuffer bb = ByteBuffer.allocate(4).order(ByteOrder.nativeOrder());
+        try {
+            push = context.socket(SocketType.PUSH);
+            pull = context.socket(SocketType.PULL);
+            pull.bind("tcp://*:" + port);
+            push.connect("tcp://localhost:" + port);
+
+            bb.put("PING".getBytes(ZMQ.CHARSET));
+            bb.flip();
+
+            Thread.sleep(1000);
+            push.sendByteBuffer(bb, 0);
+            String actual = new String(pull.recv(), ZMQ.CHARSET);
+            assertEquals("PING", actual);
+
+            writeExploitPayload(port);
+
+            bb.put("PONG".getBytes(ZMQ.CHARSET));
+            bb.flip();
+            push.sendByteBuffer(bb, 0);
+            String newMsg = new String(pull.recv(), ZMQ.CHARSET);
+            assertEquals("PONG", newMsg);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+        } finally {
+            try {
+                push.close();
+            } catch (Exception ignore) {
+                ignore.printStackTrace();
+            }
+            try {
+                pull.close();
+            } catch (Exception ignore) {
+                ignore.printStackTrace();
+            }
+            try {
+                context.term();
+            } catch (Exception ignore) {
+                ignore.printStackTrace();
+            }
+        }
+    }
+
+    public void writeExploitPayload(int port) throws IOException {
+        byte[] greeting = {
+                (byte) 0xFF, /* Indicates 'versioned' in zmq::stream_engine_t::receive_greeting */
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* Unused */
+                0x01, /* Indicates 'versioned' in zmq::stream_engine_t::receive_greeting */
+                0x01, // Selects ZMTP_2_0 handshake selection
+                0x00  // Padding
+        };
+        byte[] v2msg = {
+                0x02, // Eight Byte Size
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF  // Oversized frame length
+        };
+        byte[] prePayload = new byte[8183];
+
+        ByteBuffer contentTReplacement = ByteBuffer.allocate(32);
+        contentTReplacement.putLong(0, (long) System.identityHashCode(new byte[8]));
+        contentTReplacement.putLong(16, (long) System.identityHashCode("ping google.com".getBytes()));
+        contentTReplacement.putLong(24, 0L);
+
+        // Total size of all components
+        int totalSize = greeting.length + v2msg.length + prePayload.length + contentTReplacement.capacity();
+        ByteBuffer bSend = ByteBuffer.allocate(totalSize);
+
+        // Combine all byte arrays into the buffer
+        bSend.put(greeting);
+        bSend.put(v2msg);
+        bSend.put(prePayload);
+        bSend.put(contentTReplacement.array());
+
+        java.net.Socket pushSocket = new java.net.Socket("localhost", port);
+        OutputStream push = pushSocket.getOutputStream();
+        push.write(bSend.array());
+        push.flush();
     }
 }


### PR DESCRIPTION
Addresses the issue described in https://github.com/zeromq/jeromq/issues/1005

The check added in V2Decoder is the same as the one in V1Decoder to ensure protocol error if the size is less than 0