### PR TITLE
Fixed link to guide in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ public class hwserver
 
 ### More examples
 
-The JeroMQ [translations of the zguide examples](src/test/java/guide) are a good
+The JeroMQ [translations of the zguide examples](jeromq-core/src/test/java/guide) are a good
 reference for recommended usage.
 
 ### Documentation


### PR DESCRIPTION
Link in README.md that pointed at the wrong location for the guide examples.  This is now pointing to the right location.