### PR TITLE
Tell the user the address that failed to connect.

### DIFF
--- a/jeromq-core/src/main/java/zmq/io/net/tcp/TcpAddress.java
+++ b/jeromq-core/src/main/java/zmq/io/net/tcp/TcpAddress.java
@@ -160,7 +160,7 @@ public class TcpAddress implements Address.IZAddress<InetSocketAddress>
             }
         }
         catch (UnknownHostException e) {
-            throw new ZMQException(e.getMessage(), ZError.EADDRNOTAVAIL, e);
+            throw new ZMQException("failed connecting to " + addrStr + ": " + e.getMessage(), ZError.EADDRNOTAVAIL, e);
         }
 
         if (addrNet == null) {


### PR DESCRIPTION
Current:

```
Caused by: org.zeromq.ZMQException: blah-blah : Address not available
```

Yes, but _which_ address??

New error (I think?):

```
Caused by: org.zeromq.ZMQException: failed connecting to 0.0.0.0:5678: blah-blah : Address not available
```